### PR TITLE
PASETO: Replace Payload struct by paseto.JSONToken + Improve helpers and public errors

### DIFF
--- a/paseto/config.go
+++ b/paseto/config.go
@@ -113,14 +113,14 @@ func configDefault(authConfigs ...Config) Config {
 	}
 
 	if config.ContextKey == "" {
-		config.ContextKey = DefaultContextKey
+		config.ContextKey = ConfigDefault.ContextKey
 	}
 
 	if config.TokenLookup[0] == "" {
-		config.TokenLookup[0] = LookupHeader
+		config.TokenLookup[0] = ConfigDefault.TokenLookup[0]
 	}
 	if config.TokenLookup[1] == "" {
-		config.TokenLookup[1] = fiber.HeaderAuthorization
+		config.TokenLookup[1] = ConfigDefault.TokenLookup[1]
 	}
 
 	if len(config.SymmetricKey) != chacha20poly1305.KeySize {

--- a/paseto/config.go
+++ b/paseto/config.go
@@ -100,7 +100,7 @@ func configDefault(authConfigs ...Config) Config {
 
 			if err := payload.Validate(
 				paseto.ValidAt(time.Now()), paseto.Subject(pasetoTokenSubject),
-				paseto.IssuedBy(pasetoTokenIssuer), paseto.ForAudience(pasetoTokenAudience),
+				paseto.ForAudience(pasetoTokenAudience),
 			); err != nil {
 				return "", err
 			}

--- a/paseto/config_test.go
+++ b/paseto/config_test.go
@@ -18,6 +18,13 @@ func Test_Config_No_SymmetricKey(t *testing.T) {
 	utils.AssertEqual(t, "", config.SymmetricKey)
 }
 
+func Test_Config_Invalid_SymmetricKey(t *testing.T) {
+	defer assertRecoveryPanic(t)
+	config := configDefault()
+
+	utils.AssertEqual(t, symmetricKey+symmetricKey, config.SymmetricKey)
+}
+
 func Test_ConfigDefault(t *testing.T) {
 	config := configDefault(Config{
 		SymmetricKey: []byte(symmetricKey),

--- a/paseto/helpers.go
+++ b/paseto/helpers.go
@@ -19,6 +19,7 @@ const (
 
 var (
 	ErrExpiredToken  = errors.New("token has expired")
+	ErrMissingToken  = errors.New("missing PASETO token")
 	ErrDataUnmarshal = errors.New("can't unmarshal token data to Payload type")
 	pasetoObject     = paseto.NewV2()
 )

--- a/paseto/helpers.go
+++ b/paseto/helpers.go
@@ -24,10 +24,16 @@ var (
 	pasetoObject     = paseto.NewV2()
 )
 
-// Acquire Token methods
-
 type acquireToken func(c *fiber.Ctx, key string) string
 
+// PayloadValidator Function that receives the decrypted payload and returns an interface and an error
+// that's a result of validation logic
+type PayloadValidator func(decrypted []byte) (interface{}, error)
+
+// PayloadCreator Signature of a function that generates a payload token
+type PayloadCreator func(key []byte, dataInfo string, duration time.Duration) (string, error)
+
+// Acquire Token methods
 func acquireFromHeader(c *fiber.Ctx, key string) string {
 	return c.Get(key)
 }

--- a/paseto/paseto.go
+++ b/paseto/paseto.go
@@ -1,7 +1,6 @@
 package pasetoware
 
 import (
-	"errors"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -32,7 +31,7 @@ func New(authConfigs ...Config) fiber.Handler {
 			return c.Next()
 		}
 		if token == "" {
-			return config.ErrorHandler(c, errors.New("bad: missing PASETO token"))
+			return config.ErrorHandler(c, ErrMissingToken)
 		}
 
 		var decryptedData []byte

--- a/paseto/paseto.go
+++ b/paseto/paseto.go
@@ -4,7 +4,8 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-// New ...
+// New PASETO middleware, returns a handler that takes a token in selected lookup param and in case token is valid
+// it saves the decrypted token on ctx.Locals, take a look on Config to know more configuration options
 func New(authConfigs ...Config) fiber.Handler {
 	// Set default authConfig
 	config := configDefault(authConfigs...)

--- a/paseto/paseto_test.go
+++ b/paseto/paseto_test.go
@@ -51,7 +51,8 @@ func Test_PASETO_TokenDecrypt(t *testing.T) {
 	})
 	request, err := generateTokenRequest("/")
 	if err == nil {
-		resp, err := app.Test(request)
+		var resp *http.Response
+		resp, err = app.Test(request)
 		utils.AssertEqual(t, nil, err)
 		utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
 	}

--- a/paseto/paseto_test.go
+++ b/paseto/paseto_test.go
@@ -2,6 +2,7 @@ package pasetoware
 
 import (
 	"encoding/json"
+	"errors"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/utils"
 	"net/http"
@@ -12,17 +13,89 @@ import (
 
 const (
 	testMessage  = "fiber with PASETO middleware!!"
+	invalidToken = "We are gophers!"
+	durationTest = 10 * time.Minute
 	symmetricKey = "go+fiber=love;FiberWithPASETO<3!"
 )
 
-func generateTokenRequest(targetRoute string) (*http.Request, error) {
-	token, err := CreateToken([]byte(symmetricKey), testMessage, 10*time.Minute)
+type customPayload struct {
+	Data           string        `json:"data"`
+	ExpirationTime time.Duration `json:"expiration_time"`
+	CreatedAt      time.Time     `json:"created_at"`
+}
+
+func createCustomToken(key []byte, dataInfo string, duration time.Duration) (string, error) {
+	return pasetoObject.Encrypt(key, customPayload{
+		Data:           dataInfo,
+		ExpirationTime: duration,
+		CreatedAt:      time.Now(),
+	}, nil)
+}
+
+func generateTokenRequest(
+	targetRoute string, tokenGenerator PayloadCreator, duration time.Duration,
+) (*http.Request, error) {
+	token, err := tokenGenerator([]byte(symmetricKey), testMessage, duration)
 	if err != nil {
 		return nil, err
 	}
 	request := httptest.NewRequest("GET", targetRoute, nil)
 	request.Header.Set(fiber.HeaderAuthorization, token)
 	return request, nil
+}
+
+func assertErrorHandler(t *testing.T, toAssert error) fiber.ErrorHandler {
+	return func(ctx *fiber.Ctx, err error) error {
+		utils.AssertEqual(t, toAssert, err)
+		utils.AssertEqual(t, true, errors.Is(err, toAssert))
+		return defaultErrorHandler(ctx, err)
+	}
+}
+
+func Test_PASETO_MissingToken(t *testing.T) {
+	app := fiber.New()
+	app.Use(New(Config{
+		SymmetricKey: []byte(symmetricKey),
+		ContextKey:   DefaultContextKey,
+		ErrorHandler: assertErrorHandler(t, ErrMissingToken),
+	}))
+	request := httptest.NewRequest("GET", "/", nil)
+	resp, err := app.Test(request)
+	if err == nil {
+		utils.AssertEqual(t, fiber.StatusBadRequest, resp.StatusCode)
+	}
+}
+
+func Test_PASETO_ErrDataUnmarshal(t *testing.T) {
+	app := fiber.New()
+	app.Use(New(Config{
+		SymmetricKey: []byte(symmetricKey),
+		ContextKey:   DefaultContextKey,
+		ErrorHandler: assertErrorHandler(t, ErrDataUnmarshal),
+	}))
+	request, err := generateTokenRequest("/", createCustomToken, durationTest)
+	if err == nil {
+		var resp *http.Response
+		resp, err = app.Test(request)
+		utils.AssertEqual(t, nil, err)
+		utils.AssertEqual(t, fiber.StatusUnauthorized, resp.StatusCode)
+	}
+}
+
+func Test_PASETO_ErrTokenExpired(t *testing.T) {
+	app := fiber.New()
+	app.Use(New(Config{
+		SymmetricKey: []byte(symmetricKey),
+		ContextKey:   DefaultContextKey,
+		ErrorHandler: assertErrorHandler(t, ErrExpiredToken),
+	}))
+	request, err := generateTokenRequest("/", CreateToken, time.Nanosecond*-10)
+	if err == nil {
+		var resp *http.Response
+		resp, err = app.Test(request)
+		utils.AssertEqual(t, nil, err)
+		utils.AssertEqual(t, fiber.StatusUnauthorized, resp.StatusCode)
+	}
 }
 
 func Test_PASETO_Next(t *testing.T) {
@@ -34,7 +107,9 @@ func Test_PASETO_Next(t *testing.T) {
 		},
 	}))
 
-	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
+	request := httptest.NewRequest("GET", "/", nil)
+	request.Header.Set(fiber.HeaderAuthorization, invalidToken)
+	resp, err := app.Test(request)
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, fiber.StatusNotFound, resp.StatusCode)
 }
@@ -49,7 +124,7 @@ func Test_PASETO_TokenDecrypt(t *testing.T) {
 		utils.AssertEqual(t, testMessage, ctx.Locals(DefaultContextKey))
 		return nil
 	})
-	request, err := generateTokenRequest("/")
+	request, err := generateTokenRequest("/", CreateToken, durationTest)
 	if err == nil {
 		var resp *http.Response
 		resp, err = app.Test(request)
@@ -65,19 +140,13 @@ func Test_PASETO_InvalidToken(t *testing.T) {
 		ContextKey:   DefaultContextKey,
 	}))
 	request := httptest.NewRequest("GET", "/", nil)
-	request.Header.Set(fiber.HeaderAuthorization, "We are gophers!")
+	request.Header.Set(fiber.HeaderAuthorization, invalidToken)
 	resp, err := app.Test(request)
 	utils.AssertEqual(t, nil, err)
-	utils.AssertEqual(t, fiber.StatusUnauthorized, resp.StatusCode)
+	utils.AssertEqual(t, fiber.StatusBadRequest, resp.StatusCode)
 }
 
 func Test_PASETO_CustomValidate(t *testing.T) {
-	type customPayload struct {
-		Data           string        `json:"data"`
-		ExpirationTime time.Duration `json:"expiration_time"`
-		CreatedAt      time.Time     `json:"created_at"`
-	}
-
 	app := fiber.New()
 	app.Use(New(Config{
 		SymmetricKey: []byte(symmetricKey),

--- a/paseto/payload.go
+++ b/paseto/payload.go
@@ -7,8 +7,7 @@ import (
 )
 
 const (
-	pasetoTokenAudience = "gofiber"
-	pasetoTokenIssuer   = "gofiber.pasetoware"
+	pasetoTokenAudience = "gofiber.gophers"
 	pasetoTokenSubject  = "user-token"
 	pasetoTokenField    = "data"
 )
@@ -23,7 +22,6 @@ func NewPayload(userToken string, duration time.Duration) (*paseto.JSONToken, er
 	timeNow := time.Now()
 	payload := &paseto.JSONToken{
 		Audience:   pasetoTokenAudience,
-		Issuer:     pasetoTokenIssuer,
 		Jti:        tokenID.String(),
 		Subject:    pasetoTokenSubject,
 		IssuedAt:   timeNow,

--- a/paseto/payload.go
+++ b/paseto/payload.go
@@ -2,30 +2,35 @@ package pasetoware
 
 import (
 	"github.com/google/uuid"
+	"github.com/o1egl/paseto"
 	"time"
+)
+
+const (
+	pasetoTokenAudience = "gofiber"
+	pasetoTokenIssuer   = "gofiber.pasetoware"
+	pasetoTokenSubject  = "user-token"
+	pasetoTokenField    = "data"
 )
 
 type PayloadValidator func(decrypted []byte) (interface{}, error)
 
-type Payload struct {
-	ID        uuid.UUID `json:"id"`
-	UserToken string    `json:"user_token"`
-	IssuedAt  time.Time `json:"issued_at"`
-	ExpiredAt time.Time `json:"expired_at"`
-}
-
-func NewPayload(userToken string, duration time.Duration) (*Payload, error) {
+func NewPayload(userToken string, duration time.Duration) (*paseto.JSONToken, error) {
 	tokenID, err := uuid.NewRandom()
 	if err != nil {
 		return nil, err
 	}
-
-	payload := &Payload{
-		ID:        tokenID,
-		UserToken: userToken,
-		IssuedAt:  time.Now(),
-		ExpiredAt: time.Now().Add(duration),
+	timeNow := time.Now()
+	payload := &paseto.JSONToken{
+		Audience:   pasetoTokenAudience,
+		Issuer:     pasetoTokenIssuer,
+		Jti:        tokenID.String(),
+		Subject:    pasetoTokenSubject,
+		IssuedAt:   timeNow,
+		Expiration: time.Now().Add(duration),
+		NotBefore:  timeNow,
 	}
 
+	payload.Set(pasetoTokenField, userToken)
 	return payload, nil
 }

--- a/paseto/payload.go
+++ b/paseto/payload.go
@@ -12,8 +12,7 @@ const (
 	pasetoTokenField    = "data"
 )
 
-type PayloadValidator func(decrypted []byte) (interface{}, error)
-
+// NewPayload generates a new paseto.JSONToken and returns it and a error that can be caused by uuid
 func NewPayload(userToken string, duration time.Duration) (*paseto.JSONToken, error) {
 	tokenID, err := uuid.NewRandom()
 	if err != nil {
@@ -25,7 +24,7 @@ func NewPayload(userToken string, duration time.Duration) (*paseto.JSONToken, er
 		Jti:        tokenID.String(),
 		Subject:    pasetoTokenSubject,
 		IssuedAt:   timeNow,
-		Expiration: time.Now().Add(duration),
+		Expiration: timeNow.Add(duration),
 		NotBefore:  timeNow,
 	}
 


### PR DESCRIPTION
As requested in #4 this PR improve some things about config and move all errors to helpers.go

- All errors are now public
- Improve default ErrorHandler error verification
- Add ContextKey and TokenLookup configs to DefaultConfig

More additions
- Replaced `Payload` struct by `paseto.JSONToken`  struct
- Fixed some typos
- Use `ConfigDefault` values when a given config is empty, to be more consistent with `ConfigDefault`