### PR TITLE
:fax: paseto: Add TokenPrefix to config

### DIFF
--- a/paseto/config.go
+++ b/paseto/config.go
@@ -47,6 +47,13 @@ type Config struct {
 	// - ["param","<name>"]
 	// - ["cookie","<name>"]
 	TokenLookup [2]string
+
+	// TokenPrefix is a string that holds the prefix for the token lookup.
+	// Generally it's used the "Bearer" prefix.
+	//
+	// Optional. Default value ""
+	// Recommended value: "Bearer"
+	TokenPrefix string
 }
 
 // ConfigDefault is the default config

--- a/paseto/helpers.go
+++ b/paseto/helpers.go
@@ -18,10 +18,11 @@ const (
 )
 
 var (
-	ErrExpiredToken  = errors.New("token has expired")
-	ErrMissingToken  = errors.New("missing PASETO token")
-	ErrDataUnmarshal = errors.New("can't unmarshal token data to Payload type")
-	pasetoObject     = paseto.NewV2()
+	ErrExpiredToken         = errors.New("token has expired")
+	ErrMissingToken         = errors.New("missing PASETO token")
+	ErrIncorrectTokenPrefix = errors.New("missing prefix for PASETO token")
+	ErrDataUnmarshal        = errors.New("can't unmarshal token data to Payload type")
+	pasetoObject            = paseto.NewV2()
 )
 
 type acquireToken func(c *fiber.Ctx, key string) string

--- a/paseto/paseto.go
+++ b/paseto/paseto.go
@@ -2,6 +2,7 @@ package pasetoware
 
 import (
 	"github.com/gofiber/fiber/v2"
+	"strings"
 )
 
 // New PASETO middleware, returns a handler that takes a token in selected lookup param and in case token is valid
@@ -31,8 +32,16 @@ func New(authConfigs ...Config) fiber.Handler {
 		if config.Next != nil && config.Next(c) {
 			return c.Next()
 		}
-		if token == "" {
+		if len(token) <= 0 {
 			return config.ErrorHandler(c, ErrMissingToken)
+		}
+
+		if len(config.TokenPrefix) > 0 {
+			if strings.HasPrefix(token, config.TokenPrefix) {
+				token = strings.TrimPrefix(token, config.TokenPrefix+" ")
+			} else {
+				return config.ErrorHandler(c, ErrIncorrectTokenPrefix)
+			}
 		}
 
 		var decryptedData []byte


### PR DESCRIPTION
This change make possible to the PASETO middleware get the token that has a prefix like "Bearer".

So requests that have the token in format "Bearer v2.my_paseto_token.sign" can get the token correctly