### PR TITLE
Add support for `c.Scheme` and `c.Protocol` updated functions

### DIFF
--- a/fiberzap/zap.go
+++ b/fiberzap/zap.go
@@ -79,6 +79,8 @@ func New(config ...Config) fiber.Handler {
 				fields = append(fields, zap.String("referer", c.Get(fiber.HeaderReferer)))
 			case "protocol":
 				fields = append(fields, zap.String("protocol", c.Protocol()))
+			case "scheme":
+				fields = append(fields, zap.String("scheme", c.Scheme()))
 			case "pid":
 				fields = append(fields, zap.String("pid", pid))
 			case "port":

--- a/fiberzap/zap_test.go
+++ b/fiberzap/zap_test.go
@@ -63,7 +63,7 @@ func Test_Logger_All(t *testing.T) {
 
 	app.Use(New(Config{
 		Logger: logger,
-		Fields: []string{"protocol", "pid", "body", "ip", "host", "url", "route", "method", "resBody", "queryParams", "bytesReceived", "bytesSent"},
+		Fields: []string{"scheme", "protocol", "pid", "body", "ip", "host", "url", "route", "method", "resBody", "queryParams", "bytesReceived", "bytesSent"},
 	}))
 
 	resp, err := app.Test(httptest.NewRequest("GET", "/?foo=bar", nil))
@@ -77,7 +77,8 @@ func Test_Logger_All(t *testing.T) {
 		"url":           "/?foo=bar",
 		"method":        "GET",
 		"route":         "/",
-		"protocol":      "http",
+		"scheme":        "http",
+		"protocol":      "HTTP/1.1",
 		"pid":           strconv.Itoa(os.Getpid()),
 		"queryParams":   "foo=bar",
 		"resBody":       "Cannot GET /",

--- a/otelfiber/fiber.go
+++ b/otelfiber/fiber.go
@@ -72,7 +72,7 @@ func Middleware(service string, opts ...Option) fiber.Handler {
 				semconv.NetHostNameKey.String(c.Hostname()),
 				semconv.HTTPUserAgentKey.String(string(c.Request().Header.UserAgent())),
 				semconv.HTTPRequestContentLengthKey.Int(c.Request().Header.ContentLength()),
-				semconv.HTTPSchemeKey.String(c.Protocol()),
+				semconv.HTTPSchemeKey.String(c.Scheme()),
 				semconv.NetTransportTCP),
 			oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		}


### PR DESCRIPTION
Refer [this PR](https://github.com/gofiber/fiber/pull/1746) for more information.

`c.Scheme()` usage:

```go
app.Get("/", func(c *Ctx) error {
    return c.JSON(c.Scheme()) // return "http" or "https"
})
```

`c.Protocol()` usage:

```go
app.Get("/", func(c *Ctx) error {
    return c.JSON(c.Protocol()) // return "HTTP/1.1"
})
```