### PR TITLE
fix: use `UserContext()` & fix incorrect strings

### DIFF
--- a/otelfiber/fiber.go
+++ b/otelfiber/fiber.go
@@ -62,28 +62,31 @@ func Middleware(service string, opts ...Option) fiber.Handler {
 		ctx := cfg.Propagators.Extract(savedCtx, propagation.HeaderCarrier(reqHeader))
 		opts := []oteltrace.SpanStartOption{
 			oteltrace.WithAttributes(
+				// utils.CopyString: we need to copy the string as fasthttp strings are by default
+				// mutable so it will be unsafe to use in this middleware as it might be used after
+				// the handler returns.
 				semconv.HTTPServerNameKey.String(service),
-				semconv.HTTPMethodKey.String(c.Method()),
-				semconv.HTTPTargetKey.String(string(c.Request().RequestURI())),
-				semconv.HTTPURLKey.String(c.OriginalURL()),
-				semconv.NetHostIPKey.String(c.IP()),
-				semconv.NetHostNameKey.String(c.Hostname()),
-				semconv.HTTPUserAgentKey.String(string(c.Request().Header.UserAgent())),
+				semconv.HTTPMethodKey.String(utils.CopyString(c.Method())),
+				semconv.HTTPTargetKey.String(string(utils.CopyBytes(c.Request().RequestURI()))),
+				semconv.HTTPURLKey.String(utils.CopyString(c.OriginalURL())),
+				semconv.NetHostIPKey.String(utils.CopyString(c.IP())),
+				semconv.NetHostNameKey.String(utils.CopyString(c.Hostname())),
+				semconv.HTTPUserAgentKey.String(string(utils.CopyBytes(c.Request().Header.UserAgent()))),
 				semconv.HTTPRequestContentLengthKey.Int(c.Request().Header.ContentLength()),
-				semconv.HTTPSchemeKey.String(c.Protocol()),
+				semconv.HTTPSchemeKey.String(utils.CopyString(c.Protocol())),
 				semconv.NetTransportTCP),
 			oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		}
 		if username, ok := hasBasicAuth(c.Get(fiber.HeaderAuthorization)); ok {
-			opts = append(opts, oteltrace.WithAttributes(semconv.EnduserIDKey.String(username)))
+			opts = append(opts, oteltrace.WithAttributes(semconv.EnduserIDKey.String(utils.CopyString(username))))
 		}
 		if len(c.IPs()) > 0 {
-			opts = append(opts, oteltrace.WithAttributes(semconv.HTTPClientIPKey.String(c.IPs()[0])))
+			opts = append(opts, oteltrace.WithAttributes(semconv.HTTPClientIPKey.String(utils.CopyString(c.IPs()[0]))))
 		}
 		// temporary set to c.Path() first
 		// update with c.Route().Path after c.Next() is called
 		// to get pathRaw
-		spanName := c.Path()
+		spanName := utils.CopyString(c.Path())
 		ctx, span := tracer.Start(ctx, spanName, opts...)
 		defer span.End()
 
@@ -94,6 +97,7 @@ func Middleware(service string, opts ...Option) fiber.Handler {
 		err := c.Next()
 
 		span.SetName(cfg.SpanNameFormatter(c))
+		// no need to copy c.Route().Path: route strings should be immutable across app lifecycle
 		span.SetAttributes(semconv.HTTPRouteKey.String(c.Route().Path))
 
 		if err != nil {

--- a/otelfiber/fiber.go
+++ b/otelfiber/fiber.go
@@ -6,13 +6,10 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gofiber/fiber/v2/utils"
-
 	"github.com/gofiber/fiber/v2"
-
+	"github.com/gofiber/fiber/v2/utils"
 	otelcontrib "go.opentelemetry.io/contrib"
 	"go.opentelemetry.io/otel"
-
 	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -50,7 +47,7 @@ func Middleware(service string, opts ...Option) fiber.Handler {
 
 	return func(c *fiber.Ctx) error {
 		c.Locals(tracerKey, tracer)
-		savedCtx, cancel := context.WithCancel(c.Context())
+		savedCtx, cancel := context.WithCancel(c.UserContext())
 
 		defer func() {
 			c.SetUserContext(savedCtx)


### PR DESCRIPTION
This is to infer context from `UserContext()` instead, so the value set in `UserContext()` by users will not be simply overwritten and simply been discarded.

This PR also resolves issue #143.

---

Discussed in Discord

> Hi! I was trying to use https://github.com/gofiber/contrib/tree/v0.4.1/otelfiber and I noticed that my values set in UserContext() is not passing down. Further digging showed that at https://github.com/gofiber/contrib/blob/v0.4.1/otelfiber/fiber.go#L53-L56 the middleware just used Context() (which is of type *fasthttp.RequestCtx()) to create a new context of type context.Context and later overrides the UserContext() with that. 
>
> I think it would be more feasible for the middleware to infer context from UserContext() instead, so the value set in UserContext() will not be simply discarded.