### PR TITLE
support configuring log levels and reqHeaders support

### DIFF
--- a/fiberzap/README.md
+++ b/fiberzap/README.md
@@ -32,6 +32,7 @@ fiberzap.New(config ...Config) fiber.Handler
 | Logger | `*zap.Logger`        | Add custom zap logger.                                                                                                                                  | `zap.NewDevelopment()`                      |
 | Fields   | `[]string` | Add fields what you want see.                                                                                                                                 | `[]string{"latency", "status", "method", "url"}` |
 | Messages       | `[]string`              | Custom response messages. | `[]string{"Server error", "Client error", "Success"}`                           |                
+| Levels       | `[]zapcore.Level`              | Custom response levels. | `[]zapcore.Level{zapcore.ErrorLevel, zapcore.WarnLevel, zapcore.InfoLevel}`                           |   
 | SkipURIs       | `[]string`              | Skip logging these URI. | `[]string{}`                           |                
 
 ### Example

--- a/fiberzap/config.go
+++ b/fiberzap/config.go
@@ -3,6 +3,7 @@ package fiberzap
 import (
 	"github.com/gofiber/fiber/v2"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // Config defines the config for middleware.
@@ -41,6 +42,11 @@ type Config struct {
 	//
 	// Optional. Default: {"Server error", "Client error", "Success"}
 	Messages []string
+
+	// Custom response levels.
+	//
+	// Optional. Default: {zapcore.ErrorLevel, zapcore.WarnLevel, zapcore.InfoLevel}
+	Levels []zapcore.Level
 }
 
 // Use zap.NewProduction() as default logging instance.
@@ -52,6 +58,7 @@ var ConfigDefault = Config{
 	Logger:   logger,
 	Fields:   []string{"latency", "status", "method", "url"},
 	Messages: []string{"Server error", "Client error", "Success"},
+	Levels:   []zapcore.Level{zapcore.ErrorLevel, zapcore.WarnLevel, zapcore.InfoLevel},
 }
 
 // Helper function to set default values
@@ -79,6 +86,10 @@ func configDefault(config ...Config) Config {
 
 	if cfg.Messages == nil {
 		cfg.Messages = ConfigDefault.Messages
+	}
+
+	if cfg.Levels == nil {
+		cfg.Levels = ConfigDefault.Levels
 	}
 
 	return cfg

--- a/fiberzap/config.go
+++ b/fiberzap/config.go
@@ -39,11 +39,21 @@ type Config struct {
 	Fields []string
 
 	// Custom response messages.
+	// Response codes >= 500 will be logged with Messages[0].
+	// Response codes >= 400 will be logged with Messages[1].
+	// Other response codes will be logged with Messages[2].
+	// You can specify less, than 3 messages, but you must specify at least 1.
+	// Specifying more than 3 messages is useless.
 	//
 	// Optional. Default: {"Server error", "Client error", "Success"}
 	Messages []string
 
 	// Custom response levels.
+	// Response codes >= 500 will be logged with Levels[0].
+	// Response codes >= 400 will be logged with Levels[1].
+	// Other response codes will be logged with Levels[2].
+	// You can specify less, than 3 levels, but you must specify at least 1.
+	// Specifying more than 3 levels is useless.
 	//
 	// Optional. Default: {zapcore.ErrorLevel, zapcore.WarnLevel, zapcore.InfoLevel}
 	Levels []zapcore.Level

--- a/fiberzap/zap.go
+++ b/fiberzap/zap.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 // New creates a new middleware handler
@@ -83,17 +82,28 @@ func New(config ...Config) fiber.Handler {
 		}
 
 		// Check if the logger has the appropriate level
-		s := c.Response().StatusCode()
-		var ce *zapcore.CheckedEntry
+		var (
+			s     = c.Response().StatusCode()
+			index int
+		)
 		switch {
 		case s >= 500:
-			ce = cfg.Logger.Check(cfg.Levels[0], cfg.Messages[0])
+			// error index is zero
 		case s >= 400:
-			ce = cfg.Logger.Check(cfg.Levels[1], cfg.Messages[1])
+			index = 1
 		default:
-			ce = cfg.Logger.Check(cfg.Levels[2], cfg.Messages[2])
+			index = 2
+		}
+		levelIndex := index
+		if levelIndex >= len(cfg.Levels) {
+			levelIndex = len(cfg.Levels) - 1
+		}
+		messageIndex := index
+		if messageIndex >= len(cfg.Messages) {
+			messageIndex = len(cfg.Messages) - 1
 		}
 
+		ce := cfg.Logger.Check(cfg.Levels[levelIndex], cfg.Messages[messageIndex])
 		if ce == nil {
 			return nil
 		}

--- a/fiberzap/zap_test.go
+++ b/fiberzap/zap_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gofiber/fiber/v2/utils"
 	"github.com/valyala/fasthttp"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 )
 
@@ -330,4 +331,90 @@ func Test_Req_Headers(t *testing.T) {
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
 	utils.AssertEqual(t, expected, logs.All()[0].ContextMap())
+}
+
+// go test -run Test_LoggerLevelsAndMessages
+func Test_LoggerLevelsAndMessages(t *testing.T) {
+	app := fiber.New()
+	logger, logs := setupLogsCapture()
+
+	levels := []zapcore.Level{zapcore.ErrorLevel, zapcore.WarnLevel, zapcore.InfoLevel}
+	messages := []string{"server error", "client error", "success"}
+	app.Use(New(Config{
+		Logger:   logger,
+		Messages: messages,
+		Levels:   levels,
+	}))
+
+	app.Get("/200", func(c *fiber.Ctx) error {
+		c.Status(fiber.StatusOK)
+		return nil
+	})
+	app.Get("/400", func(c *fiber.Ctx) error {
+		c.Status(fiber.StatusBadRequest)
+		return nil
+	})
+	app.Get("/500", func(c *fiber.Ctx) error {
+		c.Status(fiber.StatusInternalServerError)
+		return nil
+	})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/500", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, fiber.StatusInternalServerError, resp.StatusCode)
+	utils.AssertEqual(t, levels[0], logs.All()[0].Level)
+	utils.AssertEqual(t, messages[0], logs.All()[0].Message)
+	resp, err = app.Test(httptest.NewRequest("GET", "/400", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, fiber.StatusBadRequest, resp.StatusCode)
+	utils.AssertEqual(t, levels[1], logs.All()[1].Level)
+	utils.AssertEqual(t, messages[1], logs.All()[1].Message)
+	resp, err = app.Test(httptest.NewRequest("GET", "/200", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
+	utils.AssertEqual(t, levels[2], logs.All()[2].Level)
+	utils.AssertEqual(t, messages[2], logs.All()[2].Message)
+}
+
+// go test -run Test_LoggerLevelsAndMessagesSingle
+func Test_LoggerLevelsAndMessagesSingle(t *testing.T) {
+	app := fiber.New()
+	logger, logs := setupLogsCapture()
+
+	levels := []zapcore.Level{zapcore.ErrorLevel}
+	messages := []string{"server error"}
+	app.Use(New(Config{
+		Logger:   logger,
+		Messages: messages,
+		Levels:   levels,
+	}))
+
+	app.Get("/200", func(c *fiber.Ctx) error {
+		c.Status(fiber.StatusOK)
+		return nil
+	})
+	app.Get("/400", func(c *fiber.Ctx) error {
+		c.Status(fiber.StatusBadRequest)
+		return nil
+	})
+	app.Get("/500", func(c *fiber.Ctx) error {
+		c.Status(fiber.StatusInternalServerError)
+		return nil
+	})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/500", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, fiber.StatusInternalServerError, resp.StatusCode)
+	utils.AssertEqual(t, levels[0], logs.All()[0].Level)
+	utils.AssertEqual(t, messages[0], logs.All()[0].Message)
+	resp, err = app.Test(httptest.NewRequest("GET", "/400", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, fiber.StatusBadRequest, resp.StatusCode)
+	utils.AssertEqual(t, levels[0], logs.All()[1].Level)
+	utils.AssertEqual(t, messages[0], logs.All()[1].Message)
+	resp, err = app.Test(httptest.NewRequest("GET", "/200", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
+	utils.AssertEqual(t, levels[0], logs.All()[2].Level)
+	utils.AssertEqual(t, messages[0], logs.All()[2].Message)
 }


### PR DESCRIPTION
This PR has 2 features:
1. Supports dumping all the headers with the reqHeaders field
2. Allows to specify your own log levels in a similar way to log messages

As a bonus it speeds up the middleware as the fields are not getting marshalled if the log won't be sent to the output