### PR TITLE
feat(otelfiber): add metrics to otelfiber

### DIFF
--- a/otelfiber/config.go
+++ b/otelfiber/config.go
@@ -2,6 +2,7 @@ package otelfiber
 
 import (
 	"github.com/gofiber/fiber/v2"
+	otelmetric "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
@@ -9,6 +10,7 @@ import (
 // config is used to configure the Fiber middleware.
 type config struct {
 	TracerProvider    oteltrace.TracerProvider
+	MeterProvider     otelmetric.MeterProvider
 	Propagators       propagation.TextMapPropagator
 	SpanNameFormatter func(*fiber.Ctx) string
 }
@@ -38,6 +40,14 @@ func WithPropagators(propagators propagation.TextMapPropagator) Option {
 func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.TracerProvider = provider
+	})
+}
+
+// WithMeterProvider specifies a meter provider to use for reporting.
+// If none is specified, the global provider is used.
+func WithMeterProvider(provider otelmetric.MeterProvider) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.MeterProvider = provider
 	})
 }
 

--- a/otelfiber/go.mod
+++ b/otelfiber/go.mod
@@ -8,7 +8,9 @@ require (
 	go.opentelemetry.io/contrib v1.12.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.12.0
 	go.opentelemetry.io/otel v1.11.2
+	go.opentelemetry.io/otel/metric v0.32.3
 	go.opentelemetry.io/otel/oteltest v1.0.0-RC3
+	go.opentelemetry.io/otel/sdk/metric v0.32.3
 	go.opentelemetry.io/otel/trace v1.11.2
 )
 
@@ -26,6 +28,7 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.43.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.11.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/otelfiber/go.sum
+++ b/otelfiber/go.sum
@@ -47,8 +47,14 @@ go.opentelemetry.io/contrib/propagators/b3 v1.12.0/go.mod h1:0JDB4elfPUWGsCH/qha
 go.opentelemetry.io/otel v1.0.0-RC3/go.mod h1:Ka5j3ua8tZs4Rkq4Ex3hwgBgOchyPVq5S6P2lz//nKQ=
 go.opentelemetry.io/otel v1.11.2 h1:YBZcQlsVekzFsFbjygXMOXSs6pialIZxcjfO/mBDmR0=
 go.opentelemetry.io/otel v1.11.2/go.mod h1:7p4EUV+AqgdlNV9gL97IgUZiVR3yrFXYo53f9BM3tRI=
+go.opentelemetry.io/otel/metric v0.32.3 h1:dMpnJYk2KULXr0j8ph6N7+IcuiIQXlPXD4kix9t7L9c=
+go.opentelemetry.io/otel/metric v0.32.3/go.mod h1:pgiGmKohxHyTPHGOff+vrtIH39/R9fiO/WoenUQ3kcc=
 go.opentelemetry.io/otel/oteltest v1.0.0-RC3 h1:MjaeegZTaX0Bv9uB9CrdVjOFM/8slRjReoWoV9xDCpY=
 go.opentelemetry.io/otel/oteltest v1.0.0-RC3/go.mod h1:xpzajI9JBRr7gX63nO6kAmImmYIAtuQblZ36Z+LfCjE=
+go.opentelemetry.io/otel/sdk v1.11.0 h1:ZnKIL9V9Ztaq+ME43IUi/eo22mNsb6a7tGfzaOWB5fo=
+go.opentelemetry.io/otel/sdk v1.11.0/go.mod h1:REusa8RsyKaq0OlyangWXaw97t2VogoO4SSEeKkSTAk=
+go.opentelemetry.io/otel/sdk/metric v0.32.3 h1:lY46wXBbo8IuPDlh1fpVPVy/bCT4wwo3RBYve6UaHOA=
+go.opentelemetry.io/otel/sdk/metric v0.32.3/go.mod h1:nqJPheSpNDSGXhg22BQRgTQedRalfei6tZkmqTavDSk=
 go.opentelemetry.io/otel/trace v1.0.0-RC3/go.mod h1:VUt2TUYd8S2/ZRX09ZDFZQwn2RqfMB5MzO17jBojGxo=
 go.opentelemetry.io/otel/trace v1.11.2 h1:Xf7hWSF2Glv0DE3MH7fBHvtpSBsjcBUe5MYAmZM/+y0=
 go.opentelemetry.io/otel/trace v1.11.2/go.mod h1:4N+yC7QEz7TTsG9BSRLNAa63eg5E06ObSbKPmxQ/pKA=

--- a/otelfiber/semconv.go
+++ b/otelfiber/semconv.go
@@ -1,0 +1,23 @@
+package otelfiber
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/utils"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+)
+
+func httpServerMetricAttributesFromRequest(c *fiber.Ctx, service string) []attribute.KeyValue {
+	var attrs []attribute.KeyValue
+	attrs = append(attrs, semconv.HTTPServerNameKey.String(service))
+	if c.Context().IsTLS() {
+		attrs = append(attrs, semconv.HTTPSchemeHTTPS)
+	} else {
+		attrs = append(attrs, semconv.HTTPSchemeHTTP)
+	}
+	attrs = append(attrs, semconv.HTTPHostKey.String(utils.CopyString(c.Hostname())))
+	attrs = append(attrs, semconv.HTTPFlavorHTTP11)
+	attrs = append(attrs, semconv.HTTPMethodKey.String(utils.CopyString(c.Method())))
+	attrs = append(attrs, semconv.HTTPRouteKey.String(utils.CopyString(c.Route().Path)))
+	return attrs
+}


### PR DESCRIPTION
This patch adds metrics to otelfiber and follows conventions defined by [Semantic Conventions for HTTP Metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#semantic-conventions-for-http-metrics). The metric instruments are added:

- http.server.duration
- http.server.request.size
- http.server.response.size
- http.server.active_requests

The Metrics package in the OpenTelmetry-Go is still in progress. However, I believe that this PR is a good starting point for otelfiber's metrics.

Resolves #50