### PR TITLE
Add GetResBody to Config

### DIFF
--- a/fiberzap/config.go
+++ b/fiberzap/config.go
@@ -23,6 +23,12 @@ type Config struct {
 	// Optional. Default: nil
 	SkipResBody func(c *fiber.Ctx) bool
 
+	// GetResBody defines a function to get ResBody.
+	//  eg: when use compress middleware, resBody is unreadable. you can set GetResBody func to get readable resBody.
+	//
+	// Optional. Default: nil
+	GetResBody func(c *fiber.Ctx) []byte
+
 	// Skip logging for these uri
 	//
 	// Optional. Default: nil

--- a/fiberzap/zap.go
+++ b/fiberzap/zap.go
@@ -146,7 +146,11 @@ func New(config ...Config) fiber.Handler {
 				fields = append(fields, zap.String("queryParams", c.Request().URI().QueryArgs().String()))
 			case "body":
 				if cfg.SkipBody == nil || !cfg.SkipBody(c) {
-					fields = append(fields, zap.ByteString("body", c.Body()))
+					if cfg.GetResBody == nil {
+						fields = append(fields, zap.ByteString("body", c.Response().Body()))
+					} else {
+						fields = append(fields, zap.ByteString("body", cfg.GetResBody(c)))
+					}
 				}
 			case "bytesReceived":
 				fields = append(fields, zap.Int("bytesReceived", len(c.Request().Body())))


### PR DESCRIPTION
When use compress middleware, resBody is unreadable. 
You can set GetResBody func to get readable resBody.

![fiberzap](https://user-images.githubusercontent.com/54696/211186456-aa0acc26-4b70-43da-a6d0-3d135603bf1c.png)
