### PR TITLE
Add GetResBody to Config

### DIFF
--- a/fiberzap/README.md
+++ b/fiberzap/README.md
@@ -26,15 +26,15 @@ fiberzap.New(config ...Config) fiber.Handler
 
 ### Config
 
-| Property       | Type                            | Description                                                                                                                                                                                             | Default                         |
-| :------------- | :------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------------------------ |
-| Next           | `func(*Ctx) bool`               | Define a function to skip this middleware when returned true                                                                                                                                                                   | `nil`                           |
-| Logger | `*zap.Logger`        | Add custom zap logger.                                                                                                                                  | `zap.NewDevelopment()`                      |
-| Fields   | `[]string` | Add fields what you want see.                                                                                                                                 | `[]string{"latency", "status", "method", "url"}` |
-| Messages       | `[]string`              | Custom response messages. | `[]string{"Server error", "Client error", "Success"}`                           |                
-| Levels       | `[]zapcore.Level`              | Custom response levels. | `[]zapcore.Level{zapcore.ErrorLevel, zapcore.WarnLevel, zapcore.InfoLevel}`                           |   
-| SkipURIs       | `[]string`              | Skip logging these URI. | `[]string{}`                           |                
-
+| Property      | Type                           | Description                                                                                                                                                                   | Default                                                                     |
+|:--------------|:-------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------|
+| Next          | `func(*Ctx) bool`              | Define a function to skip this middleware when returned true                                                                                                                  | `nil`                                                                       |
+| Logger        | `*zap.Logger`                  | Add custom zap logger.                                                                                                                                                        | `zap.NewDevelopment()`                                                      |
+| Fields        | `[]string`                     | Add fields what you want see.                                                                                                                                                 | `[]string{"latency", "status", "method", "url"}`                            |
+| Messages      | `[]string`                     | Custom response messages.                                                                                                                                                     | `[]string{"Server error", "Client error", "Success"}`                       |                
+| Levels        | `[]zapcore.Level`              | Custom response levels.                                                                                                                                                       | `[]zapcore.Level{zapcore.ErrorLevel, zapcore.WarnLevel, zapcore.InfoLevel}` |   
+| SkipURIs      | `[]string`                     | Skip logging these URI.                                                                                                                                                       | `[]string{}`                                                                |                
+| GetResBody    | func(c *fiber.Ctx) []byte      | Define a function to get response body when return non-nil.<br>eg: When use compress middleware, resBody is unreadable. you can set GetResBody func to get readable resBody.  | nil                                                                         |
 ### Example
 ```go
 package main

--- a/fiberzap/README.md
+++ b/fiberzap/README.md
@@ -34,7 +34,7 @@ fiberzap.New(config ...Config) fiber.Handler
 | Messages      | `[]string`                     | Custom response messages.                                                                                                                                                     | `[]string{"Server error", "Client error", "Success"}`                       |                
 | Levels        | `[]zapcore.Level`              | Custom response levels.                                                                                                                                                       | `[]zapcore.Level{zapcore.ErrorLevel, zapcore.WarnLevel, zapcore.InfoLevel}` |   
 | SkipURIs      | `[]string`                     | Skip logging these URI.                                                                                                                                                       | `[]string{}`                                                                |                
-| GetResBody    | func(c *fiber.Ctx) []byte      | Define a function to get response body when return non-nil.<br>eg: When use compress middleware, resBody is unreadable. you can set GetResBody func to get readable resBody.  | nil                                                                         |
+| GetResBody    | func(c *fiber.Ctx) []byte      | Define a function to get response body when return non-nil.<br>eg: When use compress middleware, resBody is unreadable. you can set GetResBody func to get readable resBody.  | `nil`                                                                       |
 ### Example
 ```go
 package main

--- a/fiberzap/config.go
+++ b/fiberzap/config.go
@@ -23,6 +23,12 @@ type Config struct {
 	// Optional. Default: nil
 	SkipResBody func(c *fiber.Ctx) bool
 
+	// GetResBody defines a function to get ResBody.
+	//  eg: when use compress middleware, resBody is unreadable. you can set GetResBody func to get readable resBody.
+	//
+	// Optional. Default: nil
+	GetResBody func(c *fiber.Ctx) []byte
+
 	// Skip logging for these uri
 	//
 	// Optional. Default: nil

--- a/fiberzap/zap.go
+++ b/fiberzap/zap.go
@@ -140,7 +140,11 @@ func New(config ...Config) fiber.Handler {
 				fields = append(fields, zap.Int("status", c.Response().StatusCode()))
 			case "resBody":
 				if cfg.SkipResBody == nil || !cfg.SkipResBody(c) {
-					fields = append(fields, zap.ByteString("resBody", c.Response().Body()))
+					if cfg.GetResBody == nil {
+						fields = append(fields, zap.ByteString("resBody", c.Response().Body()))
+					} else {
+						fields = append(fields, zap.ByteString("resBody", cfg.GetResBody(c)))
+					}
 				}
 			case "queryParams":
 				fields = append(fields, zap.String("queryParams", c.Request().URI().QueryArgs().String()))


### PR DESCRIPTION
When use compress middleware, resBody is unreadable. 
You can set GetResBody func to get readable resBody.
![fiberzap](https://user-images.githubusercontent.com/54696/211186803-0b7a15c9-aac4-4b1b-9e36-d5267605d3c5.png)
