### PR TITLE
Add support for passing existing New Relic application

### DIFF
--- a/fibernewrelic/README.md
+++ b/fibernewrelic/README.md
@@ -22,13 +22,13 @@ fibernewrelic.New(config fibernewrelic.Config) fiber.Handler
 
 ### Config
 
-| Property       | Type         | Description                      | Default     |
-|:---------------|:-------------|:---------------------------------|:------------|
-| License        | `string`     | Required - New Relic License Key | `""`        |
-| AppName        | `string`     | New Relic Application Name       | `fiber-api` |
-| Enabled        | `bool`       | Enable/Disable New Relic         | `false`     |
-| TransportType  | `string`     | Can be HTTP or HTTPS             | `"HTTP"`    |
-| Application    | `Application | Existing New Relic App           | `nil`       |
+| Property       | Type          | Description                      | Default     |
+|:---------------|:--------------|:---------------------------------|:------------|
+| License        | `string`      | Required - New Relic License Key | `""`        |
+| AppName        | `string`      | New Relic Application Name       | `fiber-api` |
+| Enabled        | `bool`        | Enable/Disable New Relic         | `false`     |
+| TransportType  | `string`      | Can be HTTP or HTTPS             | `"HTTP"`    |
+| Application    | `Application` | Existing New Relic App           | `nil`       |
 
 ### Usage
 

--- a/fibernewrelic/README.md
+++ b/fibernewrelic/README.md
@@ -22,12 +22,13 @@ fibernewrelic.New(config fibernewrelic.Config) fiber.Handler
 
 ### Config
 
-| Property       | Type     | Description                      | Default     |
-|:---------------|:---------|:---------------------------------|:------------|
-| License        | `string` | Required - New Relic License Key | `""`        |
-| AppName        | `string` | New Relic Application Name       | `fiber-api` |
-| Enabled        | `bool`   | Enable/Disable New Relic         | `false`     |
-| TransportType  | `string` | Can be HTTP or HTTPS             | `"HTTP"`    |
+| Property       | Type         | Description                      | Default     |
+|:---------------|:-------------|:---------------------------------|:------------|
+| License        | `string`     | Required - New Relic License Key | `""`        |
+| AppName        | `string`     | New Relic Application Name       | `fiber-api` |
+| Enabled        | `bool`       | Enable/Disable New Relic         | `false`     |
+| TransportType  | `string`     | Can be HTTP or HTTPS             | `"HTTP"`    |
+| Application    | `Application | Existing New Relic App           | `nil`       |
 
 ### Usage
 
@@ -51,6 +52,40 @@ func main() {
 		AppName:       "MyCustomApi",
 		Enabled:       true,
 		TransportType: "HTTP",
+	}
+
+	app.Use(fibernewrelic.New(cfg))
+
+	app.Listen(":8080")
+}
+```
+
+### Usage with existing New Relic application
+
+```go
+package main
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/contrib/fibernewrelic"
+	"github.com/newrelic/go-agent/v3/newrelic"
+)
+
+func main() {
+	newrelicApp, err := newrelic.NewApplication(
+		newrelic.ConfigAppName("MyCustomApi"),
+		newrelic.ConfigLicense("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
+		newrelic.ConfigEnabled(true),
+	)
+
+	app := fiber.New()
+
+	app.Get("/", func(ctx *fiber.Ctx) error {
+		return ctx.SendStatus(200)
+	})
+
+	cfg := fibernewrelic.Config{
+		Application:       newrelicApp
 	}
 
 	app.Use(fibernewrelic.New(cfg))

--- a/fibernewrelic/fiber.go
+++ b/fibernewrelic/fiber.go
@@ -15,7 +15,7 @@ type Config struct {
 	AppName string
 	// Enabled parameter passed to enable/disable newrelic
 	Enabled bool
-	// TransportType can be HTTP or HTTPS (case-sensitive), default is HTTP
+	// TransportType can be HTTP or HTTPS, default is HTTP
 	TransportType string
 	// Application field is required to use an existing newrelic application
 	Application *newrelic.Application

--- a/fibernewrelic/fiber_test.go
+++ b/fibernewrelic/fiber_test.go
@@ -2,6 +2,7 @@ package fibernewrelic
 
 import (
 	"github.com/gofiber/fiber/v2"
+	"github.com/newrelic/go-agent/v3/newrelic"
 	"github.com/stretchr/testify/assert"
 	"net/http/httptest"
 	"testing"
@@ -32,6 +33,18 @@ func TestNewrelicAppConfig(t *testing.T) {
 			})
 		})
 
+	t.Run("Panic when License is invalid length",
+		func(t *testing.T) {
+			assert.Panics(t, func() {
+				New(Config{
+					License:       "invalid_key",
+					AppName:       "",
+					Enabled:       false,
+					TransportType: "",
+				})
+			})
+		})
+
 	t.Run("Run successfully as middleware",
 		func(t *testing.T) {
 			app := fiber.New()
@@ -51,7 +64,161 @@ func TestNewrelicAppConfig(t *testing.T) {
 
 			r := httptest.NewRequest("GET", "/", nil)
 			resp, _ := app.Test(r, -1)
-
 			assert.Equal(t, 200, resp.StatusCode)
+		})
+
+	t.Run("Test for invalid URL",
+		func(t *testing.T) {
+			app := fiber.New()
+
+			app.Get("/", func(ctx *fiber.Ctx) error {
+				return ctx.SendStatus(200)
+			})
+
+			cfg := Config{
+				License:       "0123456789abcdef0123456789abcdef01234567",
+				AppName:       "",
+				Enabled:       true,
+				TransportType: "",
+			}
+			app.Use(New(cfg))
+
+			r := httptest.NewRequest("GET", "/invalid-url", nil)
+			resp, _ := app.Test(r, -1)
+			assert.Equal(t, 404, resp.StatusCode)
+		})
+
+	t.Run("Test HTTP transport type",
+		func(t *testing.T) {
+			app := fiber.New()
+
+			app.Get("/", func(ctx *fiber.Ctx) error {
+				return ctx.SendStatus(200)
+			})
+
+			cfg := Config{
+				License:       "0123456789abcdef0123456789abcdef01234567",
+				AppName:       "",
+				Enabled:       true,
+				TransportType: "HTTP",
+			}
+			app.Use(New(cfg))
+
+			r := httptest.NewRequest("GET", "/", nil)
+			resp, _ := app.Test(r, -1)
+			assert.Equal(t, 200, resp.StatusCode)
+		})
+
+	t.Run("Test http transport type (lowercase)",
+		func(t *testing.T) {
+			app := fiber.New()
+
+			app.Get("/", func(ctx *fiber.Ctx) error {
+				return ctx.SendStatus(200)
+			})
+
+			cfg := Config{
+				License:       "0123456789abcdef0123456789abcdef01234567",
+				AppName:       "",
+				Enabled:       true,
+				TransportType: "http",
+			}
+			app.Use(New(cfg))
+
+			r := httptest.NewRequest("GET", "/", nil)
+			resp, _ := app.Test(r, -1)
+			assert.Equal(t, 200, resp.StatusCode)
+		})
+
+	t.Run("Test HTTPS transport type",
+		func(t *testing.T) {
+			app := fiber.New()
+
+			app.Get("/", func(ctx *fiber.Ctx) error {
+				return ctx.SendStatus(200)
+			})
+
+			cfg := Config{
+				License:       "0123456789abcdef0123456789abcdef01234567",
+				AppName:       "",
+				Enabled:       true,
+				TransportType: "HTTPS",
+			}
+			app.Use(New(cfg))
+
+			r := httptest.NewRequest("GET", "/", nil)
+			resp, _ := app.Test(r, -1)
+			assert.Equal(t, 200, resp.StatusCode)
+		})
+
+	t.Run("Test invalid transport type",
+		func(t *testing.T) {
+			app := fiber.New()
+
+			app.Get("/", func(ctx *fiber.Ctx) error {
+				return ctx.SendStatus(200)
+			})
+
+			cfg := Config{
+				License:       "0123456789abcdef0123456789abcdef01234567",
+				AppName:       "",
+				Enabled:       true,
+				TransportType: "InvalidTransport",
+			}
+			app.Use(New(cfg))
+
+			r := httptest.NewRequest("GET", "/", nil)
+			resp, _ := app.Test(r, -1)
+			assert.Equal(t, 200, resp.StatusCode)
+		})
+
+	t.Run("Test using existing newrelic application (configured)",
+		func(t *testing.T) {
+			app := fiber.New()
+
+			app.Get("/", func(ctx *fiber.Ctx) error {
+				return ctx.SendStatus(200)
+			})
+
+			newrelicApp, err := newrelic.NewApplication(
+				newrelic.ConfigAppName("testApp"),
+				newrelic.ConfigLicense("0123456789abcdef0123456789abcdef01234567"),
+			)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, newrelicApp)
+
+			cfg := Config{
+				Application: newrelicApp,
+			}
+			app.Use(New(cfg))
+
+			r := httptest.NewRequest("GET", "/", nil)
+			resp, _ := app.Test(r, -1)
+			assert.Equal(t, 200, resp.StatusCode)
+		})
+
+	t.Run("Assert panic with existing newrelic application (no config)",
+		func(t *testing.T) {
+			assert.Panics(t, func() {
+				app := fiber.New()
+
+				app.Get("/", func(ctx *fiber.Ctx) error {
+					return ctx.SendStatus(200)
+				})
+
+				newrelicApp, err := newrelic.NewApplication()
+				assert.Error(t, err)
+				assert.Nil(t, newrelicApp)
+
+				cfg := Config{
+					Application: newrelicApp,
+				}
+				app.Use(New(cfg))
+
+				r := httptest.NewRequest("GET", "/", nil)
+				resp, _ := app.Test(r, -1)
+				assert.Equal(t, 200, resp.StatusCode)
+			})
 		})
 }

--- a/fibernewrelic/fiber_test.go
+++ b/fibernewrelic/fiber_test.go
@@ -183,6 +183,7 @@ func TestNewrelicAppConfig(t *testing.T) {
 			newrelicApp, err := newrelic.NewApplication(
 				newrelic.ConfigAppName("testApp"),
 				newrelic.ConfigLicense("0123456789abcdef0123456789abcdef01234567"),
+				newrelic.ConfigEnabled(true),
 			)
 
 			assert.NoError(t, err)


### PR DESCRIPTION
The main purpose of this PR is to fix #269 allowing the user to pass an existing `newrelic.Application`. If passed all the other config values will be ignored except for the transport type, since it's used by middleware function.

Also included:
- `TransportType` is now case insensitive. We now run ToUpper internally.
- Updated readme with example usage
- Added unit-test for testing different transport types (HTTP, HTTPS, http, invalid (defaults to HTTP))
- Added unit-test for testing against an invalid key (shorter than 40 chars)
- Added unit-test for passing a valid existing newrelic.Application
- Added unit-test for passing an invalid newrelic.Application