### PR TITLE
change newrelic fiber to group transaction metrics under the same route

### DIFF
--- a/fibernewrelic/README.md
+++ b/fibernewrelic/README.md
@@ -22,12 +22,13 @@ fibernewrelic.New(config fibernewrelic.Config) fiber.Handler
 
 ### Config
 
-| Property       | Type          | Description                      | Default     |
-|:---------------|:--------------|:---------------------------------|:------------|
-| License        | `string`      | Required - New Relic License Key | `""`        |
-| AppName        | `string`      | New Relic Application Name       | `fiber-api` |
-| Enabled        | `bool`        | Enable/Disable New Relic         | `false`     |
-| Application    | `Application` | Existing New Relic App           | `nil`       |
+| Property          | Type             | Description                            | Default        |
+|:------------------|:-----------------|:---------------------------------------|:---------------|
+| License           | `string`         | Required - New Relic License Key       | `""`           |
+| AppName           | `string`         | New Relic Application Name             | `fiber-api`    |
+| Enabled           | `bool`           | Enable/Disable New Relic               | `false`        |
+| ~~TransportType~~ | ~~`string`~~     | ~~Can be HTTP or HTTPS~~ (Deprecated)  | ~~`"HTTP"`~~   |
+| Application       | `Application`    | Existing New Relic App                 | `nil`          |
 
 ### Usage
 

--- a/fibernewrelic/README.md
+++ b/fibernewrelic/README.md
@@ -27,7 +27,6 @@ fibernewrelic.New(config fibernewrelic.Config) fiber.Handler
 | License        | `string`      | Required - New Relic License Key | `""`        |
 | AppName        | `string`      | New Relic Application Name       | `fiber-api` |
 | Enabled        | `bool`        | Enable/Disable New Relic         | `false`     |
-| TransportType  | `string`      | Can be HTTP or HTTPS             | `"HTTP"`    |
 | Application    | `Application` | Existing New Relic App           | `nil`       |
 
 ### Usage
@@ -51,7 +50,6 @@ func main() {
 		License:       "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
 		AppName:       "MyCustomApi",
 		Enabled:       true,
-		TransportType: "HTTP",
 	}
 
 	app.Use(fibernewrelic.New(cfg))

--- a/fibernewrelic/fiber.go
+++ b/fibernewrelic/fiber.go
@@ -17,18 +17,15 @@ type Config struct {
 	AppName string
 	// Enabled parameter passed to enable/disable newrelic
 	Enabled bool
-	// TransportType can be HTTP or HTTPS, default is HTTP
-	TransportType string
 	// Application field is required to use an existing newrelic application
 	Application *newrelic.Application
 }
 
 var ConfigDefault = Config{
-	Application:   nil,
-	License:       "",
-	AppName:       "fiber-api",
-	Enabled:       false,
-	TransportType: string(newrelic.TransportHTTP),
+	Application: nil,
+	License:     "",
+	AppName:     "fiber-api",
+	Enabled:     false,
 }
 
 func New(cfg Config) fiber.Handler {
@@ -55,14 +52,6 @@ func New(cfg Config) fiber.Handler {
 		if err != nil {
 			panic(fmt.Errorf("unable to create New Relic Application -> %w", err))
 		}
-	}
-
-	normalizeTransport := strings.ToUpper(cfg.TransportType)
-
-	if normalizeTransport != "HTTP" && normalizeTransport != "HTTPS" {
-		cfg.TransportType = ConfigDefault.TransportType
-	} else {
-		cfg.TransportType = normalizeTransport
 	}
 
 	return func(c *fiber.Ctx) error {

--- a/fibernewrelic/fiber.go
+++ b/fibernewrelic/fiber.go
@@ -2,10 +2,12 @@ package fibernewrelic
 
 import (
 	"fmt"
-	"github.com/gofiber/fiber/v2"
-	"github.com/newrelic/go-agent/v3/newrelic"
 	"net/url"
 	"strings"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/utils"
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 type Config struct {
@@ -64,27 +66,54 @@ func New(cfg Config) fiber.Handler {
 	}
 
 	return func(c *fiber.Ctx) error {
-		txn := app.StartTransaction(c.Method() + " " + c.Path())
-		originalURL, err := url.Parse(c.OriginalURL())
-		if err != nil {
-			return c.Next()
+		txn := app.StartTransaction("")
+		defer txn.End()
+
+		err := c.Next()
+
+		method := utils.CopyString(c.Method())
+		routePath := utils.CopyString(c.Route().Path)
+		host := string(c.Request().URI().Host())
+
+		u := url.URL{
+			Scheme:   string(c.Request().URI().Scheme()),
+			Host:     host,
+			Path:     string(c.Request().URI().Path()),
+			RawQuery: string(c.Request().URI().QueryString()),
 		}
 
 		txn.SetWebRequest(newrelic.WebRequest{
-			URL:       originalURL,
-			Method:    c.Method(),
-			Transport: newrelic.TransportType(cfg.TransportType),
-			Host:      c.Hostname(),
+			URL:       &u,
+			Method:    method,
+			Transport: transport(u.Scheme),
+			Host:      host,
 		})
+		txn.SetName(fmt.Sprintf("%s %s", method, routePath))
 
-		err = c.Next()
+		statusCode := c.Context().Response.StatusCode()
+
 		if err != nil {
+			if fiberErr, ok := err.(*fiber.Error); ok {
+				statusCode = fiberErr.Code
+			}
+
 			txn.NoticeError(err)
 		}
 
-		defer txn.SetWebResponse(nil).WriteHeader(c.Response().StatusCode())
-		defer txn.End()
+		txn.SetWebResponse(nil).WriteHeader(statusCode)
 
 		return err
 	}
+}
+
+func transport(schema string) newrelic.TransportType {
+	if strings.HasPrefix(schema, "https") {
+		return newrelic.TransportHTTPS
+	}
+
+	if strings.HasPrefix(schema, "http") {
+		return newrelic.TransportHTTP
+	}
+
+	return newrelic.TransportUnknown
 }

--- a/fibernewrelic/fiber.go
+++ b/fibernewrelic/fiber.go
@@ -17,6 +17,9 @@ type Config struct {
 	AppName string
 	// Enabled parameter passed to enable/disable newrelic
 	Enabled bool
+	// TransportType can be HTTP or HTTPS, default is HTTP
+	// Deprecated: The Transport type now acquiring from request URL scheme internally
+	TransportType string
 	// Application field is required to use an existing newrelic application
 	Application *newrelic.Application
 }

--- a/fibernewrelic/fiber_test.go
+++ b/fibernewrelic/fiber_test.go
@@ -14,10 +14,9 @@ func TestNewrelicAppConfig(t *testing.T) {
 		func(t *testing.T) {
 			assert.Panics(t, func() {
 				New(Config{
-					License:       "",
-					AppName:       "",
-					Enabled:       false,
-					TransportType: "",
+					License: "",
+					AppName: "",
+					Enabled: false,
 				})
 			})
 		})
@@ -26,10 +25,9 @@ func TestNewrelicAppConfig(t *testing.T) {
 		func(t *testing.T) {
 			assert.NotPanics(t, func() {
 				New(Config{
-					License:       "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-					AppName:       "",
-					Enabled:       false,
-					TransportType: "",
+					License: "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+					AppName: "",
+					Enabled: false,
 				})
 			})
 		})
@@ -38,10 +36,9 @@ func TestNewrelicAppConfig(t *testing.T) {
 		func(t *testing.T) {
 			assert.Panics(t, func() {
 				New(Config{
-					License:       "invalid_key",
-					AppName:       "",
-					Enabled:       false,
-					TransportType: "",
+					License: "invalid_key",
+					AppName: "",
+					Enabled: false,
 				})
 			})
 		})
@@ -51,11 +48,39 @@ func TestNewrelicAppConfig(t *testing.T) {
 			app := fiber.New()
 
 			cfg := Config{
-				License:       "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-				AppName:       "",
-				Enabled:       true,
-				TransportType: "",
+				License: "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+				AppName: "",
+				Enabled: true,
 			}
+
+			app.Use(New(cfg))
+
+			app.Get("/", func(ctx *fiber.Ctx) error {
+				return ctx.SendStatus(200)
+			})
+
+			r := httptest.NewRequest("GET", "/", nil)
+			resp, _ := app.Test(r, -1)
+			assert.Equal(t, 200, resp.StatusCode)
+		})
+
+	t.Run("Run successfully as middleware",
+		func(t *testing.T) {
+			app := fiber.New()
+
+			cfg := Config{
+				License: "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+				AppName: "",
+				Enabled: true,
+			}
+
+			newRelicApp, _ := newrelic.NewApplication(
+				newrelic.ConfigAppName(cfg.AppName),
+				newrelic.ConfigLicense(cfg.License),
+				newrelic.ConfigEnabled(cfg.Enabled),
+			)
+
+			cfg.Application = newRelicApp
 
 			app.Use(New(cfg))
 
@@ -73,10 +98,9 @@ func TestNewrelicAppConfig(t *testing.T) {
 			app := fiber.New()
 
 			cfg := Config{
-				License:       "0123456789abcdef0123456789abcdef01234567",
-				AppName:       "",
-				Enabled:       true,
-				TransportType: "",
+				License: "0123456789abcdef0123456789abcdef01234567",
+				AppName: "",
+				Enabled: true,
 			}
 			app.Use(New(cfg))
 
@@ -94,10 +118,9 @@ func TestNewrelicAppConfig(t *testing.T) {
 			app := fiber.New()
 
 			cfg := Config{
-				License:       "0123456789abcdef0123456789abcdef01234567",
-				AppName:       "",
-				Enabled:       true,
-				TransportType: "HTTP",
+				License: "0123456789abcdef0123456789abcdef01234567",
+				AppName: "",
+				Enabled: true,
 			}
 			app.Use(New(cfg))
 
@@ -115,10 +138,9 @@ func TestNewrelicAppConfig(t *testing.T) {
 			app := fiber.New()
 
 			cfg := Config{
-				License:       "0123456789abcdef0123456789abcdef01234567",
-				AppName:       "",
-				Enabled:       true,
-				TransportType: "http",
+				License: "0123456789abcdef0123456789abcdef01234567",
+				AppName: "",
+				Enabled: true,
 			}
 			app.Use(New(cfg))
 
@@ -136,31 +158,9 @@ func TestNewrelicAppConfig(t *testing.T) {
 			app := fiber.New()
 
 			cfg := Config{
-				License:       "0123456789abcdef0123456789abcdef01234567",
-				AppName:       "",
-				Enabled:       true,
-				TransportType: "HTTPS",
-			}
-			app.Use(New(cfg))
-
-			app.Get("/", func(ctx *fiber.Ctx) error {
-				return ctx.SendStatus(200)
-			})
-
-			r := httptest.NewRequest("GET", "/", nil)
-			resp, _ := app.Test(r, -1)
-			assert.Equal(t, 200, resp.StatusCode)
-		})
-
-	t.Run("Test invalid transport type",
-		func(t *testing.T) {
-			app := fiber.New()
-
-			cfg := Config{
-				License:       "0123456789abcdef0123456789abcdef01234567",
-				AppName:       "",
-				Enabled:       true,
-				TransportType: "InvalidTransport",
+				License: "0123456789abcdef0123456789abcdef01234567",
+				AppName: "",
+				Enabled: true,
 			}
 			app.Use(New(cfg))
 
@@ -211,7 +211,7 @@ func TestNewrelicAppConfig(t *testing.T) {
 					Application: newrelicApp,
 				}
 				app.Use(New(cfg))
-				
+
 				app.Get("/", func(ctx *fiber.Ctx) error {
 					return ctx.SendStatus(200)
 				})

--- a/fibernewrelic/fiber_test.go
+++ b/fibernewrelic/fiber_test.go
@@ -1,11 +1,12 @@
 package fibernewrelic
 
 import (
+	"net/http/httptest"
+	"testing"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/newrelic/go-agent/v3/newrelic"
 	"github.com/stretchr/testify/assert"
-	"net/http/httptest"
-	"testing"
 )
 
 func TestNewrelicAppConfig(t *testing.T) {
@@ -49,10 +50,6 @@ func TestNewrelicAppConfig(t *testing.T) {
 		func(t *testing.T) {
 			app := fiber.New()
 
-			app.Get("/", func(ctx *fiber.Ctx) error {
-				return ctx.SendStatus(200)
-			})
-
 			cfg := Config{
 				License:       "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
 				AppName:       "",
@@ -61,6 +58,10 @@ func TestNewrelicAppConfig(t *testing.T) {
 			}
 
 			app.Use(New(cfg))
+
+			app.Get("/", func(ctx *fiber.Ctx) error {
+				return ctx.SendStatus(200)
+			})
 
 			r := httptest.NewRequest("GET", "/", nil)
 			resp, _ := app.Test(r, -1)
@@ -71,10 +72,6 @@ func TestNewrelicAppConfig(t *testing.T) {
 		func(t *testing.T) {
 			app := fiber.New()
 
-			app.Get("/", func(ctx *fiber.Ctx) error {
-				return ctx.SendStatus(200)
-			})
-
 			cfg := Config{
 				License:       "0123456789abcdef0123456789abcdef01234567",
 				AppName:       "",
@@ -82,6 +79,10 @@ func TestNewrelicAppConfig(t *testing.T) {
 				TransportType: "",
 			}
 			app.Use(New(cfg))
+
+			app.Get("/", func(ctx *fiber.Ctx) error {
+				return ctx.SendStatus(200)
+			})
 
 			r := httptest.NewRequest("GET", "/invalid-url", nil)
 			resp, _ := app.Test(r, -1)
@@ -92,10 +93,6 @@ func TestNewrelicAppConfig(t *testing.T) {
 		func(t *testing.T) {
 			app := fiber.New()
 
-			app.Get("/", func(ctx *fiber.Ctx) error {
-				return ctx.SendStatus(200)
-			})
-
 			cfg := Config{
 				License:       "0123456789abcdef0123456789abcdef01234567",
 				AppName:       "",
@@ -103,6 +100,10 @@ func TestNewrelicAppConfig(t *testing.T) {
 				TransportType: "HTTP",
 			}
 			app.Use(New(cfg))
+
+			app.Get("/", func(ctx *fiber.Ctx) error {
+				return ctx.SendStatus(200)
+			})
 
 			r := httptest.NewRequest("GET", "/", nil)
 			resp, _ := app.Test(r, -1)
@@ -113,10 +114,6 @@ func TestNewrelicAppConfig(t *testing.T) {
 		func(t *testing.T) {
 			app := fiber.New()
 
-			app.Get("/", func(ctx *fiber.Ctx) error {
-				return ctx.SendStatus(200)
-			})
-
 			cfg := Config{
 				License:       "0123456789abcdef0123456789abcdef01234567",
 				AppName:       "",
@@ -124,6 +121,10 @@ func TestNewrelicAppConfig(t *testing.T) {
 				TransportType: "http",
 			}
 			app.Use(New(cfg))
+
+			app.Get("/", func(ctx *fiber.Ctx) error {
+				return ctx.SendStatus(200)
+			})
 
 			r := httptest.NewRequest("GET", "/", nil)
 			resp, _ := app.Test(r, -1)
@@ -134,10 +135,6 @@ func TestNewrelicAppConfig(t *testing.T) {
 		func(t *testing.T) {
 			app := fiber.New()
 
-			app.Get("/", func(ctx *fiber.Ctx) error {
-				return ctx.SendStatus(200)
-			})
-
 			cfg := Config{
 				License:       "0123456789abcdef0123456789abcdef01234567",
 				AppName:       "",
@@ -145,6 +142,10 @@ func TestNewrelicAppConfig(t *testing.T) {
 				TransportType: "HTTPS",
 			}
 			app.Use(New(cfg))
+
+			app.Get("/", func(ctx *fiber.Ctx) error {
+				return ctx.SendStatus(200)
+			})
 
 			r := httptest.NewRequest("GET", "/", nil)
 			resp, _ := app.Test(r, -1)
@@ -155,10 +156,6 @@ func TestNewrelicAppConfig(t *testing.T) {
 		func(t *testing.T) {
 			app := fiber.New()
 
-			app.Get("/", func(ctx *fiber.Ctx) error {
-				return ctx.SendStatus(200)
-			})
-
 			cfg := Config{
 				License:       "0123456789abcdef0123456789abcdef01234567",
 				AppName:       "",
@@ -166,6 +163,10 @@ func TestNewrelicAppConfig(t *testing.T) {
 				TransportType: "InvalidTransport",
 			}
 			app.Use(New(cfg))
+
+			app.Get("/", func(ctx *fiber.Ctx) error {
+				return ctx.SendStatus(200)
+			})
 
 			r := httptest.NewRequest("GET", "/", nil)
 			resp, _ := app.Test(r, -1)
@@ -176,23 +177,23 @@ func TestNewrelicAppConfig(t *testing.T) {
 		func(t *testing.T) {
 			app := fiber.New()
 
-			app.Get("/", func(ctx *fiber.Ctx) error {
-				return ctx.SendStatus(200)
-			})
-
 			newrelicApp, err := newrelic.NewApplication(
 				newrelic.ConfigAppName("testApp"),
 				newrelic.ConfigLicense("0123456789abcdef0123456789abcdef01234567"),
 				newrelic.ConfigEnabled(true),
 			)
 
-			assert.NoError(t, err)
-			assert.NotNil(t, newrelicApp)
-
 			cfg := Config{
 				Application: newrelicApp,
 			}
 			app.Use(New(cfg))
+
+			app.Get("/", func(ctx *fiber.Ctx) error {
+				return ctx.SendStatus(200)
+			})
+
+			assert.NoError(t, err)
+			assert.NotNil(t, newrelicApp)
 
 			r := httptest.NewRequest("GET", "/", nil)
 			resp, _ := app.Test(r, -1)
@@ -204,18 +205,19 @@ func TestNewrelicAppConfig(t *testing.T) {
 			assert.Panics(t, func() {
 				app := fiber.New()
 
-				app.Get("/", func(ctx *fiber.Ctx) error {
-					return ctx.SendStatus(200)
-				})
-
 				newrelicApp, err := newrelic.NewApplication()
-				assert.Error(t, err)
-				assert.Nil(t, newrelicApp)
 
 				cfg := Config{
 					Application: newrelicApp,
 				}
 				app.Use(New(cfg))
+				
+				app.Get("/", func(ctx *fiber.Ctx) error {
+					return ctx.SendStatus(200)
+				})
+
+				assert.Error(t, err)
+				assert.Nil(t, newrelicApp)
 
 				r := httptest.NewRequest("GET", "/", nil)
 				resp, _ := app.Test(r, -1)


### PR DESCRIPTION
It prevents creating separate transactions on NewRelic.

It groups different path params under the same route now.

Here is the NewRelic screenshot:

![image](https://user-images.githubusercontent.com/12763626/216334214-bcdbfc92-152b-4839-a788-715f822987ce.png)
