### PR TITLE
feat: add error status code handler

### DIFF
--- a/fibernewrelic/README.md
+++ b/fibernewrelic/README.md
@@ -29,6 +29,7 @@ fibernewrelic.New(config fibernewrelic.Config) fiber.Handler
 | Enabled           | `bool`           | Enable/Disable New Relic               | `false`        |
 | ~~TransportType~~ | ~~`string`~~     | ~~Can be HTTP or HTTPS~~ (Deprecated)  | ~~`"HTTP"`~~   |
 | Application       | `Application`    | Existing New Relic App                 | `nil`          |
+| ErrorStatusCodeHandler       | `func(c *fiber.Ctx, err error) int`    | If you want to change newrelic status code, you can use it.                 | `DefaultErrorStatusCodeHandler`          |
 
 ### Usage
 


### PR DESCRIPTION
We need to change the new relic status code when an error occurs. 

For example, if you use FiberErrorHandler and don't return a status code from the handler, you can configure a new relic status code with this MR.