### PR TITLE
fix fiberi18n error on concurrent requests

### DIFF
--- a/fiberi18n/config.go
+++ b/fiberi18n/config.go
@@ -72,20 +72,23 @@ var ConfigDefault = &Config{
 	FormatBundleFile: "yaml",
 	UnmarshalFunc:    yaml.Unmarshal,
 	Loader:           LoaderFunc(os.ReadFile),
-	LangHandler: func(c *fiber.Ctx, defaultLang string) string {
-		if c == nil {
-			return defaultLang
-		}
-		lang := c.Get("Accept-Language")
-		if lang != "" {
-			return lang
-		}
-		lang = c.Query("lang")
-		if lang == "" {
-			return defaultLang
-		}
+	LangHandler:      defaultLangHandler,
+}
+
+func defaultLangHandler(c *fiber.Ctx, defaultLang string) string {
+	var lang string
+	lang = c.Query("lang")
+	if lang != "" {
 		return lang
-	},
+	}
+
+	lang = c.Get("Accept-Language")
+	if lang != "" {
+		return lang
+	}
+
+	return defaultLang
+
 }
 
 func configDefault(config ...*Config) *Config {


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://github.com/gofiber/contrib/issues/594

#### How to resolve this issue:

In fact the template only needs to be read once when the program is initialised.

But I didn't do that 😰
