### PR TITLE
OtelFiber: Replace deprecated SemVersion with Version

### DIFF
--- a/otelfiber/fiber.go
+++ b/otelfiber/fiber.go
@@ -43,7 +43,7 @@ func Middleware(opts ...Option) fiber.Handler {
 	}
 	tracer := cfg.TracerProvider.Tracer(
 		instrumentationName,
-		oteltrace.WithInstrumentationVersion(otelcontrib.SemVersion()),
+		oteltrace.WithInstrumentationVersion(otelcontrib.Version()),
 	)
 
 	if cfg.MeterProvider == nil {
@@ -51,7 +51,7 @@ func Middleware(opts ...Option) fiber.Handler {
 	}
 	meter := cfg.MeterProvider.Meter(
 		instrumentationName,
-		metric.WithInstrumentationVersion(otelcontrib.SemVersion()),
+		metric.WithInstrumentationVersion(otelcontrib.Version()),
 	)
 
 	httpServerDuration, err := meter.Float64Histogram(metricNameHttpServerDuration, metric.WithUnit(UnitMilliseconds), metric.WithDescription("measures the duration inbound HTTP requests"))

--- a/otelfiber/fiber_test.go
+++ b/otelfiber/fiber_test.go
@@ -299,7 +299,7 @@ func TestMetric(t *testing.T) {
 func assertScopeMetrics(t *testing.T, sm metricdata.ScopeMetrics, route string, requestAttrs []attribute.KeyValue, responseAttrs []attribute.KeyValue) {
 	assert.Equal(t, instrumentation.Scope{
 		Name:    instrumentationName,
-		Version: otelcontrib.SemVersion(),
+		Version: otelcontrib.Version(),
 	}, sm.Scope)
 
 	// Duration value is not predictable.


### PR DESCRIPTION
otelcontrib.SemVersion is depracated in favour of otelcontrib.Version.
https://pkg.go.dev/go.opentelemetry.io/contrib#SemVersion
