### PR TITLE
feat: propagate newrelic tx info by using fiber.Ctx and little refact…

### DIFF
--- a/fibernewrelic/README.md
+++ b/fibernewrelic/README.md
@@ -90,9 +90,19 @@ func main() {
 	app.Get("/", func(ctx *fiber.Ctx) error {
 		return ctx.SendStatus(200)
 	})
+	
+	app.Get("/foo", func(ctx *fiber.Ctx) error {
+		txn := newrelic.FromContext(ctx)
+		segment := txn.StartSegment("foo segment")
+		defer segment.End()
+		
+		// do foo 
+
+		return nil
+	})
 
 	cfg := fibernewrelic.Config{
-		Application:       newrelicApp
+		Application:       newrelicApp,
 	}
 
 	app.Use(fibernewrelic.New(cfg))

--- a/fibernewrelic/fiber.go
+++ b/fibernewrelic/fiber.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/utils"
 	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
@@ -66,33 +65,26 @@ func New(cfg Config) fiber.Handler {
 	}
 
 	return func(c *fiber.Ctx) error {
-		txn := app.StartTransaction("")
+		txn := app.StartTransaction(createTransactionName(c))
 		defer txn.End()
 
-		handlerErr := c.Next()
-
-		var (
-			method    = utils.CopyString(c.Method())
-			routePath = utils.CopyString(c.Route().Path)
-			host      = utils.CopyString(c.Hostname())
-		)
-
-		u := url.URL{
-			Host:     host,
-			Scheme:   string(c.Request().URI().Scheme()),
-			Path:     string(c.Request().URI().Path()),
-			RawQuery: string(c.Request().URI().QueryString()),
-		}
-
-		txn.SetName(fmt.Sprintf("%s %s", method, routePath))
+		scheme := c.Request().URI().Scheme()
 
 		txn.SetWebRequest(newrelic.WebRequest{
-			URL:       &u,
-			Method:    method,
-			Transport: transport(u.Scheme),
-			Host:      host,
+			Host:      c.Hostname(),
+			Method:    c.Method(),
+			Transport: transport(string(scheme)),
+			URL: &url.URL{
+				Host:     c.Hostname(),
+				Scheme:   string(c.Request().URI().Scheme()),
+				Path:     string(c.Request().URI().Path()),
+				RawQuery: string(c.Request().URI().QueryString()),
+			},
 		})
 
+		c.SetUserContext(newrelic.NewContext(c.UserContext(), txn))
+
+		handlerErr := c.Next()
 		statusCode := c.Context().Response.StatusCode()
 
 		if handlerErr != nil {
@@ -104,6 +96,16 @@ func New(cfg Config) fiber.Handler {
 
 		return handlerErr
 	}
+}
+
+// FromContext returns the Transaction from the context if present, and nil
+// otherwise.
+func FromContext(c *fiber.Ctx) *newrelic.Transaction {
+	return newrelic.FromContext(c.UserContext())
+}
+
+func createTransactionName(c *fiber.Ctx) string {
+	return fmt.Sprintf("%s %s", c.Request().Header.Method(), c.Request().URI().Path())
 }
 
 func transport(schema string) newrelic.TransportType {

--- a/fibernewrelic/fiber.go
+++ b/fibernewrelic/fiber.go
@@ -2,6 +2,7 @@ package fibernewrelic
 
 import (
 	"fmt"
+	"github.com/gofiber/fiber/v2/utils"
 	"net/url"
 	"strings"
 
@@ -68,14 +69,19 @@ func New(cfg Config) fiber.Handler {
 		txn := app.StartTransaction(createTransactionName(c))
 		defer txn.End()
 
+		var (
+			host   = utils.CopyString(c.Hostname())
+			method = utils.CopyString(c.Method())
+		)
+
 		scheme := c.Request().URI().Scheme()
 
 		txn.SetWebRequest(newrelic.WebRequest{
-			Host:      c.Hostname(),
-			Method:    c.Method(),
+			Host:      host,
+			Method:    method,
 			Transport: transport(string(scheme)),
 			URL: &url.URL{
-				Host:     c.Hostname(),
+				Host:     host,
 				Scheme:   string(c.Request().URI().Scheme()),
 				Path:     string(c.Request().URI().Path()),
 				RawQuery: string(c.Request().URI().QueryString()),


### PR DESCRIPTION
In order to create segments we need to pass created new relic transaction using fiber.Ctx to the chain.