### PR TITLE
fix: Increase the judgment of type strong rotation

### DIFF
--- a/fiberi18n/i18n.go
+++ b/fiberi18n/i18n.go
@@ -103,10 +103,19 @@ Localize get the i18n message
 		})
 */
 func Localize(ctx *fiber.Ctx, params interface{}) (string, error) {
-	appCfg := ctx.Locals(localsKey).(*Config)
-	lang := appCfg.LangHandler(ctx, appCfg.DefaultLanguage.String())
+	local := ctx.Locals(localsKey)
+	if local == nil {
+		return "", fmt.Errorf("i18n.Localize error: %v", "Config is nil")
+	}
 
+	appCfg, ok := local.(*Config)
+	if !ok {
+		return "", fmt.Errorf("i18n.Localize error: %v", "Config is not *Config type")
+	}
+
+	lang := appCfg.LangHandler(ctx, appCfg.DefaultLanguage.String())
 	localizer, _ := appCfg.localizerMap.Load(lang)
+
 	if localizer == nil {
 		defaultLang := appCfg.DefaultLanguage.String()
 		localizer, _ = appCfg.localizerMap.Load(defaultLang)


### PR DESCRIPTION
## Fix
https://github.com/gofiber/contrib/issues/758

## Reason

`c.Locals` may take out `nil` in case of high concurrency, so it is added to prevent the program from crashing.