### PR TITLE
Refactoring and fixes to Swagger Middleware

### DIFF
--- a/swagger/README.md
+++ b/swagger/README.md
@@ -1,5 +1,6 @@
 ---
 id: swagger
+title: Swagger
 ---
 
 # Swagger
@@ -14,28 +15,30 @@ Swagger middleware for [Fiber](https://github.com/gofiber/fiber). The middleware
 
 **Note: Requires Go 1.18 and above**
 
-## Install
+### Table of Contents
+- [Signatures](#signatures)
+- [Installation](#installation)
+- [Examples](#examples)
+- [Config](#config)
+- [Default Config](#default-config)
 
-```
-go get -u github.com/gofiber/fiber/v2
-go get -u github.com/gofiber/contrib/swagger
-```
-
-## Signatures
+### Signatures
 ```go
 func New(config ...swagger.Config) fiber.Handler
 ```
 
-## Config
+### Installation
+Swagger is tested on the latests [Go versions](https://golang.org/dl/) with support for modules. So make sure to initialize one first if you didn't do that yet:
+```bash
+go mod init github.com/<user>/<repo>
+```
+And then install the swagger middleware:
+```bash
+go get github.com/gofiber/contrib/swagger
+```
 
-| Property  | Type     | Description                                                           | Default |
-|:----------|:---------|:----------------------------------------------------------------------|:--------|
-| BasePath  | `string` | BasePath is the base path for the configuration file.                  | `""`    |
-| FilePath  | `string` | FilePath is the file path to the configuration file.                   | `""`    |
-
-
-## Examples
-Import the middleware package that is part of the Fiber web framework
+### Examples
+Import the middleware package
 ```go
 import (
   "github.com/gofiber/fiber/v2"
@@ -43,23 +46,81 @@ import (
 )
 ```
 
-Then create a Fiber app with app := fiber.New().
-
-After you initiate your Fiber app, you can use the following possibilities:
-
-## Default Config
-
+Using the default config:
 ```go
 app.Use(swagger.New(cfg))
 ```
 
-## Custom Config
-
+Using a custom config:
 ```go
 cfg := swagger.Config{
-    BasePath: "/", //swagger ui base path
+    BasePath: "/",
     FilePath: "./docs/swagger.json",
+    Path:     "swagger",
+    Title:    "Swagger API Docs",
 }
 
 app.Use(swagger.New(cfg))
+```
+
+Using multiple instances of Swagger:
+```go
+// Create Swagger middleware for v1
+//
+// Swagger will be available at: /api/v1/docs
+app.Use(swagger.New(swagger.Config{
+    BasePath: "/api/v1/",
+    FilePath: "./docs/v1/swagger.json",
+    Path:     "docs",
+}))
+
+// Create Swagger middleware for v2
+//
+// Swagger will be available at: /api/v2/docs
+app.Use(swagger.New(swagger.Config{
+    BasePath: "/api/v2/",
+    FilePath: "./docs/v2/swagger.json",
+    Path:     "docs",
+}))
+```
+
+### Config
+```go
+type Config struct {
+	// Next defines a function to skip this middleware when returned true.
+	//
+	// Optional. Default: nil
+	Next func(c *fiber.Ctx) bool
+
+	// BasePath for the UI path
+	//
+	// Optional. Default: /
+	BasePath string
+
+	// FilePath for the swagger.json or swagger.yaml file
+	//
+	// Optional. Default: ./swagger.json
+	FilePath string
+
+	// Path combines with BasePath for the full UI path
+	//
+	// Optional. Default: docs
+	Path string
+
+	// Title for the documentation site
+	//
+	// Optional. Default: Fiber API documentation
+	Title string
+}
+```
+
+### Default Config
+```go
+var ConfigDefault = Config{
+	Next:     nil,
+	BasePath: "/",
+	FilePath: "./swagger.json",
+	Path:     "docs",
+	Title:    "Fiber API documentation",
+}
 ```

--- a/swagger/README.md
+++ b/swagger/README.md
@@ -111,6 +111,11 @@ type Config struct {
 	//
 	// Optional. Default: Fiber API documentation
 	Title string
+
+	// CacheAge defines the max-age for the Cache-Control header in seconds.
+	//
+	// Optional. Default: 3600 (1 hour)
+	CacheAge int
 }
 ```
 
@@ -122,5 +127,6 @@ var ConfigDefault = Config{
 	FilePath: "./swagger.json",
 	Path:     "docs",
 	Title:    "Fiber API documentation",
+	CacheAge: 3600, // Default to 1 hour
 }
 ```

--- a/swagger/go.mod
+++ b/swagger/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-openapi/runtime v0.26.0
 	github.com/gofiber/fiber/v2 v2.49.2
 	github.com/stretchr/testify v1.8.4
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (

--- a/swagger/go.mod
+++ b/swagger/go.mod
@@ -3,23 +3,20 @@ module github.com/gofiber/contrib/swagger
 go 1.18
 
 require (
-	github.com/go-openapi/loads v0.21.2
 	github.com/go-openapi/runtime v0.26.0
 	github.com/gofiber/fiber/v2 v2.49.2
-	github.com/gorilla/handlers v1.5.1
 	github.com/stretchr/testify v1.8.4
-	github.com/valyala/fasthttp v1.50.0
 )
 
 require (
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/go-openapi/analysis v0.21.4 // indirect
 	github.com/go-openapi/errors v0.20.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
+	github.com/go-openapi/loads v0.21.2 // indirect
 	github.com/go-openapi/spec v0.20.8 // indirect
 	github.com/go-openapi/strfmt v0.21.7 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
@@ -36,6 +33,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasthttp v1.50.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect
 	go.mongodb.org/mongo-driver v1.11.3 // indirect
 	golang.org/x/sys v0.12.0 // indirect

--- a/swagger/go.sum
+++ b/swagger/go.sum
@@ -10,8 +10,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
-github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-openapi/analysis v0.21.2/go.mod h1:HZwRk4RRisyG8vx2Oe6aqeSQcoxRp47Xkp3+K6q+LdY=
 github.com/go-openapi/analysis v0.21.4 h1:ZDFLvSNxpDaomuCueM0BlSXxpANBlFYiBvr+GXrvIHc=
 github.com/go-openapi/analysis v0.21.4/go.mod h1:4zQ35W4neeZTqh3ol0rv/O8JBbka9QyAgQRPp9y3pfo=
@@ -80,8 +78,6 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
-github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -108,7 +108,6 @@ func New(config ...Config) fiber.Handler {
 			w.Header().Set("Content-Type", "application/json")
 			w.Write(rawSpec)
 		} else {
-			fmt.Printf("Somehow here? %s\n", r.URL.Path)
 			http.NotFound(w, r)
 		}
 	})
@@ -131,22 +130,9 @@ func New(config ...Config) fiber.Handler {
 			return c.Next()
 		}
 
-		// Only respond to requests to this middleware
+		// Only respond to requests to SwaggerUI and SpecURL (swagger.json)
 		if !(c.Path() == swaggerUIPath || c.Path() == specURL) {
-			fmt.Println("-----")
-			fmt.Printf("c.Path() is %s\n", c.Path())
-			fmt.Printf("BasePath is %s\n", cfg.BasePath)
-			fmt.Printf("swaggerUIPath is %s\n", swaggerUIPath)
-			fmt.Printf("specURL is %s\n", specURL)
-
 			return c.Next()
-		} else {
-			fmt.Println("+++++")
-			fmt.Printf("c.Path() is %s\n", c.Path())
-			fmt.Printf("BasePath is %s\n", cfg.BasePath)
-			fmt.Printf("swaggerUIPath is %s\n", swaggerUIPath)
-			fmt.Printf("specURL is %s\n", specURL)
-
 		}
 
 		// Pass Fiber context to handler

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -1,27 +1,54 @@
 package swagger
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/go-openapi/loads"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gorilla/handlers"
-	"github.com/valyala/fasthttp/fasthttpadaptor"
-	"os"
-	"path"
+	"github.com/gofiber/fiber/v2/middleware/adaptor"
 )
 
+// Config defines the config for middleware.
 type Config struct {
+	// Next defines a function to skip this middleware when returned true.
+	//
+	// Optional. Default: nil
+	Next func(c *fiber.Ctx) bool
+
+	// BasePath for the UI path
+	//
+	// Optional. Default: /
 	BasePath string
+
+	// FilePath for the swagger.json or swagger.yaml file
+	//
+	// Optional. Default: ./swagger.json
 	FilePath string
+
+	// Path combines with BasePath for the full UI path
+	//
+	// Optional. Default: docs
+	Path string
+
+	// Title for the documentation site
+	//
+	// Optional. Default: Fiber API documentation
+	Title string
 }
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
+	Next:     nil,
 	BasePath: "/",
 	FilePath: "./swagger.json",
+	Path:     "docs",
+	Title:    "Fiber API documentation",
 }
 
 // New creates a new middleware handler
@@ -40,36 +67,90 @@ func New(config ...Config) fiber.Handler {
 		if len(cfg.FilePath) == 0 {
 			cfg.FilePath = ConfigDefault.FilePath
 		}
+		if len(cfg.Path) == 0 {
+			cfg.Path = ConfigDefault.Path
+		}
+		if len(cfg.Title) == 0 {
+			cfg.Title = ConfigDefault.Title
+		}
 	}
 
+	// Verify Swagger file exists
 	if _, err := os.Stat(cfg.FilePath); os.IsNotExist(err) {
-		panic(errors.New(fmt.Sprintf("%s file is not exist", cfg.FilePath)))
+		panic(errors.New(fmt.Sprintf("%s file does not exist", cfg.FilePath)))
 	}
 
-	specDoc, err := loads.Spec(cfg.FilePath)
+	// Read Swagger Spec into memory
+	rawSpec, err := os.ReadFile(cfg.FilePath)
 	if err != nil {
+		log.Fatalf("Failed to read Swagger YAML file: %v", err)
 		panic(err)
 	}
 
-	b, err := json.MarshalIndent(specDoc.Spec(), "", "  ")
+	// Generate URL path's for the middleware
+	specURL, err := url.JoinPath(cfg.BasePath, cfg.FilePath)
 	if err != nil {
+		log.Fatalf("Failed to join URL path between %s and %s", cfg.BasePath, cfg.FilePath)
+		panic(err)
+	}
+	swaggerUIPath, err := url.JoinPath(cfg.BasePath, cfg.Path)
+	if err != nil {
+		log.Fatalf("UnaFailedble to join URL between %s and %s", cfg.BasePath, cfg.Path)
 		panic(err)
 	}
 
-	specUrl := path.Join(cfg.BasePath, "swagger.json")
+	// Serve the Swagger spec from memory
+	swaggerSpecHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, specURL) || strings.HasSuffix(r.URL.Path, specURL) {
+			w.Header().Set("Content-Type", "application/yaml")
+			w.Write(rawSpec)
+		} else if strings.HasSuffix(r.URL.Path, specURL) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(rawSpec)
+		} else {
+			fmt.Printf("Somehow here? %s\n", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	})
+
+	// Define UI Options
 	swaggerUIOpts := middleware.SwaggerUIOpts{
 		BasePath: cfg.BasePath,
-		SpecURL:  specUrl,
-		Path:     "docs",
+		SpecURL:  specURL,
+		Path:     cfg.Path,
+		Title:    cfg.Title,
 	}
 
-	swaggerUiHandler := middleware.SwaggerUI(swaggerUIOpts, nil)
-	specFileHandler, err := handlers.CORS()(middleware.Spec(cfg.BasePath, b, swaggerUiHandler)), nil
+	// Create UI middleware
+	middlewareHandler := adaptor.HTTPHandler(middleware.SwaggerUI(swaggerUIOpts, swaggerSpecHandler))
 
 	// Return new handler
 	return func(c *fiber.Ctx) error {
-		handler := fasthttpadaptor.NewFastHTTPHandler(specFileHandler)
-		handler(c.Context())
+		// Don't execute middleware if Next returns true
+		if cfg.Next != nil && cfg.Next(c) {
+			return c.Next()
+		}
+
+		// Only respond to requests to this middleware
+		if !(c.Path() == swaggerUIPath || c.Path() == specURL) {
+			fmt.Println("-----")
+			fmt.Printf("c.Path() is %s\n", c.Path())
+			fmt.Printf("BasePath is %s\n", cfg.BasePath)
+			fmt.Printf("swaggerUIPath is %s\n", swaggerUIPath)
+			fmt.Printf("specURL is %s\n", specURL)
+
+			return c.Next()
+		} else {
+			fmt.Println("+++++")
+			fmt.Printf("c.Path() is %s\n", c.Path())
+			fmt.Printf("BasePath is %s\n", cfg.BasePath)
+			fmt.Printf("swaggerUIPath is %s\n", swaggerUIPath)
+			fmt.Printf("specURL is %s\n", specURL)
+
+		}
+
+		// Pass Fiber context to handler
+		middlewareHandler(c)
 		return nil
 	}
 }

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -88,16 +88,8 @@ func New(config ...Config) fiber.Handler {
 	}
 
 	// Generate URL path's for the middleware
-	specURL, err := url.JoinPath(cfg.BasePath, cfg.FilePath)
-	if err != nil {
-		log.Fatalf("Failed to join URL path between %s and %s", cfg.BasePath, cfg.FilePath)
-		panic(err)
-	}
-	swaggerUIPath, err := url.JoinPath(cfg.BasePath, cfg.Path)
-	if err != nil {
-		log.Fatalf("UnaFailedble to join URL between %s and %s", cfg.BasePath, cfg.Path)
-		panic(err)
-	}
+	specURL := path.Join(cfg.BasePath, cfg.FilePath)
+	swaggerUIPath := path.Join(cfg.BasePath, cfg.Path)
 
 	// Serve the Swagger spec from memory
 	swaggerSpecHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1,0 +1,12 @@
+consumes:
+  - application/json
+produces:
+  - application/json
+schemes:
+  - http
+swagger: "2.0"
+info:
+  description: "Documentation for TestApi"
+  title: "TestApi"
+  version: "1.0.0"
+basePath: "/"

--- a/swagger/swagger_test.go
+++ b/swagger/swagger_test.go
@@ -1,22 +1,58 @@
 package swagger
 
 import (
-	"github.com/gofiber/fiber/v2"
-	"github.com/stretchr/testify/assert"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/require"
 )
 
 func performRequest(method, target string, app *fiber.App) *http.Response {
 	r := httptest.NewRequest(method, target, nil)
-
 	resp, _ := app.Test(r, -1)
-
 	return resp
 }
 
 func TestNew(t *testing.T) {
+	t.Run("Endpoint check with only custom path", func(t *testing.T) {
+		app := fiber.New()
+
+		cfg := Config{
+			Path: "custompath",
+		}
+		app.Use(New(cfg))
+
+		w1 := performRequest("GET", "/custompath", app)
+		require.Equal(t, 200, w1.StatusCode)
+
+		w2 := performRequest("GET", "/swagger.json", app)
+		require.Equal(t, 200, w2.StatusCode)
+
+		w3 := performRequest("GET", "/notfound", app)
+		require.Equal(t, 404, w3.StatusCode)
+	})
+
+	t.Run("Endpoint check with only custom basepath", func(t *testing.T) {
+		app := fiber.New()
+
+		cfg := Config{
+			BasePath: "/api/v1",
+		}
+		app.Use(New(cfg))
+
+		w1 := performRequest("GET", "/api/v1/docs", app)
+		require.Equal(t, 200, w1.StatusCode)
+
+		w2 := performRequest("GET", "/api/v1/swagger.json", app)
+		require.Equal(t, 200, w2.StatusCode)
+
+		w3 := performRequest("GET", "/notfound", app)
+		require.Equal(t, 404, w3.StatusCode)
+	})
+
 	t.Run("Endpoint check with custom config", func(t *testing.T) {
 		app := fiber.New()
 
@@ -27,13 +63,72 @@ func TestNew(t *testing.T) {
 		app.Use(New(cfg))
 
 		w1 := performRequest("GET", "/docs", app)
-		assert.Equal(t, 200, w1.StatusCode)
+		require.Equal(t, 200, w1.StatusCode)
 
 		w2 := performRequest("GET", "/swagger.json", app)
-		assert.Equal(t, 200, w2.StatusCode)
+		require.Equal(t, 200, w2.StatusCode)
 
 		w3 := performRequest("GET", "/notfound", app)
-		assert.Equal(t, 404, w3.StatusCode)
+		require.Equal(t, 404, w3.StatusCode)
+	})
+
+	t.Run("Endpoint check with custom path", func(t *testing.T) {
+		app := fiber.New()
+
+		cfg := Config{
+			BasePath: "/",
+			FilePath: "swagger.json",
+			Path:     "swagger",
+		}
+		app.Use(New(cfg))
+
+		w1 := performRequest("GET", "/swagger", app)
+		require.Equal(t, 200, w1.StatusCode)
+
+		w2 := performRequest("GET", "/swagger.json", app)
+		require.Equal(t, 200, w2.StatusCode)
+
+		w3 := performRequest("GET", "/notfound", app)
+		require.Equal(t, 404, w3.StatusCode)
+	})
+
+	t.Run("Endpoint check with custom config and yaml spec", func(t *testing.T) {
+		app := fiber.New()
+
+		cfg := Config{
+			BasePath: "/",
+			FilePath: "./swagger.yaml",
+		}
+		app.Use(New(cfg))
+
+		w1 := performRequest("GET", "/docs", app)
+		require.Equal(t, 200, w1.StatusCode)
+
+		w2 := performRequest("GET", "/swagger.yaml", app)
+		require.Equal(t, 200, w2.StatusCode)
+
+		w3 := performRequest("GET", "/notfound", app)
+		require.Equal(t, 404, w3.StatusCode)
+	})
+
+	t.Run("Endpoint check with custom path and yaml spec", func(t *testing.T) {
+		app := fiber.New()
+
+		cfg := Config{
+			BasePath: "/",
+			FilePath: "swagger.yaml",
+			Path:     "swagger",
+		}
+		app.Use(New(cfg))
+
+		w1 := performRequest("GET", "/swagger", app)
+		require.Equal(t, 200, w1.StatusCode)
+
+		w2 := performRequest("GET", "/swagger.yaml", app)
+		require.Equal(t, 200, w2.StatusCode)
+
+		w3 := performRequest("GET", "/notfound", app)
+		require.Equal(t, 404, w3.StatusCode)
 	})
 
 	t.Run("Endpoint check with empty custom config", func(t *testing.T) {
@@ -44,13 +139,13 @@ func TestNew(t *testing.T) {
 		app.Use(New(cfg))
 
 		w1 := performRequest("GET", "/docs", app)
-		assert.Equal(t, 200, w1.StatusCode)
+		require.Equal(t, 200, w1.StatusCode)
 
 		w2 := performRequest("GET", "/swagger.json", app)
-		assert.Equal(t, 200, w2.StatusCode)
+		require.Equal(t, 200, w2.StatusCode)
 
 		w3 := performRequest("GET", "/notfound", app)
-		assert.Equal(t, 404, w3.StatusCode)
+		require.Equal(t, 404, w3.StatusCode)
 	})
 
 	t.Run("Endpoint check with default config", func(t *testing.T) {
@@ -59,13 +154,13 @@ func TestNew(t *testing.T) {
 		app.Use(New())
 
 		w1 := performRequest("GET", "/docs", app)
-		assert.Equal(t, 200, w1.StatusCode)
+		require.Equal(t, 200, w1.StatusCode)
 
 		w2 := performRequest("GET", "/swagger.json", app)
-		assert.Equal(t, 200, w2.StatusCode)
+		require.Equal(t, 200, w2.StatusCode)
 
 		w3 := performRequest("GET", "/notfound", app)
-		assert.Equal(t, 404, w3.StatusCode)
+		require.Equal(t, 404, w3.StatusCode)
 	})
 
 	t.Run("Swagger.json file is not exist", func(t *testing.T) {
@@ -75,7 +170,7 @@ func TestNew(t *testing.T) {
 			FilePath: "./docs/swagger.json",
 		}
 
-		assert.Panics(t, func() {
+		require.Panics(t, func() {
 			app.Use(New(cfg))
 		}, "/swagger.json file is not exist")
 	})
@@ -87,8 +182,80 @@ func TestNew(t *testing.T) {
 			FilePath: "./docs/swagger_missing.json",
 		}
 
-		assert.Panics(t, func() {
+		require.Panics(t, func() {
 			app.Use(New(cfg))
 		}, "invalid character ':' after object key:value pair")
+	})
+
+	t.Run("Endpoint check with multiple Swagger instances", func(t *testing.T) {
+		app := fiber.New()
+
+		app.Use(New(Config{
+			BasePath: "/api/v1",
+		}))
+
+		app.Use(New(Config{
+			BasePath: "/api/v2",
+		}))
+
+		w1 := performRequest("GET", "/api/v1/docs", app)
+		require.Equal(t, 200, w1.StatusCode)
+
+		w2 := performRequest("GET", "/api/v1/swagger.json", app)
+		require.Equal(t, 200, w2.StatusCode)
+
+		w3 := performRequest("GET", "/api/v2/docs", app)
+		require.Equal(t, 200, w3.StatusCode)
+
+		w4 := performRequest("GET", "/api/v2/swagger.json", app)
+		require.Equal(t, 200, w4.StatusCode)
+
+		w5 := performRequest("GET", "/notfound", app)
+		require.Equal(t, 404, w5.StatusCode)
+	})
+
+	t.Run("Endpoint check with custom routes", func(t *testing.T) {
+		app := fiber.New()
+
+		app.Use(New(Config{
+			BasePath: "/api/v1",
+		}))
+
+		app.Get("/api/v1/tasks", func(c *fiber.Ctx) error {
+			return c.SendString("success")
+		})
+
+		app.Get("/api/v1", func(c *fiber.Ctx) error {
+			return c.SendString("success")
+		})
+
+		w1 := performRequest("GET", "/api/v1/docs", app)
+		require.Equal(t, 200, w1.StatusCode)
+
+		w2 := performRequest("GET", "/api/v1/swagger.json", app)
+		require.Equal(t, 200, w2.StatusCode)
+
+		w3 := performRequest("GET", "/notfound", app)
+		require.Equal(t, 404, w3.StatusCode)
+
+		// Verify we can send request to handler with the same BasePath as the middleware
+		w4 := performRequest("GET", "/api/v1/tasks", app)
+		bodyBytes, err := io.ReadAll(w4.Body)
+		require.NoError(t, err)
+		require.Equal(t, 200, w4.StatusCode)
+		require.Equal(t, "success", string(bodyBytes))
+
+		// Verify handler in BasePath still works
+		w5 := performRequest("GET", "/api/v1", app)
+		bodyBytes, err = io.ReadAll(w5.Body)
+		require.NoError(t, err)
+		require.Equal(t, 200, w5.StatusCode)
+		require.Equal(t, "success", string(bodyBytes))
+
+		w6 := performRequest("GET", "/api/v1/", app)
+		bodyBytes, err = io.ReadAll(w6.Body)
+		require.NoError(t, err)
+		require.Equal(t, 200, w6.StatusCode)
+		require.Equal(t, "success", string(bodyBytes))
 	})
 }


### PR DESCRIPTION
- Added support for using `YAML` as Swagger spec. Fixes #708 
- Migrated from `fasthttpadapter` to `fiber/v2/adaptor`
- Added support for `Next()`, and other missing checks
- Update documentation
- Added support for `Path` and `Title`
- Fixed bug where the middleware was reading the Spec and assuming `JSON` then passing this as `Bytes` to the `go-openapi` middleware.
  - Instead now we have a `http.HandlerFunc` able to serve the SPEC based on extension type back to the middleware
- Added support for running multiple SwaggerUI's, for example:

```go
// Create Swagger middleware for v1
//
// Swagger will be available at: /api/v1/docs
app.Use(swagger.New(swagger.Config{
    BasePath: "/api/v1/",
    FilePath: "./docs/v1/swagger.json",
    Path:     "docs",
}))

// Create Swagger middleware for v2
//
// Swagger will be available at: /api/v2/docs
app.Use(swagger.New(swagger.Config{
    BasePath: "/api/v2/",
    FilePath: "./docs/v2/swagger.json",
    Path:     "docs",
}))
```
- Added extensive unit-tests to verify normal handlers still work.
- ~Replaced `join.Path` with `url.JoinPath`~
- Use `testify.Require()` instead of `testify.Assert()`
- Added documentation to `swagger.Config{}`
- Added example `swagger.yaml`

Note: I don't consider this PR a breaking change, since the original functionality stayed the same, it's mostly bug fixes and new features.