### PR TITLE
fiberzap: Fix wrong warning message

### DIFF
--- a/fiberzap/logger.go
+++ b/fiberzap/logger.go
@@ -129,7 +129,7 @@ func NewLogger(config ...LoggerConfig) *LoggerConfig {
 // SetOutput sets the output destination for the logger.
 func (l *LoggerConfig) SetOutput(w io.Writer) {
 	if l.SetLogger != nil {
-		fiberlog.Warn("SetLevel is ignored when SetLogger is set")
+		fiberlog.Warn("SetOutput is ignored when SetLogger is set")
 		return
 	}
 	l.CoreConfigs[0].WriteSyncer = zapcore.AddSync(w)


### PR DESCRIPTION
# Details

In `fiberzap`, `SetOutput` warning log incorrectly refer to `SetLevel` instead of `SetOutput`