### PR TITLE
docs: fix casbin adapter documentation url

### DIFF
--- a/casbin/README.md
+++ b/casbin/README.md
@@ -19,7 +19,7 @@ Casbin middleware for Fiber.
 go get -u github.com/gofiber/fiber/v2
 go get -u github.com/gofiber/contrib/casbin
 ```
-choose an adapter from [here](https://casbin.org/docs/en/adapters)
+choose an adapter from [here](https://casbin.org/docs/adapters)
 ```
 go get -u github.com/casbin/xorm-adapter
 ```


### PR DESCRIPTION
fixes Casbin.org urls