### PR TITLE
SocketIO: Add optional websocket.Config param

### DIFF
--- a/socketio/README.md
+++ b/socketio/README.md
@@ -24,7 +24,8 @@ go get -u github.com/gofiber/contrib/socketio
 ```go
 // Initialize new socketio in the callback this will
 // execute a callback that expects kws *Websocket Object
-func New(callback func(kws *Websocket)) func(*fiber.Ctx) error
+// and optional config websocket.Config
+func New(callback func(kws *Websocket), config ...websocket.Config) func(*fiber.Ctx) error
 ```
 
 ```go

--- a/socketio/socketio.go
+++ b/socketio/socketio.go
@@ -234,7 +234,7 @@ var listeners = safeListeners{
 	list: make(map[string][]eventCallback),
 }
 
-func New(callback func(kws *Websocket)) func(*fiber.Ctx) error {
+func New(callback func(kws *Websocket), config ...websocket.Config) func(*fiber.Ctx) error {
 	return websocket.New(func(c *websocket.Conn) {
 		kws := &Websocket{
 			Conn: c,
@@ -269,7 +269,7 @@ func New(callback func(kws *Websocket)) func(*fiber.Ctx) error {
 
 		// Run the loop for the given connection
 		kws.run()
-	})
+	}, config...)
 }
 
 func (kws *Websocket) GetUUID() string {


### PR DESCRIPTION
In `socketio` package we were not able to set config for recovery explained [here](https://github.com/gofiber/contrib/tree/main/websocket#note-with-recover-middleware). In this PR I have added option to set config.