### PR TITLE
Otel : Don't read response body size if the content-type is text/event-stream

### DIFF
--- a/otelfiber/fiber.go
+++ b/otelfiber/fiber.go
@@ -132,10 +132,13 @@ func Middleware(opts ...Option) fiber.Handler {
 			semconv.HTTPAttributesFromHTTPStatusCode(c.Response().StatusCode()),
 			semconv.HTTPRouteKey.String(c.Route().Path), // no need to copy c.Route().Path: route strings should be immutable across app lifecycle
 		)
-
+		
+		var responseSize int64
 		requestSize := int64(len(c.Request().Body()))
-		responseSize := int64(len(c.Response().Body()))
-
+		if c.GetRespHeader("Content-Type") != "text/event-stream" {
+			responseSize = int64(len(c.Response().Body()))
+		}
+		
 		defer func() {
 			responseMetricAttrs = append(
 				responseMetricAttrs,


### PR DESCRIPTION
The default behavior of the Otel middleware is to read the response size before proceeding with the request response.
This breaks Server Sent Events using Fiber's `SetBodyStreamWriter` as the body is never properly flushed to the client.

This change is small and explicit for SSE, but there could be a more advanced mechanism to control this behavior per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved response size calculation in middleware to handle "text/event-stream" content types correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->