### PR TITLE
[feature] fibernewrelic add skip middleware next function.

### DIFF
--- a/fibernewrelic/README.md
+++ b/fibernewrelic/README.md
@@ -29,14 +29,16 @@ fibernewrelic.New(config fibernewrelic.Config) fiber.Handler
 
 ## Config
 
-| Property          | Type             | Description                            | Default        |
-|:------------------|:-----------------|:---------------------------------------|:---------------|
-| License           | `string`         | Required - New Relic License Key       | `""`           |
-| AppName           | `string`         | New Relic Application Name             | `fiber-api`    |
-| Enabled           | `bool`           | Enable/Disable New Relic               | `false`        |
-| ~~TransportType~~ | ~~`string`~~     | ~~Can be HTTP or HTTPS~~ (Deprecated)  | ~~`"HTTP"`~~   |
-| Application       | `Application`    | Existing New Relic App                 | `nil`          |
-| ErrorStatusCodeHandler       | `func(c *fiber.Ctx, err error) int`    | If you want to change newrelic status code, you can use it.                 | `DefaultErrorStatusCodeHandler`          |
+| Property               | Type             | Description                                                 | Default                         |
+|:-----------------------|:-----------------|:------------------------------------------------------------|:--------------------------------|
+| License                | `string`         | Required - New Relic License Key                            | `""`                            |
+| AppName                | `string`         | New Relic Application Name                                  | `fiber-api`                     |
+| Enabled                | `bool`           | Enable/Disable New Relic                                    | `false`                         |
+| ~~TransportType~~      | ~~`string`~~     | ~~Can be HTTP or HTTPS~~ (Deprecated)                       | ~~`"HTTP"`~~                    |
+| Application            | `Application`    | Existing New Relic App                                      | `nil`                           |
+| ErrorStatusCodeHandler | `func(c *fiber.Ctx, err error) int`    | If you want to change newrelic status code, you can use it. | `DefaultErrorStatusCodeHandler` |
+| Next                   | `func(c *fiber.Ctx) bool`    | Next defines a function to skip this middleware when returned true.                                                           | `nil`                           |
+
 
 ## Usage
 

--- a/fibernewrelic/fiber.go
+++ b/fibernewrelic/fiber.go
@@ -25,6 +25,9 @@ type Config struct {
 	// ErrorStatusCodeHandler is executed when an error is returned from handler
 	// Optional. Default: DefaultErrorStatusCodeHandler
 	ErrorStatusCodeHandler func(c *fiber.Ctx, err error) int
+	// Next defines a function to skip this middleware when returned true.
+	// Optional. Default: nil
+	Next func(c *fiber.Ctx) bool
 }
 
 var ConfigDefault = Config{
@@ -33,6 +36,7 @@ var ConfigDefault = Config{
 	AppName:                "fiber-api",
 	Enabled:                false,
 	ErrorStatusCodeHandler: DefaultErrorStatusCodeHandler,
+	Next:                   nil,
 }
 
 func New(cfg Config) fiber.Handler {
@@ -66,6 +70,10 @@ func New(cfg Config) fiber.Handler {
 	}
 
 	return func(c *fiber.Ctx) error {
+		if cfg.Next != nil && cfg.Next(c) {
+			return c.Next()
+		}
+
 		txn := app.StartTransaction(createTransactionName(c))
 		defer txn.End()
 


### PR DESCRIPTION
Add Next Function on config
Next defines a function to skip newrelic middleware when returned true.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced a `Next` function in the configuration to allow skipping middleware based on a custom condition.

- **Bug Fixes**
    - Updated `ErrorStatusCodeHandler` in the configuration to provide more flexibility in handling status codes.

- **Tests**
    - Added new test cases to verify the behavior of the `Next` function in the middleware configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->