### PR TITLE
otelfiber: add WithCustomMetricAttrbutes option

### DIFF
--- a/otelfiber/README.md
+++ b/otelfiber/README.md
@@ -34,17 +34,18 @@ otelfiber.Middleware(opts ...otelfiber.Option) fiber.Handler
 You can configure the middleware using functional parameters
 
 
-| Function          | Argument Type                            | Description                                                                      | Default                                                             |
-| :------------------ | :-------------------------------- | :--------------------------------------------------------------------------------- | :-------------------------------------------------------------------- |
-| `WithNext`              | `func(*fiber.Ctx) bool`         | Define a function to skip this middleware when returned true .| nil                                                                 |
-| `WithTracerProvider`    | `oteltrace.TracerProvider`      | Specifies a tracer provider to use for creating a tracer.                         | nil - the global tracer provider is used                                   |
-| `WithMeterProvider`     | `otelmetric.MeterProvider`      | Specifies a meter provider to use for reporting.                                     | nil - the global meter provider is used                                                             |
-| `WithPort`              | `int`                          | Specifies the value to use when setting the `net.host.port` attribute on metrics/spans.                            | Defaults to (`80` for `http`, `443` for `https`)              |
-| `WithPropagators`       | `propagation.TextMapPropagator` | Specifies propagators to use for extracting information from the HTTP requests.                     | If none are specified, global ones will be used                                                               |
-| `WithServerName`        | `string`                       | Specifies the value to use when setting the `http.server_name` attribute on metrics/spans.                                          | -                                                                   |
-| `WithSpanNameFormatter` | `func(*fiber.Ctx) string`       | Takes a function that will be called on every request and the returned string will become the span Name.                                   | Default formatter returns the route pathRaw |
-| `WithCustomAttributes`  | `func(*fiber.Ctx) []attribute.KeyValue` | Define a function to add custom attributes to the span.                  | nil                                                                 |
-| `WithCollectClientIP`   | `bool` | Specifies whether to collect the client's IP address from the request. | true |
+| Function                | Argument Type                            | Description                                                                      | Default                                                             |
+| :------------------------ | :-------------------------------- | :--------------------------------------------------------------------------------- | :-------------------------------------------------------------------- |
+| `WithNext`                    | `func(*fiber.Ctx) bool`         | Define a function to skip this middleware when returned true .| nil                                                                 |
+| `WithTracerProvider`          | `oteltrace.TracerProvider`      | Specifies a tracer provider to use for creating a tracer.                         | nil - the global tracer provider is used                                   |
+| `WithMeterProvider`           | `otelmetric.MeterProvider`      | Specifies a meter provider to use for reporting.                                     | nil - the global meter provider is used                                                             |
+| `WithPort`                    | `int`                          | Specifies the value to use when setting the `net.host.port` attribute on metrics/spans.                            | Defaults to (`80` for `http`, `443` for `https`)              |
+| `WithPropagators`             | `propagation.TextMapPropagator` | Specifies propagators to use for extracting information from the HTTP requests.                     | If none are specified, global ones will be used                                                               |
+| `WithServerName`              | `string`                       | Specifies the value to use when setting the `http.server_name` attribute on metrics/spans.                                          | -                                                                   |
+| `WithSpanNameFormatter`       | `func(*fiber.Ctx) string`       | Takes a function that will be called on every request and the returned string will become the span Name.                                   | Default formatter returns the route pathRaw |
+| `WithCustomAttributes`        | `func(*fiber.Ctx) []attribute.KeyValue` | Define a function to add custom attributes to the span.                  | nil                                                                 |
+| `WithCustomMetricAttributes`  | `func(*fiber.Ctx) []attribute.KeyValue` | Define a function to add custom attributes to the metrics.               | nil                                                                 |
+| `WithCollectClientIP`         | `bool` | Specifies whether to collect the client's IP address from the request. | true |
 
 ## Usage
 

--- a/otelfiber/config.go
+++ b/otelfiber/config.go
@@ -10,15 +10,16 @@ import (
 
 // config is used to configure the Fiber middleware.
 type config struct {
-	Next              func(*fiber.Ctx) bool
-	TracerProvider    oteltrace.TracerProvider
-	MeterProvider     otelmetric.MeterProvider
-	Port              *int
-	Propagators       propagation.TextMapPropagator
-	ServerName        *string
-	SpanNameFormatter func(*fiber.Ctx) string
-	CustomAttributes  func(*fiber.Ctx) []attribute.KeyValue
-	collectClientIP   bool
+	Next                   func(*fiber.Ctx) bool
+	TracerProvider         oteltrace.TracerProvider
+	MeterProvider          otelmetric.MeterProvider
+	Port                   *int
+	Propagators            propagation.TextMapPropagator
+	ServerName             *string
+	SpanNameFormatter      func(*fiber.Ctx) string
+	CustomAttributes       func(*fiber.Ctx) []attribute.KeyValue
+	CustomMetricAttributes func(*fiber.Ctx) []attribute.KeyValue
+	collectClientIP        bool
 }
 
 // Option specifies instrumentation configuration options.
@@ -95,6 +96,14 @@ func WithPort(port int) Option {
 func WithCustomAttributes(f func(ctx *fiber.Ctx) []attribute.KeyValue) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.CustomAttributes = f
+	})
+}
+
+// WithCustomMetricAttributes specifies a function that will be called on every
+// request and the returned attributes will be added to the metrics.
+func WithCustomMetricAttributes(f func(ctx *fiber.Ctx) []attribute.KeyValue) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.CustomMetricAttributes = f
 	})
 }
 

--- a/otelfiber/fiber.go
+++ b/otelfiber/fiber.go
@@ -132,13 +132,13 @@ func Middleware(opts ...Option) fiber.Handler {
 			semconv.HTTPAttributesFromHTTPStatusCode(c.Response().StatusCode()),
 			semconv.HTTPRouteKey.String(c.Route().Path), // no need to copy c.Route().Path: route strings should be immutable across app lifecycle
 		)
-		
+
 		var responseSize int64
 		requestSize := int64(len(c.Request().Body()))
 		if c.GetRespHeader("Content-Type") != "text/event-stream" {
 			responseSize = int64(len(c.Response().Body()))
 		}
-		
+
 		defer func() {
 			responseMetricAttrs = append(
 				responseMetricAttrs,

--- a/otelfiber/semconv.go
+++ b/otelfiber/semconv.go
@@ -26,6 +26,10 @@ func httpServerMetricAttributesFromRequest(c *fiber.Ctx, cfg config) []attribute
 		attrs = append(attrs, semconv.HTTPServerNameKey.String(*cfg.ServerName))
 	}
 
+	if cfg.CustomMetricAttributes != nil {
+		attrs = append(attrs, cfg.CustomMetricAttributes(c)...)
+	}
+
 	return attrs
 }
 


### PR DESCRIPTION
Add `WithCustomMetricAttributes` which is analogous to `WithCustomAttributes` for span.

Alternatively, we can apply `WithCustmAttributes` to metrics, but it doesn't give enough control over attributes

Fixes #1156

(If the solution is good, I'll update the README then)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced custom metric attributes functionality for enhanced observability in the Fiber middleware.
	- Added configuration options to define custom attributes for metrics in the middleware.

- **Bug Fixes**
	- Improved readability of the middleware code without altering its logic.

- **Tests**
	- Implemented a test function to ensure correct behavior of custom metric attributes within the Fiber framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->