### PR TITLE
Add Note for WebSocket subprotocols

### DIFF
--- a/websocket/README.md
+++ b/websocket/README.md
@@ -146,8 +146,8 @@ app.Get("/ws/:id", websocket.New(func(c *websocket.Conn) {}, cfg))
 
 ## Note for WebSocket subprotocols
 
-The config `Subprotocols` only help you negotiates subprotocol and set a `Sec-Websocket-Protocol` header if has a suitable subprotocol. For more about negotiates process, check the comment for `Subprotocols` in [fasthttp.Upgrader](https://pkg.go.dev/github.com/fasthttp/websocket#Upgrader) .
+The config `Subprotocols` only helps you negotiate subprotocols and sets a `Sec-Websocket-Protocol` header if it has a suitable subprotocol. For more about negotiates process, check the comment for `Subprotocols` in [fasthttp.Upgrader](https://pkg.go.dev/github.com/fasthttp/websocket#Upgrader) .
 
-All connection will be send to handler function no matter the subprotocol negotiation is successful or not. You can get the selected subprotocol from `conn.Subprotocol()`. 
+All connections will be sent to the handler function no matter whether the subprotocol negotiation is successful or not. You can get the selected subprotocol from `conn.Subprotocol()`. 
 
 If there is a connection with `Sec-Websocket-Protocol` header in the request with failed negotitation, the connection will be disconnected by browser after received upgrade response immediately.

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -143,3 +143,11 @@ app.Get("/ws/:id", websocket.New(func(c *websocket.Conn) {}, cfg))
 
 
 ```
+
+## Note for WebSocket subprotocols
+
+The config `Subprotocols` only help you negotiates subprotocol and set a `Sec-Websocket-Protocol` header if has a suitable subprotocol. For more about negotiates process, check the comment for `Subprotocols` in [fasthttp.Upgrader](https://pkg.go.dev/github.com/fasthttp/websocket#Upgrader) .
+
+All connection will be send to handler function no matter the subprotocol negotiation is successful or not. You can get the selected subprotocol from `conn.Subprotocol()`. 
+
+If there is a connection with `Sec-Websocket-Protocol` header in the request with failed negotitation, the connection will be disconnected by browser after received upgrade response immediately.

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -150,4 +150,4 @@ The config `Subprotocols` only helps you negotiate subprotocols and sets a `Sec-
 
 All connections will be sent to the handler function no matter whether the subprotocol negotiation is successful or not. You can get the selected subprotocol from `conn.Subprotocol()`. 
 
-If there is a connection with `Sec-Websocket-Protocol` header in the request with failed negotitation, the connection will be disconnected by browser after received upgrade response immediately.
+If a connection includes the `Sec-Websocket-Protocol` header in the request but the protocol negotiation fails, the browser will immediately disconnect the connection after receiving the upgrade response.


### PR DESCRIPTION
Sorry for my poor English....

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Added detailed information on handling WebSocket subprotocols to the `README.md`, clarifying configuration, negotiation, and connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->