### PR TITLE
SocketIO: Change isAlive to atomic update to solve the high concurrency problem

### DIFF
--- a/socketio/socketio.go
+++ b/socketio/socketio.go
@@ -567,13 +567,12 @@ func (kws *Websocket) disconnected(err error) {
 	kws.mu.Lock()
 	defer kws.mu.Unlock()
 
-	kws.fireEvent(EventDisconnect, nil, err)
-
 	// may be called multiple times from different go routines
 	if kws.IsAlive() {
+		kws.setAlive(false)
 		close(kws.done)
+		kws.fireEvent(EventDisconnect, nil, err)
 	}
-	kws.setAlive(false)
 
 	// Fire error event if the connection is
 	// disconnected by an error

--- a/socketio/socketio.go
+++ b/socketio/socketio.go
@@ -564,13 +564,12 @@ func (kws *Websocket) read(ctx context.Context) {
 
 // When the connection closes, disconnected method
 func (kws *Websocket) disconnected(err error) {
-	kws.mu.Lock()
-	defer kws.mu.Unlock()
-
 	// may be called multiple times from different go routines
 	if kws.IsAlive() {
 		kws.setAlive(false)
-		close(kws.done)
+		if !kws.IsAlive() {
+			close(kws.done)
+		}
 		kws.fireEvent(EventDisconnect, nil, err)
 	}
 

--- a/socketio/socketio.go
+++ b/socketio/socketio.go
@@ -564,6 +564,9 @@ func (kws *Websocket) read(ctx context.Context) {
 
 // When the connection closes, disconnected method
 func (kws *Websocket) disconnected(err error) {
+	kws.mu.Lock()
+	defer kws.mu.Unlock()
+
 	kws.fireEvent(EventDisconnect, nil, err)
 
 	// may be called multiple times from different go routines


### PR DESCRIPTION
SocketIO: Change isAlive to atomic update to solve the high concurrency problem, It is found that in the disconnected method, the channel is closed repeatedly, which may be caused by concurrent execution of multiple coroutines

```
Aug 26 08:21:45 iZbp11svgbsui9avcnt22kZ chi-api[424959]: panic: close of closed channel
Aug 26 08:21:45 iZbp11svgbsui9avcnt22kZ chi-api[424959]: goroutine 65402 [running]:
Aug 26 08:21:45 iZbp11svgbsui9avcnt22kZ chi-api[424959]: github.com/gofiber/contrib/socketio.(*Websocket).disconnected(0xc0001df3b0, {0xedd9a0, 0xc000f1ce88})
Aug 26 08:21:45 iZbp11svgbsui9avcnt22kZ chi-api[424959]:         /home/aoc/go/pkg/mod/github.com/gofiber/contrib/socketio@v1.1.2/socketio.go:571 +0x5b
Aug 26 08:21:45 iZbp11svgbsui9avcnt22kZ chi-api[424959]: github.com/gofiber/contrib/socketio.(*Websocket).read(0xc0001df3b0, {0xee7da0, 0xc001011130})
Aug 26 08:21:45 iZbp11svgbsui9avcnt22kZ chi-api[424959]:         /home/aoc/go/pkg/mod/github.com/gofiber/contrib/socketio@v1.1.2/socketio.go:553 +0x25f
Aug 26 08:21:45 iZbp11svgbsui9avcnt22kZ chi-api[424959]: created by github.com/gofiber/contrib/socketio.(*Websocket).run in goroutine 65399
Aug 26 08:21:45 iZbp11svgbsui9avcnt22kZ chi-api[424959]:         /home/aoc/go/pkg/mod/github.com/gofiber/contrib/socketio@v1.1.2/socketio.go:513 +0xec

```
@ReneWerner87  @antoniodipinto 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the stability of the Websocket connection handling by ensuring thread-safe operations during disconnection, reducing the risk of crashes and inconsistent states.
	- Enhanced the logic for disconnecting by ensuring events are fired only when the connection is confirmed to be inactive, increasing overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->