### PR TITLE
Abstract Fiber Context with Interface for Version Independence

### DIFF
--- a/monitor/config.go
+++ b/monitor/config.go
@@ -2,8 +2,6 @@ package monitor
 
 import (
 	"time"
-
-	"github.com/gofiber/fiber/v3"
 )
 
 // Config defines the config for middleware.
@@ -26,7 +24,7 @@ type Config struct {
 	// Next defines a function to skip this middleware when returned true.
 	//
 	// Optional. Default: nil
-	Next func(c *fiber.Ctx) bool
+	Next func(c Context) bool
 
 	// Custom HTML Code to Head Section(Before End)
 	//

--- a/monitor/context.go
+++ b/monitor/context.go
@@ -1,0 +1,18 @@
+package monitor
+
+import "github.com/gofiber/fiber/v3"
+
+// Context is an interface that abstracts the Fiber context.
+type Context interface {
+	Method(override ...string) string
+	Get(key string, defaultValue ...string) string
+	// TODO: return self is a problem
+	Status(status int) fiber.Ctx
+	JSON(data any, ctype ...string) error
+	Next() error
+	Set(key, val string)
+	SendString(body string) error
+}
+
+// Handler is a function type that takes a Context and returns an error.
+type Handler[T Context] func(T) error

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -53,7 +53,7 @@ var (
 )
 
 // New creates a new middleware handler
-func New(config ...Config) fiber.Handler {
+func New[T Context](config ...Config) Handler[T] {
 	// Set default config
 	cfg := configDefault(config...)
 
@@ -74,9 +74,9 @@ func New(config ...Config) fiber.Handler {
 
 	// Return new handler
 	//nolint:errcheck // Ignore the type-assertion errors
-	return func(c fiber.Ctx) error {
+	return func(c T) error {
 		// Don't execute middleware if Next returns true
-		if cfg.Next != nil && cfg.Next(&c) {
+		if cfg.Next != nil && cfg.Next(c) {
 			return c.Next()
 		}
 

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -19,7 +19,7 @@ func Test_Monitor_405(t *testing.T) {
 
 	app := fiber.New()
 
-	app.Use("/", New())
+	app.Use("/", New[fiber.Ctx]())
 
 	resp, err := app.Test(httptest.NewRequest(fiber.MethodPost, "/", nil))
 	assert.Equal(t, nil, err)
@@ -32,7 +32,7 @@ func Test_Monitor_Html(t *testing.T) {
 	app := fiber.New()
 
 	// defaults
-	app.Get("/", New())
+	app.Get("/", New[fiber.Ctx]())
 	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
 
 	assert.Equal(t, nil, err)
@@ -48,7 +48,7 @@ func Test_Monitor_Html(t *testing.T) {
 
 	// custom config
 	conf := Config{Title: "New " + defaultTitle, Refresh: defaultRefresh + time.Second}
-	app.Get("/custom", New(conf))
+	app.Get("/custom", New[fiber.Ctx](conf))
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/custom", nil))
 
 	assert.Equal(t, nil, err)
@@ -69,7 +69,7 @@ func Test_Monitor_Html_CustomCodes(t *testing.T) {
 	app := fiber.New()
 
 	// defaults
-	app.Get("/", New())
+	app.Get("/", New[fiber.Ctx]())
 	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
 
 	assert.Equal(t, nil, err)
@@ -91,7 +91,7 @@ func Test_Monitor_Html_CustomCodes(t *testing.T) {
 		FontURL:    "/public/my-font.css",
 		CustomHead: `<style>body{background:#fff}</style>`,
 	}
-	app.Get("/custom", New(conf))
+	app.Get("/custom", New[fiber.Ctx](conf))
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/custom", nil))
 
 	assert.Equal(t, nil, err)
@@ -116,7 +116,7 @@ func Test_Monitor_JSON(t *testing.T) {
 
 	app := fiber.New()
 
-	app.Get("/", New())
+	app.Get("/", New[fiber.Ctx]())
 
 	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
 	req.Header.Set(fiber.HeaderAccept, fiber.MIMEApplicationJSON)
@@ -135,7 +135,7 @@ func Test_Monitor_JSON(t *testing.T) {
 func Benchmark_Monitor(b *testing.B) {
 	app := fiber.New()
 
-	app.Get("/", New())
+	app.Get("/", New[fiber.Ctx]())
 
 	h := app.Handler()
 
@@ -165,8 +165,8 @@ func Test_Monitor_Next(t *testing.T) {
 
 	app := fiber.New()
 
-	app.Use("/", New(Config{
-		Next: func(_ *fiber.Ctx) bool {
+	app.Use("/", New[fiber.Ctx](Config{
+		Next: func(_ Context) bool {
 			return true
 		},
 	}))
@@ -180,7 +180,7 @@ func Test_Monitor_Next(t *testing.T) {
 func Test_Monitor_APIOnly(t *testing.T) {
 	app := fiber.New()
 
-	app.Get("/", New(Config{
+	app.Get("/", New[fiber.Ctx](Config{
 		APIOnly: true,
 	}))
 


### PR DESCRIPTION
This PR introduces an abstraction for the Fiber context to make Fiber contrib libraries independent of the Fiber version being used.

Key Changes:

1.	Context Interface:
	- Created a Context interface that defines the required methods from fiber.Ctx for use in the middleware.
	- This allows the middleware to work with any implementation of Context, decoupling it from a specific Fiber version.
2.	Generics Support:
	- Introduced generics in the middleware handler with Handler[T Context] to ensure type safety and support for different context implementations.
3.	Test Adjustments:
	- Updated all middleware tests to use the new generic-based handler and fiber.Ctx implementation.

Known Issue:

Currently, the fiber.Ctx interface presents a limitation for complete version independence. Methods such as Status() return fiber.Ctx itself, which tightly couples the interface to the original Fiber implementation. This behavior makes the abstraction less flexible and middleware dependent on a specific Fiber version.
A fix for this issue is planned by modifying the Context interface to return the abstracted Context instead of fiber.Ctx.

This PR is an important step towards making Fiber contrib libraries more flexible, reusable, and compatible across different Fiber versions. Further refinements will follow to address the self-referential return issue and fully decouple the middleware from the Fiber framework.