### PR TITLE
[Feature]: Add option to disable metrics in otelfiber

### DIFF
--- a/otelfiber/config.go
+++ b/otelfiber/config.go
@@ -19,6 +19,7 @@ type config struct {
 	CustomAttributes       func(*fiber.Ctx) []attribute.KeyValue
 	CustomMetricAttributes func(*fiber.Ctx) []attribute.KeyValue
 	collectClientIP        bool
+	withoutMetrics         bool
 }
 
 // Option specifies instrumentation configuration options.
@@ -103,5 +104,12 @@ func WithCustomMetricAttributes(f func(ctx *fiber.Ctx) []attribute.KeyValue) Opt
 func WithCollectClientIP(collect bool) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.collectClientIP = collect
+	})
+}
+
+// WithoutMetrics disables metrics collection when set to true
+func WithoutMetrics(withoutMetrics bool) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.withoutMetrics = withoutMetrics
 	})
 }


### PR DESCRIPTION
This PR introduces a new WithoutMetrics option in otelfiber.Config that allows users to selectively disable otelfiber's metrics collection, without affecting other active metrics providers for the service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to disable metrics collection in the middleware configuration.

- **Tests**
  - Introduced a new test to verify that metrics are not collected when the disable option is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->