### PR TITLE
feat: Make Swagger CDN assets configurable

### DIFF
--- a/.github/workflows/test-swagger.yml
+++ b/.github/workflows/test-swagger.yml
@@ -21,6 +21,9 @@ jobs:
           - 1.19.x
           - 1.20.x
           - 1.21.x
+          - 1.22.x
+          - 1.23.x
+          - 1.24.x
     steps:
       - name: Fetch Repository
         uses: actions/checkout@v4

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -52,6 +52,19 @@ type Config struct {
 	//
 	// Optional. Default: 3600 (1 hour)
 	CacheAge int
+
+	// The three components needed to embed swagger-ui
+
+	// SwaggerURL points to the js that generates the SwaggerUI site.
+	//
+	// Defaults to: https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js
+	SwaggerURL string
+
+	SwaggerPresetURL string
+	SwaggerStylesURL string
+
+	Favicon32 string
+	Favicon16 string
 }
 
 // ConfigDefault is the default config
@@ -154,11 +167,22 @@ func New(config ...Config) fiber.Handler {
 		SpecURL:          specURL,
 		Path:             cfg.Path,
 		Title:            cfg.Title,
-		SwaggerURL:       "https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.min.js",
-		SwaggerPresetURL: "https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-standalone-preset.min.js",
-		SwaggerStylesURL: "https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css",
-		Favicon32:        "https://cdn.jsdelivr.net/npm/swagger-ui-dist/favicon-32x32.png",
-		Favicon16:        "https://cdn.jsdelivr.net/npm/swagger-ui-dist/favicon-16x16.png",
+	}
+
+	if cfg.SwaggerURL != "" {
+		swaggerUIOpts.SwaggerURL = cfg.SwaggerURL
+	}
+	if cfg.SwaggerPresetURL != "" {
+		swaggerUIOpts.SwaggerPresetURL = cfg.SwaggerPresetURL
+	}
+	if cfg.SwaggerStylesURL != "" {
+		swaggerUIOpts.SwaggerStylesURL = cfg.SwaggerStylesURL
+	}
+	if cfg.Favicon32 != "" {
+		swaggerUIOpts.Favicon32 = cfg.Favicon32
+	}
+	if cfg.Favicon16 != "" {
+		swaggerUIOpts.Favicon16 = cfg.Favicon16
 	}
 
 	// Create UI middleware

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -150,10 +150,15 @@ func New(config ...Config) fiber.Handler {
 
 	// Define UI Options
 	swaggerUIOpts := middleware.SwaggerUIOpts{
-		BasePath: cfg.BasePath,
-		SpecURL:  specURL,
-		Path:     cfg.Path,
-		Title:    cfg.Title,
+		BasePath:         cfg.BasePath,
+		SpecURL:          specURL,
+		Path:             cfg.Path,
+		Title:            cfg.Title,
+		SwaggerURL:       "https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.min.js",
+		SwaggerPresetURL: "https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-standalone-preset.min.js",
+		SwaggerStylesURL: "https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css",
+		Favicon32:        "https://cdn.jsdelivr.net/npm/swagger-ui-dist/favicon-32x32.png",
+		Favicon16:        "https://cdn.jsdelivr.net/npm/swagger-ui-dist/favicon-16x16.png",
 	}
 
 	// Create UI middleware


### PR DESCRIPTION
Swagger UI Bundle from unpkg is broken / incomplete on load. I switched to jsdelivr and it solved the problem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Swagger UI now supports customizable URLs for its JavaScript, CSS, and favicon assets, allowing enhanced flexibility in how API documentation resources are loaded and displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->