### PR TITLE
JWT: Fix usage with custom headers.

### DIFF
--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -184,6 +184,35 @@ func TestJwtFromHeader(t *testing.T) {
 		}
 	})
 
+	t.Run("custom", func(t *testing.T) {
+		for _, test := range hamac {
+			// Arrange
+			app := fiber.New()
+
+			app.Use(jwtware.New(jwtware.Config{
+				SigningKey: jwtware.SigningKey{
+					JWTAlg: test.SigningMethod,
+					Key:    []byte(defaultSigningKey),
+				},
+				TokenLookup: "header:X-Token",
+			}))
+
+			app.Get("/ok", func(c *fiber.Ctx) error {
+				return c.SendString("OK")
+			})
+
+			req := httptest.NewRequest("GET", "/ok", nil)
+			req.Header.Add("x-token", test.Token)
+
+			// Act
+			resp, err := app.Test(req)
+
+			// Assert
+			utils.AssertEqual(t, nil, err)
+			utils.AssertEqual(t, 200, resp.StatusCode)
+		}
+	})
+
 	t.Run("malformed header", func(t *testing.T) {
 		for _, test := range hamac {
 			// Arrange

--- a/jwt/utils.go
+++ b/jwt/utils.go
@@ -17,7 +17,9 @@ type jwtExtractor func(c *fiber.Ctx) (string, error)
 // jwtFromHeader returns a function that extracts token from the request header.
 func jwtFromHeader(header string, authScheme string) func(c *fiber.Ctx) (string, error) {
 	// Enforce the presence of a space between the authentication scheme and the token
-	authScheme = authScheme + " "
+	if authScheme != "" {
+		authScheme = authScheme + " "
+	}
 	return func(c *fiber.Ctx) (string, error) {
 		auth := c.Get(header)
 		l := len(authScheme)


### PR DESCRIPTION
A recent commit broke support for custom headers via `TokenLookup: "header:X-Token"` by enforcing a whitespace "between" scheme and value. Since custom Headers don't have a schema this enforce a space at the beginning of custom header values, which is not possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JWT token extraction from custom HTTP headers, ensuring correct authentication even when no authentication scheme is specified.
- **Tests**
  - Added tests to verify JWT authentication works with tokens provided in custom headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->