### PR TITLE
feat(): add possibility to define custom OnShed handler;

### DIFF
--- a/loadshed/loadshed.go
+++ b/loadshed/loadshed.go
@@ -12,6 +12,10 @@ type Config struct {
 
 	// Criteria defines the criteria to be used for load shedding.
 	Criteria LoadCriteria
+
+	// OnShed defines a custom handler that will be executed if a request should
+	// be shed
+	OnShed func(c *fiber.Ctx) error
 }
 
 var ConfigDefault = Config{
@@ -45,6 +49,11 @@ func New(config ...Config) fiber.Handler {
 
 		// Shed load if the criteria's ShouldShed method returns true
 		if cfg.Criteria.ShouldShed(metric) {
+			// Call the custom OnShed function
+			if cfg.OnShed != nil {
+				return cfg.OnShed(c)
+			}
+
 			return fiber.NewError(fiber.StatusServiceUnavailable)
 		}
 

--- a/loadshed/loadshed.go
+++ b/loadshed/loadshed.go
@@ -14,7 +14,7 @@ type Config struct {
 	Criteria LoadCriteria
 
 	// OnShed defines a custom handler that will be executed if a request should
-	// be shed
+	// be declined
 	OnShed func(c *fiber.Ctx) error
 }
 


### PR DESCRIPTION
Purpose of this PR to add possibility to define a custom `OnShed` handler. 
This will allow to control (add metrics, log messages etc.), and customize response code/message for a declined requests.