### PR TITLE
fix(): loadshed module name;

### DIFF
--- a/loadshed/go.mod
+++ b/loadshed/go.mod
@@ -1,4 +1,4 @@
-module loadshed
+module github.com/gofiber/contrib/loadshed
 
 go 1.20
 


### PR DESCRIPTION
Problem:
```
go get github.com/gofiber/contrib/loadshed

go: github.com/gofiber/contrib/loadshed@upgrade (v0.2.0) requires github.com/gofiber/contrib/loadshed@v0.2.0: parsing go.mod:
        module declares its path as: loadshed
                but was required as: github.com/gofiber/contrib/loadshed
```

`module` directive contains wrong value which prevents it to be installed as a dependency

See other:
https://github.com/gofiber/contrib/blob/main/casbin/go.mod#L1
https://github.com/gofiber/contrib/blob/main/circuitbreaker/go.mod#L1

Solution:
Use correct value.

