### PR TITLE
Add dependabot groupings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,24 @@ updates:
           fasthttp-websocket-modules:
               patterns:
                   - "github.com/fasthttp/websocket/**"
+          valyala-utils-modules:
+              patterns:
+                  - "github.com/valyala/bytebufferpool"
+                  - "github.com/valyala/tcplisten"
+          mattn-modules:
+              patterns:
+                  - "github.com/mattn/go-colorable"
+                  - "github.com/mattn/go-isatty"
+                  - "github.com/mattn/go-runewidth"
+          google-modules:
+              patterns:
+                  - "github.com/google/**"
+                  - "google.golang.org/**"
+          testing-modules:
+              patterns:
+                  - "github.com/stretchr/**"
+                  - "github.com/davecgh/go-spew"
+                  - "github.com/pmezard/go-difflib"
+          yaml-modules:
+              patterns:
+                  - "gopkg.in/yaml.*"


### PR DESCRIPTION
## Summary
- extend dependabot config with additional dependency groups

## Testing
- `go vet ./...` *(fails: directory prefix does not contain module)*

------
https://chatgpt.com/codex/tasks/task_e_686cf3fd66148326a50739892c2828bf