### PR TITLE
Fix typos in websocket middleware docs

### DIFF
--- a/websocket/README.md
+++ b/websocket/README.md
@@ -116,8 +116,8 @@ app.Get("/ws/:id", websocket.New(func(c *websocket.Conn) {}))
 
 ## Note with recover middleware
 
-For internal implementation reasons, currently recover middleware is not work with websocket middleware, please use `config.RecoverHandler` to add recover handler to websocket endpoints.
-By default, config `RecoverHandler` is recovers from panic and writes stack trace to stderr, also returns a response that contains panic message in **error** field.
+For internal implementation reasons, currently recover middleware does not work with websocket middleware, please use `config.RecoverHandler` to add recover handler to websocket endpoints.
+By default, config `RecoverHandler` recovers from panic and writes stack trace to stderr, also returns a response that contains panic message in **error** field.
 
 
 ```go


### PR DESCRIPTION
This PR fixes two minor typos in the websocket middleware documentation. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity and grammar in the middleware compatibility section.
  * Clarifies that the recover middleware does not work with websocket middleware.
  * Maintains existing guidance on using a custom recovery handler.
  * No API, behavior, or configuration changes; text-only update to reduce confusion.
  * Developers should see clearer guidance when integrating middleware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->