### PR TITLE
Allow configuring sync docs paths via environment variables

### DIFF
--- a/.github/scripts/sync_docs.sh
+++ b/.github/scripts/sync_docs.sh
@@ -6,7 +6,16 @@ AUTHOR_EMAIL=${AUTHOR_EMAIL:-github-actions[bot]@users.noreply.github.com}
 AUTHOR_USERNAME=${AUTHOR_USERNAME:-github-actions[bot]}
 VERSION_FILE=${VERSION_FILE:-contrib_versions.json}
 SOURCE_DIR=${SOURCE_DIR:-v3}
-TARGET_DIR=${REPO_DIR:?REPO_DIR environment variable is required}
+TARGET_DIR=${TARGET_DIR:-${REPO_DIR:-}}
+DESTINATION_DIR=${DESTINATION_DIR:-}
+
+if [[ -z "${DESTINATION_DIR}" ]]; then
+    if [[ -z "${TARGET_DIR}" ]]; then
+        echo "DESTINATION_DIR or TARGET_DIR (or REPO_DIR) environment variable is required" >&2
+        exit 1
+    fi
+    DESTINATION_DIR="fiber-docs/docs/${TARGET_DIR}"
+fi
 COMMIT_URL=${COMMIT_URL:-https://github.com/gofiber/contrib}
 DOCUSAURUS_COMMAND=${DOCUSAURUS_COMMAND:-npm run docusaurus -- docs:version:contrib}
 
@@ -22,7 +31,7 @@ git clone "https://${TOKEN}@${REPO_URL}" fiber-docs
 
 if [[ "${EVENT}" == "push" ]]; then
     latest_commit=$(git rev-parse --short HEAD)
-    destination="fiber-docs/docs/${TARGET_DIR}"
+    destination="${DESTINATION_DIR}"
 
     mkdir -p "${destination}"
     rsync -a --delete \

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,7 @@ on:
         branches:
             - master
             - main
+    workflow_dispatch:
 
 jobs:
     changes:
@@ -12,7 +13,7 @@ jobs:
         permissions:
             pull-requests: read
         outputs:
-            packages: ${{ steps.filter.outputs.changes || '[]' }}
+            packages: ${{ github.event_name == 'workflow_dispatch' && steps.filter-setup.outputs.packages || steps.filter.outputs.changes || '[]' }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v5
@@ -23,9 +24,11 @@ jobs:
               run: |
                   shopt -s nullglob
                   packages=(v3/*/)
+                  package_names=()
 
                   if (( ${#packages[@]} == 0 )); then
                       echo "filters={}" >> "$GITHUB_OUTPUT"
+                      echo "packages=[]" >> "$GITHUB_OUTPUT"
                       exit 0
                   fi
 
@@ -35,13 +38,23 @@ jobs:
                           pkg=${pkg#v3/}
                           pkg=${pkg%/}
                           printf "'%s': 'v3/%s/**'\n" "$pkg" "$pkg"
+                          package_names+=("$pkg")
                       done
                       echo "EOF"
                   } >> "$GITHUB_OUTPUT"
 
+                  if (( ${#package_names[@]} > 0 )); then
+                      printf -v joined '"%s",' "${package_names[@]}"
+                      joined=${joined%,}
+                      echo "packages=[${joined}]" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "packages=[]" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Filter changes
               id: filter
               uses: dorny/paths-filter@v3
+              if: github.event_name != 'workflow_dispatch'
               with:
                   filters: ${{ steps.filter-setup.outputs.filters }}
 

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -35,4 +35,4 @@ jobs:
                   EVENT: ${{ github.event_name }}
                   TAG_NAME: ${{ github.ref_name }}
                   TOKEN: ${{ secrets.DOC_SYNC_TOKEN }}
-                  REPO_DIR: contrib/v3
+                  REPO_DIR: contrib


### PR DESCRIPTION
## Summary
- allow the sync_docs script to accept environment variables for the source search root and destination directory
- retain the existing rsync-based copy logic so contrib/v3 README files still land directly under docs/contrib

## Testing
- `bash -n .github/scripts/sync_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_69036110398c8326b0ebd66e9711a600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved documentation synchronization process with enhanced configurability for destination directory management and better error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->