### PR TITLE
Align release drafter packages with directory paths

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,7 +13,7 @@ jobs:
         permissions:
             pull-requests: read
         outputs:
-            packages: ${{ github.event_name == 'workflow_dispatch' && steps.filter-setup.outputs.packages || steps.filter.outputs.changes || '[]' }}
+            packages: ${{ github.event_name == 'workflow_dispatch' && steps.filter-setup.outputs.packages || steps.map-packages.outputs.packages || '[]' }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v5
@@ -35,10 +35,11 @@ jobs:
                   {
                       echo "filters<<EOF"
                       for pkg in "${packages[@]}"; do
-                          pkg=${pkg#v3/}
-                          pkg=${pkg%/}
-                          printf "'%s': 'v3/%s/**'\n" "$pkg" "$pkg"
-                          package_names+=("$pkg")
+                          name=${pkg#v3/}
+                          name=${name%/}
+                          path=${pkg%/}
+                          printf "'%s': '%s/**'\n" "$name" "$path"
+                          package_names+=("$path")
                       done
                       echo "EOF"
                   } >> "$GITHUB_OUTPUT"
@@ -58,6 +59,21 @@ jobs:
               with:
                   filters: ${{ steps.filter-setup.outputs.filters }}
 
+            - name: Map package paths
+              id: map-packages
+              if: github.event_name != 'workflow_dispatch'
+              env:
+                  FILTER_PACKAGES: ${{ steps.filter.outputs.changes || '[]' }}
+              run: |
+                  python3 - <<'PY' >> "$GITHUB_OUTPUT"
+                  import json
+                  import os
+
+                  packages = json.loads(os.environ["FILTER_PACKAGES"])
+                  paths = [f"v3/{name}" for name in packages]
+                  print(f"packages={json.dumps(paths)}")
+                  PY
+
     release-drafter:
         needs: changes
         runs-on: ubuntu-latest
@@ -76,7 +92,7 @@ jobs:
               id: generate-config
               run: |
                   package="${{ matrix.package }}"
-                  directory="v3/${package}"
+                  directory="$package"
                   {
                       echo "config<<EOF"
                       sed -e "s|{{PACKAGE}}|$package|g" -e "s|{{DIRECTORY}}|$directory|g" .github/release-drafter-template.yml

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -36,3 +36,4 @@ jobs:
                   TAG_NAME: ${{ github.ref_name }}
                   TOKEN: ${{ secrets.DOC_SYNC_TOKEN }}
                   REPO_DIR: contrib
+                  SYNC_FLATTEN_SOURCE_DIR: "true"


### PR DESCRIPTION
## Summary
- output package selections as full directory paths so release names and tags include the folder structure
- map filtered package names to their v3/ directories before invoking release-drafter

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_69036a46fb9c8326bffbe758e1c29811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced documentation synchronization workflow with improved directory handling and filtering capabilities.
  * Added configuration option to control documentation organization during synchronization processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->