### PR TITLE
Update OPA integration to rego v1

### DIFF
--- a/v3/opa/README.md
+++ b/v3/opa/README.md
@@ -84,7 +84,7 @@ package example.authz
 
 default allow := false
 
-allow {
+allow if {
     input.method == "GET"
 }
 `

--- a/v3/opa/fiber.go
+++ b/v3/opa/fiber.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/utils/v2"
-	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/v1/rego"
 )
 
 type InputCreationFunc func(c fiber.Ctx) (map[string]interface{}, error)

--- a/v3/opa/fiber_test.go
+++ b/v3/opa/fiber_test.go
@@ -90,8 +90,8 @@ package example.authz
 
 default allow := false
 
-allow {
-	input.method == "GET"
+allow if {
+        input.method == "GET"
 }
 `
 
@@ -124,8 +124,8 @@ package example.authz
 
 default allow := false
 
-allow {
-	input.path == "/path"
+allow if {
+        input.path == "/path"
 }
 `
 
@@ -160,8 +160,8 @@ import future.keywords.in
 
 default allow := false
 
-allow {
-	input.query == {"testKey": ["testVal"]}
+allow if {
+        input.query == {"testKey": ["testVal"]}
 }
 `
 
@@ -197,8 +197,8 @@ import future.keywords.in
 
 default allow := false
 
-allow {
-	input.headers == {"testHeaderKey": "testHeaderVal"}
+allow if {
+        input.headers == {"testHeaderKey": "testHeaderVal"}
 }
 `
 
@@ -234,8 +234,8 @@ package example.authz
 
 default allow := false
 
-allow {
-	input.custom == "test"
+allow if {
+        input.custom == "test"
 }
 `
 
@@ -274,8 +274,8 @@ package example.authz
 
 default allow := false
 
-allow {
-	input.custom == "test"
+allow if {
+        input.custom == "test"
 }
 `
 


### PR DESCRIPTION
## Summary
- replace the deprecated OPA rego import with the v1 package
- update sample Rego policies to use the v1 `allow if` rule syntax

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_6904a1df85e48326bfc3aa9b329e674a