### PR TITLE
Remove config.go link from Swaggo README

### DIFF
--- a/v3/swaggo/README.md
+++ b/v3/swaggo/README.md
@@ -140,5 +140,5 @@ var ConfigDefault = Config{
 }
 ```
 
-> Refer to [`config.go`](./config.go) for a complete list of options and documentation strings.
+> Refer to `config.go` for a complete list of options and documentation strings.
 


### PR DESCRIPTION
## Summary
- remove the markdown link to config.go from the Swaggo README to avoid referencing the file directly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690746402c3c8326b360379ccb697020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reference formatting in documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->