### PR TITLE
Set gomod dependency type to all

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,9 @@ updates:
           interval: "daily"
     - package-ecosystem: "gomod"
       open-pull-requests-limit: 30
-      dependency-type: "all"
+      allow:
+          # Allow both direct and indirect updates for all packages.
+          - dependency-type: "all"
       directories:
           - "**/*"
       labels:


### PR DESCRIPTION
## Summary
- configure Dependabot Go module updates to include all dependency types

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed13f9d248326972dd435179977c1)