### PR TITLE
feat: add custom validation function for HCaptcha middleware

### DIFF
--- a/v3/hcaptcha/README.md
+++ b/v3/hcaptcha/README.md
@@ -76,10 +76,12 @@ func main() {
 		// Optional custom validation handling.
 		ValidateFunc: func(success bool, c fiber.Ctx) error {
 			if !success {
-				c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				if err := c.Status(fiber.StatusForbidden).JSON(fiber.Map{
 					"error":   "HCaptcha validation failed",
 					"details": "Please complete the captcha challenge and try again",
-				})
+				}); err != nil {
+					return err
+				}
 				return errors.New("custom validation failed")
 			}
 			return nil

--- a/v3/hcaptcha/config.go
+++ b/v3/hcaptcha/config.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/gofiber/fiber/v3"
-	"strings"
 )
 
 // DefaultSiteVerifyURL is the default URL for the HCaptcha API

--- a/v3/hcaptcha/hcaptcha.go
+++ b/v3/hcaptcha/hcaptcha.go
@@ -80,7 +80,8 @@ func (h *HCaptcha) Validate(c fiber.Ctx) error {
 	}
 
 	if validationErr != nil {
-		if c.Response().StatusCode() < fiber.StatusBadRequest {
+		statusCode := c.Response().StatusCode()
+		if statusCode == 0 || statusCode == fiber.StatusOK {
 			c.Status(fiber.StatusForbidden)
 		}
 		if len(c.Response().Body()) == 0 {


### PR DESCRIPTION
Replaces #1191

- Adds `ValidateFunc` to `Config` with a documented contract (when called, params, default behavior).
- Keeps default middleware behavior intact (`403` on failed hCaptcha) while supporting custom validation handling.
- Improves `DefaultResponseKeyFunc` by rejecting empty/whitespace tokens.
- Expands tests to cover:
  - default success/failure
  - `ValidateFunc` success/failure
  - custom status preservation
  - token validation
- Updates README config table and example, including middleware order clarification and wording fixes.
