### PR TITLE
feat: add createWebRequest function to encapsulate web request creation for New Relic transactions

### DIFF
--- a/v3/newrelic/README.md
+++ b/v3/newrelic/README.md
@@ -10,7 +10,7 @@ id: newrelic
 
 [New Relic](https://github.com/newrelic/go-agent) support for Fiber.
 
-Incoming request headers are forwarded to New Relic transactions, enabling distributed tracing header processing.
+Incoming request headers are forwarded to New Relic transactions by default. This enables distributed tracing header processing, but can also forward sensitive headers. Use `RequestHeaderFilter` to allowlist or redact headers as needed.
 
 
 **Compatible with Fiber v3.**
@@ -43,6 +43,7 @@ newrelic.New(config newrelic.Config) fiber.Handler
 | Application            | `Application`    | Existing New Relic App                                      | `nil`                           |
 | ErrorStatusCodeHandler | `func(c fiber.Ctx, err error) int`    | If you want to change newrelic status code, you can use it. | `DefaultErrorStatusCodeHandler` |
 | Next                   | `func(c fiber.Ctx) bool`    | Next defines a function to skip this middleware when returned true.                                                           | `nil`                           |
+| RequestHeaderFilter    | `func(key, value string) bool`    | Return `true` to forward a request header to New Relic, `false` to skip it. | `nil` (forward all headers) |
 
 ## Usage
 

--- a/v3/newrelic/fiber_test.go
+++ b/v3/newrelic/fiber_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
@@ -410,7 +411,7 @@ func TestCreateWebRequest(t *testing.T) {
 	t.Run("should include inbound headers for distributed tracing", func(t *testing.T) {
 		app := fiber.New()
 		app.Get("/", func(ctx fiber.Ctx) error {
-			req := createWebRequest(ctx, ctx.Hostname(), ctx.Method(), string(ctx.Request().URI().Scheme()))
+			req := createWebRequest(ctx, ctx.Hostname(), ctx.Method(), string(ctx.Request().URI().Scheme()), nil)
 			assert.Equal(t, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", req.Header.Get("traceparent"))
 			assert.ElementsMatch(t, []string{"abc", "def"}, req.Header.Values("X-Custom"))
 			return ctx.SendStatus(http.StatusNoContent)
@@ -420,6 +421,26 @@ func TestCreateWebRequest(t *testing.T) {
 		r.Header.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
 		r.Header.Add("X-Custom", "abc")
 		r.Header.Add("X-Custom", "def")
+
+		resp, err := app.Test(r, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	})
+
+	t.Run("should apply request header filter when configured", func(t *testing.T) {
+		app := fiber.New()
+		app.Get("/", func(ctx fiber.Ctx) error {
+			req := createWebRequest(ctx, ctx.Hostname(), ctx.Method(), string(ctx.Request().URI().Scheme()), func(key, _ string) bool {
+				return strings.EqualFold(key, "traceparent")
+			})
+			assert.Equal(t, "trace-value", req.Header.Get("traceparent"))
+			assert.Empty(t, req.Header.Values("Authorization"))
+			return ctx.SendStatus(http.StatusNoContent)
+		})
+
+		r := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+		r.Header.Set("traceparent", "trace-value")
+		r.Header.Set("Authorization", "Bearer secret")
 
 		resp, err := app.Test(r, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})
 		assert.NoError(t, err)


### PR DESCRIPTION
Replaces #897

## Summary

This PR replaces the changes proposed in #897 and includes the requested review follow-ups.

### What changed
- Forward incoming request headers to New Relic via `newrelic.WebRequest.Header`.
- Keep existing transaction metadata (`Host`, `Method`, `Transport`, `URL`) unchanged.
- Refactor web request construction into a dedicated helper (`createWebRequest`) for better testability.

### Tests
- Added unit test coverage to verify inbound headers are propagated correctly (including distributed tracing headers and multi-value headers).

### Docs
- Updated `v3/newrelic/README.md` to document header forwarding for distributed tracing.


