### PR TITLE
feat(docs): update docs removing `SetUserContext` and `UserContext`

### DIFF
--- a/v3/otel/README.md
+++ b/v3/otel/README.md
@@ -105,7 +105,7 @@ func main() {
 
     app.Get("/users/:id", func(c fiber.Ctx) error {
         id := c.Params("id")
-        name := getUser(c.UserContext(), id)
+        name := getUser(c.Context(), id)
         return c.JSON(fiber.Map{"id": id, "name": name})
     })
 

--- a/v3/zap/README.md
+++ b/v3/zap/README.md
@@ -113,12 +113,12 @@ func main() {
     defer logger.Sync()
 
     app.Use(func(c fiber.Ctx) error {
-        ctx := context.WithValue(c.UserContext(), "request_id", "123")
-        c.SetUserContext(ctx)
+        ctx := context.WithValue(c.Context(), "request_id", "123")
+        c.SetContext(ctx)
         return c.Next()
     })
     app.Get("/", func(c fiber.Ctx) error {
-        log.WithContext(c.UserContext()).Info("Hello, World!")
+        log.WithContext(c.Context()).Info("Hello, World!")
         return c.SendString("Hello, World!")
     })
     log.Fatal(app.Listen(":3000"))


### PR DESCRIPTION
## Description
Updates the `gofiber/contrib/v3/otel` and `gofiber/contrib/v3/zap` docs to reflect the context API change introduced in Fiber v3.

Since `fiber.Ctx` now directly satisfies the `context.Context` interface, `SetUserContext`/`UserContext` have been removed in favor of `SetContext`/`Context`.

Key changes:
- Replaced `c.UserContext()` → `c.Context()`
- Replaced `c.SetUserContext(ctx)` → `c.SetContext(ctx)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples in OpenTelemetry and Zap integration guides to reflect the latest context handling practices in the framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->