### PR TITLE
fix: ensure safe copy of IP address in websocket connection

### DIFF
--- a/.github/workflows/test-websocket.yml
+++ b/.github/workflows/test-websocket.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         go-version:
           - 1.25.x
+          - 1.26.x
     steps:
       - name: Fetch Repository
         uses: actions/checkout@v6

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -72,11 +72,11 @@ type Config struct {
 
 func defaultRecover(c *Conn) {
 	if err := recover(); err != nil {
-                _, _ = fmt.Fprintf(os.Stderr, "panic: %v\n%s\n", err, debug.Stack()) //nolint:errcheck // This will never fail
-                if err := c.WriteJSON(fiber.Map{"error": err}); err != nil {
-                        _, _ = fmt.Fprintf(os.Stderr, "could not write error response: %v\n", err)
-                }
-        }
+		_, _ = fmt.Fprintf(os.Stderr, "panic: %v\n%s\n", err, debug.Stack()) //nolint:errcheck // This will never fail
+		if err := c.WriteJSON(fiber.Map{"error": err}); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "could not write error response: %v\n", err)
+		}
+	}
 }
 
 // New returns a new `handler func(*Conn)` that upgrades a client to the
@@ -173,7 +173,7 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 		}
 
 		// ip address
-		conn.ip = c.IP()
+		conn.ip = utils.CopyString(c.IP())
 
 		if err := upgrader.Upgrade(c.RequestCtx(), func(fconn *websocket.Conn) {
 			conn.Conn = fconn

--- a/v3/websocket/websocket_test.go
+++ b/v3/websocket/websocket_test.go
@@ -350,6 +350,37 @@ func TestWebSocketConnIP(t *testing.T) {
 	assert.Equal(t, "hello websocket", msg["message"])
 }
 
+// TestWebSocketConnIPSafeCopy verifies that conn.IP() returns a safe copy
+// that is not corrupted when fasthttp reuses its internal buffer for
+// subsequent requests. See: gofiber/fiber#4208
+func TestWebSocketConnIPSafeCopy(t *testing.T) {
+	const iterations = 5
+	ips := make(chan string, iterations)
+
+	app := setupTestApp(Config{}, func(c *Conn) {
+		// Read the IP and send it back; the value must remain "127.0.0.1"
+		// even after fasthttp recycles the underlying request buffer.
+		ips <- c.IP()
+		c.WriteJSON(fiber.Map{"ip": c.IP()})
+	})
+	defer app.Shutdown()
+
+	for i := 0; i < iterations; i++ {
+		conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
+		assert.NoError(t, err)
+		var msg fiber.Map
+		err = conn.ReadJSON(&msg)
+		assert.NoError(t, err)
+		assert.Equal(t, "127.0.0.1", msg["ip"])
+		conn.Close()
+	}
+
+	close(ips)
+	for ip := range ips {
+		assert.Equal(t, "127.0.0.1", ip, "conn.IP() must be a safe copy, not a reference to recycled fasthttp buffer")
+	}
+}
+
 func setupTestApp(cfg Config, h func(c *Conn)) *fiber.App {
 	var handler fiber.Handler
 	if h == nil {

--- a/v3/websocket/websocket_test.go
+++ b/v3/websocket/websocket_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fasthttp/websocket"
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWebSocketMiddlewareDefaultConfig(t *testing.T) {
@@ -352,7 +353,7 @@ func TestWebSocketConnIP(t *testing.T) {
 
 // TestWebSocketConnIPSafeCopy verifies that conn.IP() returns a safe copy
 // that is not corrupted when fasthttp reuses its internal buffer for
-// subsequent requests. See: gofiber/fiber#4208
+// subsequent requests. See: gofiber/fiber#4208, gofiber/contrib#1800
 func TestWebSocketConnIPSafeCopy(t *testing.T) {
 	const iterations = 5
 	ips := make(chan string, iterations)
@@ -367,10 +368,10 @@ func TestWebSocketConnIPSafeCopy(t *testing.T) {
 
 	for i := 0; i < iterations; i++ {
 		conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		var msg fiber.Map
 		err = conn.ReadJSON(&msg)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "127.0.0.1", msg["ip"])
 		conn.Close()
 	}


### PR DESCRIPTION
fixed #1800

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved websocket connection IP handling to ensure safe copying of client IPs, preventing possible memory-safety issues and data corruption.

* **Tests**
  * Added a new websocket test that repeatedly connects, verifies reported IPs remain correct, and validates IP stability across sequential connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->