### PR TITLE
[v2 branch] fix: move Next check after request handling to support downstream middleware context

### DIFF
--- a/fiberzerolog/zerolog.go
+++ b/fiberzerolog/zerolog.go
@@ -20,11 +20,6 @@ func New(config ...Config) fiber.Handler {
 
 	// Return new handler
 	return func(c *fiber.Ctx) error {
-		// skip uri
-		if _, ok := skipURIs[c.Path()]; ok {
-			return c.Next()
-		}
-
 		start := time.Now()
 
 		// Handle request, store err for logging
@@ -34,6 +29,11 @@ func New(config ...Config) fiber.Handler {
 			if err := c.App().ErrorHandler(c, chainErr); err != nil {
 				_ = c.SendStatus(fiber.StatusInternalServerError)
 			}
+		}
+
+		// skip uri
+		if _, ok := skipURIs[c.Path()]; ok {
+			return nil
 		}
 
 		// Skip logging if Next returns true (request already processed)

--- a/fiberzerolog/zerolog.go
+++ b/fiberzerolog/zerolog.go
@@ -20,11 +20,6 @@ func New(config ...Config) fiber.Handler {
 
 	// Return new handler
 	return func(c *fiber.Ctx) error {
-		// Don't execute middleware if Next returns true
-		if cfg.Next != nil && cfg.Next(c) {
-			return c.Next()
-		}
-
 		// skip uri
 		if _, ok := skipURIs[c.Path()]; ok {
 			return c.Next()
@@ -39,6 +34,11 @@ func New(config ...Config) fiber.Handler {
 			if err := c.App().ErrorHandler(c, chainErr); err != nil {
 				_ = c.SendStatus(fiber.StatusInternalServerError)
 			}
+		}
+
+		// Skip logging if Next returns true (request already processed)
+		if cfg.Next != nil && cfg.Next(c) {
+			return nil
 		}
 
 		latency := time.Since(start)

--- a/fiberzerolog/zerolog_test.go
+++ b/fiberzerolog/zerolog_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/requestid"
 	"github.com/gofiber/fiber/v2/utils"
 	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_GetResBody(t *testing.T) {
@@ -193,9 +192,11 @@ func Test_Logger_Next(t *testing.T) {
 	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, fiber.StatusNotFound, resp.StatusCode)
-	assert.Equal(t, 0, len(buf.Bytes()))
+	utils.AssertEqual(t, 0, len(buf.Bytes()))
 
 	resp, err = app.Test(httptest.NewRequest("GET", "/log", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
 
 	expected := map[string]any{
 		FieldResBody: string(body),
@@ -205,14 +206,12 @@ func Test_Logger_Next(t *testing.T) {
 	_ = json.Unmarshal(buf.Bytes(), &logs)
 
 	for key, value := range expected {
-		assert.Equal(t, value, logs[key])
+		utils.AssertEqual(t, value, logs[key])
 	}
 
-	assert.Equal(t, nil, err)
-
 	bodyStr, ok := logs[FieldResBody].(string)
-	assert.Equal(t, true, ok)
-	assert.Equal(t, true, bodyStr == string(body))
+	utils.AssertEqual(t, true, ok)
+	utils.AssertEqual(t, true, bodyStr == string(body))
 }
 
 func Test_Logger_All(t *testing.T) {

--- a/fiberzerolog/zerolog_test.go
+++ b/fiberzerolog/zerolog_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/requestid"
 	"github.com/gofiber/fiber/v2/utils"
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_GetResBody(t *testing.T) {
@@ -160,16 +161,58 @@ func Test_Latency(t *testing.T) {
 func Test_Logger_Next(t *testing.T) {
 	t.Parallel()
 
+	type skipKey struct{}
+	skipLog := func(c *fiber.Ctx) error {
+		c.Locals(skipKey{}, skipKey{})
+		return c.Next()
+	}
+
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf)
+
 	app := fiber.New()
 	app.Use(New(Config{
-		Next: func(_ *fiber.Ctx) bool {
-			return true
+		Logger: &logger,
+		Next: func(c *fiber.Ctx) bool {
+			return c.Locals(skipKey{}) != nil
+		},
+		Fields: []string{
+			FieldResBody,
 		},
 	}))
+
+	app.Get("/", skipLog, func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusNotFound)
+	})
+
+	body := []byte("HELLO")
+	app.Get("/log", func(c *fiber.Ctx) error {
+		return c.Send(body)
+	})
 
 	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, fiber.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, 0, len(buf.Bytes()))
+
+	resp, err = app.Test(httptest.NewRequest("GET", "/log", nil))
+
+	expected := map[string]any{
+		FieldResBody: string(body),
+	}
+
+	var logs map[string]any
+	_ = json.Unmarshal(buf.Bytes(), &logs)
+
+	for key, value := range expected {
+		assert.Equal(t, value, logs[key])
+	}
+
+	assert.Equal(t, nil, err)
+
+	bodyStr, ok := logs[FieldResBody].(string)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, true, bodyStr == string(body))
 }
 
 func Test_Logger_All(t *testing.T) {

--- a/fiberzerolog/zerolog_test.go
+++ b/fiberzerolog/zerolog_test.go
@@ -203,15 +203,12 @@ func Test_Logger_Next(t *testing.T) {
 	}
 
 	var logs map[string]any
-	_ = json.Unmarshal(buf.Bytes(), &logs)
+	err = json.Unmarshal(buf.Bytes(), &logs)
+	utils.AssertEqual(t, nil, err)
 
 	for key, value := range expected {
 		utils.AssertEqual(t, value, logs[key])
 	}
-
-	bodyStr, ok := logs[FieldResBody].(string)
-	utils.AssertEqual(t, true, ok)
-	utils.AssertEqual(t, true, bodyStr == string(body))
 }
 
 func Test_Logger_All(t *testing.T) {


### PR DESCRIPTION
## Branch
**v2**

## Description
This PR changes the order of the `Next` skip logic in the **fiberzerolog** middleware to allow the skip decision to depend on data set by downstream middlewares or handlers.

Previously the middleware checked `cfg.Next` **before** executing the rest of the handler chain (`c.Next()`). This forced the logger middleware to be placed **first** in the middleware stack if you wanted to access any context values (e.g., user roles, request IDs) inside the skip function. This ordering constraint is unnatural and limits composability.

Now the request is fully processed **before** evaluating `cfg.Next`, making it possible to skip logging based on the final request context, including values set by any middleware that runs after the logger.

## Motivation
- It's common to skip logging for certain endpoints or user roles. The old behaviour forced the logger to be registered before authentication/authorization middlewares, which is counterintuitive.
- Downstream middleware often enriches the context with information needed for logging decisions (e.g., user ID, tenant ID). Moving the check allows a cleaner, more flexible setup.
- This change brings the behaviour closer to other logging middlewares in the Fiber ecosystem.

## Changes
### Before
```go
if cfg.Next != nil && cfg.Next(c) {
    return c.Next() // returns result of c.Next(), which re-executes the handler chain
}

start := time.Now()

chainErr := c.Next()
if chainErr != nil {
    if err := c.App().ErrorHandler(c, chainErr); err != nil {
        _ = c.SendStatus(fiber.StatusInternalServerError)
    }
}

// ... logging ...
```

### After
```go
start := time.Now()

chainErr := c.Next()
if chainErr != nil {
    if err := c.App().ErrorHandler(c, chainErr); err != nil {
        _ = c.SendStatus(fiber.StatusInternalServerError)
    }
}

//  Skip logging if Next returns true (request already processed)
if cfg.Next != nil && cfg.Next(c) {
    return nil
}

// ... logging ...
```

## Behavioural Changes

### ⚠️ Breaking Change

1. **`Next` evaluation is deferred**  
   `c.Next()` now always runs **before** the skip check. This means the `Next` function receives the fully-processed context, including any data set by downstream middlewares or the handler. If your `Next` function previously expected an empty context, you may need to adjust it.

2. **Error handling still occurs when `Next` returns true**  
   In the old version, when `Next` returned `true` the middleware called `c.Next()` and immediately returned — the error handler was never triggered. Now errors from the handler chain are **always** handled (via `c.App().ErrorHandler`) before the skip decision. This is intentional: error handling is a framework concern and should not be bypassed by a logging skip. If you rely on the old behaviour (suppressing error handling when skipping logging), you can wrap the error handling block with the `Next` check, but this is not recommended.

3. **Return value when skipping**  
   When `cfg.Next` returns `true`, the middleware now returns `nil` instead of the result of a second `c.Next()` call. The handler chain has already completed; calling `c.Next()` again would re-execute it (which is both incorrect and dangerous). Returning `nil` signals that the middleware did not produce an error. If you need to preserve and propagate a downstream error, you can change the return value to `chainErr`, but note that the error has already been passed to the error handler, and returning it again may trigger duplicate error handling.

## How to Test
1. Register a middleware **after** the logger that sets a value via `c.Locals()`, e.g. `c.Locals("role", "admin")`.
2. In the logger's `Next` function, read `c.Locals("role")` and return `true` to skip logging.
3. Make a request that goes through both middlewares. Verify:
   - The request completes successfully.
   - No log output is produced.
   - The middleware does not panic or re-execute the handler.
4. Test with a handler that returns an error. Confirm:
   - The error handler is invoked.
   - Logging is skipped (if `Next` returns `true`), but the error is still properly handled.

## Additional Notes
- The logging logic (level selection, message selection, etc.) remains completely unchanged; only the control flow has been adjusted.
- This change is backwards incompatible in the ways described above. If you want to preserve the old behaviour, you can wrap your `Next` logic to check the context before it has been enriched, but updating your code to take advantage of the new order is the recommended path.