### PR TITLE
feat: Add static window interval support

### DIFF
--- a/circuitbreaker/README.md
+++ b/circuitbreaker/README.md
@@ -53,6 +53,7 @@ circuitbreaker.New(config ...circuitbreaker.Config) *circuitbreaker.Middleware
 | Timeout | `time.Duration` | Timeout for the circuit breaker | `10 * time.Second` |
 | SuccessThreshold | `int` | Number of successful requests required to close the circuit | `5` |
 | HalfOpenMaxConcurrent | `int` | Max concurrent requests in half-open state | `1` |
+| Interval | `time.Duration` | Period after which failure counts reset in closed state. Zero means failures accumulate until the circuit opens. | `0` |
 | IsFailure | `func(error) bool` | Custom function to determine if an error is a failure | `Status >= 500` |
 | OnOpen | `func(*fiber.Ctx)` | Callback function when the circuit is opened | `503 response` |
 | OnClose | `func(*fiber.Ctx)` | Callback function when the circuit is closed | `Continue request` |
@@ -218,7 +219,23 @@ cb := circuitbreaker.New(circuitbreaker.Config{
 
 ✅ Logs when the circuit opens & increments Prometheus metrics.
 
-### 7. Advanced: Multiple Circuit Breakers for Different Services
+### 7. Circuit Breaker with Failure Count Reset Interval
+
+Use `Interval` to automatically reset the failure count after a fixed window. Without it, failures accumulate indefinitely in the closed state until the threshold is reached.
+
+```go
+cb := circuitbreaker.New(circuitbreaker.Config{
+	FailureThreshold: 5,
+	Timeout:          10 * time.Second,
+	Interval:         30 * time.Second, // Reset failure count every 30 seconds
+})
+
+app.Use(circuitbreaker.Middleware(cb))
+```
+
+✅ If 4 failures occur within a 30-second window and then recovers, the count resets at the next window boundary. The circuit only opens if 5 failures happen within the same window.
+
+### 8. Advanced: Multiple Circuit Breakers for Different Services
 
 Use different Circuit Breakers for different services.
 

--- a/circuitbreaker/circuitbreaker.go
+++ b/circuitbreaker/circuitbreaker.go
@@ -29,6 +29,9 @@ type Config struct {
 	SuccessThreshold int
 	// Maximum concurrent requests allowed in half-open state
 	HalfOpenMaxConcurrent int
+	// Interval for resetting failure counts in closed state.
+	// Zero means failures accumulate until the circuit opens.
+	Interval time.Duration
 	// Custom failure detector function (return true if response should count as failure)
 	IsFailure func(c *fiber.Ctx, err error) bool
 	// Callbacks for state transitions
@@ -43,6 +46,7 @@ var DefaultConfig = Config{
 	Timeout:               5 * time.Second,
 	SuccessThreshold:      1,
 	HalfOpenMaxConcurrent: 1,
+	Interval:              0,
 	IsFailure: func(c *fiber.Ctx, err error) bool {
 		return err != nil || c.Response().StatusCode() >= http.StatusInternalServerError
 	},
@@ -79,6 +83,8 @@ type CircuitBreaker struct {
 	now               func() time.Time   // Function for getting current time (useful for testing)
 	halfOpenSemaphore chan struct{}      // Controls limited requests in half-open state
 	lastStateChange   time.Time          // Time of last state change
+	interval          time.Duration      // Interval for resetting failure counts
+	expiry            time.Time          // Time when the failure count will be reset
 }
 
 // New initializes a circuit breaker with the given configuration
@@ -112,6 +118,11 @@ func New(config Config) *CircuitBreaker {
 	ctx, cancel := context.WithCancel(context.Background())
 	now := time.Now()
 
+	var expiry time.Time
+	if config.Interval > 0 {
+		expiry = now.Add(config.Interval)
+	}
+
 	return &CircuitBreaker{
 		failureThreshold:  config.FailureThreshold,
 		timeout:           config.Timeout,
@@ -125,6 +136,8 @@ func New(config Config) *CircuitBreaker {
 		lastStateChange:   now,
 		totalRequests:     0,
 		rejectedRequests:  0,
+		interval:          config.Interval,
+		expiry:            expiry,
 	}
 }
 
@@ -161,8 +174,12 @@ func (cb *CircuitBreaker) Reset() {
 	atomic.StoreInt64(&cb.successCount, 0)
 
 	// Reset state
+	now := cb.now()
 	cb.state = StateClosed
-	cb.lastStateChange = cb.now()
+	cb.lastStateChange = now
+	if cb.interval > 0 {
+		cb.expiry = now.Add(cb.interval)
+	}
 
 	// Cancel any pending state transitions
 	if cb.openTimer != nil {
@@ -180,11 +197,15 @@ func (cb *CircuitBreaker) ForceClose() {
 	cb.mutex.Lock()
 	defer cb.mutex.Unlock()
 
+	now := cb.now()
 	cb.state = StateClosed
-	cb.lastStateChange = cb.now()
+	cb.lastStateChange = now
 	atomic.StoreInt64(&cb.failureCount, 0)
 	atomic.StoreInt64(&cb.successCount, 0)
 
+	if cb.interval > 0 {
+		cb.expiry = now.Add(cb.interval)
+	}
 	if cb.openTimer != nil {
 		cb.openTimer.Stop()
 	}
@@ -255,6 +276,21 @@ func (cb *CircuitBreaker) transitionToClosed() {
 		// Reset counters
 		atomic.StoreInt64(&cb.failureCount, 0)
 		atomic.StoreInt64(&cb.successCount, 0)
+		if cb.interval > 0 {
+			cb.expiry = cb.now().Add(cb.interval)
+		}
+	}
+}
+
+func (cb *CircuitBreaker) resetFromExpiry() {
+	if cb.interval <= 0 {
+		return
+	}
+	cb.mutex.Lock()
+	defer cb.mutex.Unlock()
+	if cb.expiry.Before(cb.now()) {
+		atomic.StoreInt64(&cb.failureCount, 0)
+		cb.expiry = cb.expiry.Add(cb.interval)
 	}
 }
 
@@ -316,6 +352,7 @@ func (cb *CircuitBreaker) ReportFailure() {
 		// In half-open, a single failure trips the circuit
 		cb.transitionToOpen()
 	case StateClosed:
+		cb.resetFromExpiry()
 		newFailureCount := atomic.AddInt64(&cb.failureCount, 1)
 		if int(newFailureCount) >= cb.failureThreshold {
 			cb.transitionToOpen()
@@ -336,7 +373,10 @@ func (cb *CircuitBreaker) Metrics() fiber.Map {
 
 // GetStateStats returns detailed statistics about the circuit breaker
 func (cb *CircuitBreaker) GetStateStats() fiber.Map {
-	state := cb.GetState()
+	cb.mutex.RLock()
+	defer cb.mutex.RUnlock()
+	state := cb.state
+	expiry := cb.expiry
 
 	return fiber.Map{
 		"state":            state,
@@ -348,6 +388,7 @@ func (cb *CircuitBreaker) GetStateStats() fiber.Map {
 		"openDuration":     cb.timeout,
 		"failureThreshold": cb.failureThreshold,
 		"successThreshold": cb.successThreshold,
+		"expiry":           expiry,
 	}
 }
 

--- a/circuitbreaker/circuitbreaker_test.go
+++ b/circuitbreaker/circuitbreaker_test.go
@@ -520,6 +520,7 @@ func TestCircuitBreakerReset(t *testing.T) {
 		Timeout:               5 * time.Second,
 		SuccessThreshold:      2,
 		HalfOpenMaxConcurrent: 1,
+		Interval:              10 * time.Second,
 	})
 	cb.now = mockClock.Now
 
@@ -585,6 +586,17 @@ func TestCircuitBreakerReset(t *testing.T) {
 
 		// Verify lastStateChange was updated
 		require.True(t, cb.lastStateChange.After(initialTime))
+	})
+
+	t.Run("Reset updates expiry", func(t *testing.T) {
+		cb.Reset()
+		require.True(t, cb.expiry.Equal(mockClock.Now().Add(cb.config.Interval)))
+
+		// Advance time past original expiry
+		mockClock.Add(6 * time.Second)
+
+		cb.Reset()
+		require.True(t, cb.expiry.Equal(mockClock.Now().Add(cb.config.Interval)))
 	})
 
 	// Clean up
@@ -658,6 +670,68 @@ func TestForceOpen(t *testing.T) {
 
 	// Clean up
 	cb.Stop()
+}
+
+func newIntervalCB(t *testing.T, interval time.Duration) (*CircuitBreaker, *mockTime) {
+	t.Helper()
+	mockClock := newMockTime(time.Now())
+	cb := New(Config{
+		FailureThreshold:      5,
+		Timeout:               5 * time.Second,
+		SuccessThreshold:      2,
+		HalfOpenMaxConcurrent: 1,
+		Interval:              interval,
+	})
+	cb.now = mockClock.Now
+	t.Cleanup(func() { cb.Stop() })
+	return cb, mockClock
+}
+
+func TestInterval(t *testing.T) {
+	defaultInterval := 10 * time.Second
+	t.Run("Init Sets Expiry", func(t *testing.T) {
+		cb, _ := newIntervalCB(t, defaultInterval)
+		require.False(t, cb.expiry.IsZero())
+		require.WithinDuration(t, time.Now().Add(cb.config.Interval), cb.expiry, 100*time.Millisecond)
+	})
+
+	t.Run("Init with 0 interval does not set expiry", func(t *testing.T) {
+		cb, _ := newIntervalCB(t, 0)
+		require.True(t, cb.expiry.IsZero())
+	})
+
+	t.Run("Interval Resets Failure Count", func(t *testing.T) {
+		cb, mockClock := newIntervalCB(t, defaultInterval)
+
+		for i := 0; i < 4; i++ {
+			cb.ReportFailure()
+		}
+		require.Equal(t, int64(4), atomic.LoadInt64(&cb.failureCount))
+
+		// Advance time past the interval to trigger reset
+		mockClock.Add(11 * time.Second)
+
+		// Next failure triggers the expiry reset first, then increments
+		cb.ReportFailure()
+		require.Equal(t, int64(1), atomic.LoadInt64(&cb.failureCount))
+	})
+
+	t.Run("Interval does not reset Failure Count prematurely", func(t *testing.T) {
+		cb, mockClock := newIntervalCB(t, defaultInterval)
+
+		for i := 0; i < 3; i++ {
+			cb.ReportFailure()
+		}
+		require.Equal(t, int64(3), atomic.LoadInt64(&cb.failureCount))
+
+		require.True(t, cb.expiry.After(mockClock.Now()))
+		// Advance time but not past the interval
+		mockClock.Add(5 * time.Second)
+
+		// Failure count should continue accumulating
+		cb.ReportFailure()
+		require.Equal(t, int64(4), atomic.LoadInt64(&cb.failureCount))
+	})
 }
 
 // TestHealthHandler tests the health check endpoint handler


### PR DESCRIPTION
This pull request adds support for basic interval window in the circuit breaker middleware, allowing users to choose an interval in which if in closed state, the failure counts would be reset.

My thinking is that if this is an acceptable way to go, I can port this to v3 and later add rolling window support as other circuit breaker solutions have.

- [x] Added a few tests
- [x] Updated documentation with example usage
- [x] No new dependency introduced 