### PR TITLE
fix(sentry): deep-copy the converted request before storing it in the scope

### DIFF
--- a/v3/sentry/go.mod
+++ b/v3/sentry/go.mod
@@ -3,7 +3,7 @@ module github.com/gofiber/contrib/v3/sentry
 go 1.25.0
 
 require (
-	github.com/getsentry/sentry-go v0.45.1
+	github.com/getsentry/sentry-go v0.46.2
 	github.com/gofiber/fiber/v3 v3.3.0
 	github.com/gofiber/utils/v2 v2.1.0
 )

--- a/v3/sentry/go.sum
+++ b/v3/sentry/go.sum
@@ -5,8 +5,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh78=
 github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/getsentry/sentry-go v0.45.1 h1:9rfzJtGiJG+MGIaWZXidDGHcH5GU1Z5y0WVJGf9nysw=
-github.com/getsentry/sentry-go v0.45.1/go.mod h1:XDotiNZbgf5U8bPDUAfvcFmOnMQQceESxyKaObSssW0=
+github.com/getsentry/sentry-go v0.46.2 h1:1jhYwrKGa3sIpo/y5iDNXS5wDoT7I1KNzMHrnK6ojns=
+github.com/getsentry/sentry-go v0.46.2/go.mod h1:evVbw2qotNUdYG8KxXbAdjOQWWvWIwKxpjdZZIvcIPw=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/gofiber/fiber/v3 v3.3.0 h1:QBd3sYCqdy6Qs5gJYzSw4I4SbqL204jPqpdub/ueiw8=

--- a/v3/sentry/sentry.go
+++ b/v3/sentry/sentry.go
@@ -1,7 +1,12 @@
 package sentry
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/gofiber/fiber/v3"
@@ -22,11 +27,17 @@ func New(config ...Config) fiber.Handler {
 			return err
 		}
 
+		// The converted request aliases fasthttp's reusable buffers and must
+		// not be referenced once the handler has returned. Sentry serializes
+		// events on background goroutines, so store a deep copy in the scope.
+		body := utils.CopyBytes(c.Body())
+		r = cloneRequest(r, body)
+
 		// Init sentry hub
 		hub := sentry.CurrentHub().Clone()
 		scope := hub.Scope()
 		scope.SetRequest(r)
-		scope.SetRequestBody(utils.CopyBytes(c.Body()))
+		scope.SetRequestBody(body)
 		fiber.StoreInContext(c, hubKey, hub)
 
 		// Catch panics
@@ -50,6 +61,72 @@ func New(config ...Config) fiber.Handler {
 		// Return err if exist, else move to next handler
 		return c.Next()
 	}
+}
+
+// cloneRequest returns a deep copy of r whose strings no longer alias
+// fasthttp's reusable buffers, so it can safely outlive the request handler.
+// body must already be a copy that does not alias fasthttp memory.
+func cloneRequest(r *http.Request, body []byte) *http.Request {
+	rc := new(http.Request)
+	*rc = *r
+
+	rc.Method = strings.Clone(r.Method)
+	rc.Proto = strings.Clone(r.Proto)
+	rc.Host = strings.Clone(r.Host)
+	rc.RequestURI = strings.Clone(r.RequestURI)
+	rc.RemoteAddr = strings.Clone(r.RemoteAddr)
+	rc.URL = cloneURL(r.URL)
+	rc.Body = io.NopCloser(bytes.NewReader(body))
+
+	if r.Header != nil {
+		h := make(http.Header, len(r.Header))
+		for k, vv := range r.Header {
+			cvv := make([]string, len(vv))
+			for i, v := range vv {
+				cvv[i] = strings.Clone(v)
+			}
+			h[strings.Clone(k)] = cvv
+		}
+		rc.Header = h
+	}
+
+	if r.TransferEncoding != nil {
+		te := make([]string, len(r.TransferEncoding))
+		for i, v := range r.TransferEncoding {
+			te[i] = strings.Clone(v)
+		}
+		rc.TransferEncoding = te
+	}
+
+	return rc
+}
+
+// cloneURL returns a deep copy of u; the parsed URL fields are sub-strings of
+// the request URI buffer and alias fasthttp memory as well.
+func cloneURL(u *url.URL) *url.URL {
+	if u == nil {
+		return nil
+	}
+	uc := new(url.URL)
+	*uc = *u
+
+	uc.Scheme = strings.Clone(u.Scheme)
+	uc.Opaque = strings.Clone(u.Opaque)
+	uc.Host = strings.Clone(u.Host)
+	uc.Path = strings.Clone(u.Path)
+	uc.RawPath = strings.Clone(u.RawPath)
+	uc.RawQuery = strings.Clone(u.RawQuery)
+	uc.Fragment = strings.Clone(u.Fragment)
+	uc.RawFragment = strings.Clone(u.RawFragment)
+	if u.User != nil {
+		if pw, ok := u.User.Password(); ok {
+			uc.User = url.UserPassword(strings.Clone(u.User.Username()), strings.Clone(pw))
+		} else {
+			uc.User = url.User(strings.Clone(u.User.Username()))
+		}
+	}
+
+	return uc
 }
 
 // MustGetHubFromContext returns the Sentry hub from context.


### PR DESCRIPTION
The request returned by `adaptor.ConvertRequest` aliases fasthttp's reusable buffers and must not be referenced after the handler returns. The middleware stored it in the Sentry scope, and since sentry-go v0.46.x serializes events on a background goroutine (internal telemetry processor), serialization raced with fasthttp reusing the buffers for the next request, failing the race-detector tests in #1897.

This PR clones the request (method, proto, host, URL, headers, transfer encoding) and backs its body with already-copied bytes so the scope owns all of its memory, and bumps sentry-go to v0.46.2 so CI validates the fix against the new version.

- Race reproduced locally with v0.46.2 before the fix, gone after
- `go test -race -count=2`, `go vet`, `gofmt` clean

Fixes the CI failures in #1897.

🤖 Generated with [Claude Code](https://claude.com/claude-code)