### PR TITLE
fix(otel): use Content-Length for request size instead of materializing body

### DIFF
--- a/v3/otel/fiber.go
+++ b/v3/otel/fiber.go
@@ -183,7 +183,12 @@ func Middleware(opts ...Option) fiber.Handler {
 				request.SetBodyStream(requestBodyStreamSizeReader, -1)
 			}
 		} else {
-			requestSize = int64(len(request.Body()))
+			// use Content-Length to avoid re-marshaling the multipart body, including files, into memory.
+			if contentLength := request.Header.ContentLength(); contentLength > 0 {
+				requestSize = int64(contentLength)
+			} else if !isRequestBodyStream {
+				requestSize = int64(len(request.Body()))
+			}
 		}
 
 		reqHeader := make(http.Header)

--- a/v3/otel/otel_test/fiber_test.go
+++ b/v3/otel/otel_test/fiber_test.go
@@ -339,6 +339,47 @@ func TestMetric(t *testing.T) {
 	assertScopeMetrics(t, metrics.ScopeMetrics[0], route, requestAttrs, append(requestAttrs, responseAttrs...))
 }
 
+func TestRequestBodySizeUsesContentLength(t *testing.T) {
+	const contentLength = 1024
+
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		// Simulate a pre-parsed body whose in-memory representation differs from
+		// the size declared by the request, as can happen for multipart forms.
+		c.Request().Header.SetContentLength(contentLength)
+		return c.Next()
+	})
+	app.Use(fiberotel.Middleware(fiberotel.WithMeterProvider(provider)))
+	app.Post("/upload", func(c fiber.Ctx) error {
+		return c.SendStatus(http.StatusNoContent)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/upload", bytes.NewBufferString("body")))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	metrics := metricdata.ResourceMetrics{}
+	require.NoError(t, reader.Collect(context.Background(), &metrics))
+	require.Len(t, metrics.ScopeMetrics, 1)
+
+	for _, m := range metrics.ScopeMetrics[0].Metrics {
+		if m.Name != fiberotel.MetricNameHTTPServerRequestBodySize {
+			continue
+		}
+
+		histogram, ok := m.Data.(metricdata.Histogram[int64])
+		require.True(t, ok)
+		require.Len(t, histogram.DataPoints, 1)
+		assert.Equal(t, int64(contentLength), histogram.DataPoints[0].Sum)
+		return
+	}
+
+	t.Fatal("request body size metric not found")
+}
+
 func assertScopeMetrics(t *testing.T, sm metricdata.ScopeMetrics, route string, requestAttrs []attribute.KeyValue, responseAttrs []attribute.KeyValue) {
 	assert.Equal(t, instrumentation.Scope{
 		Name:    instrumentationName,


### PR DESCRIPTION
## Summary

Use the request's declared `Content-Length` when recording the OpenTelemetry request body size metric.

## Problem

Calling `request.Body()` for a pre-parsed multipart request re-marshals the entire form, including uploaded files, into a contiguous memory buffer just to determine its size. This can cause unnecessary and potentially significant memory allocation.

## Changes

- Use `Content-Length` as the request body size when available.
- Fall back to `len(request.Body())` for buffered requests without a known content length.
- Preserve the existing streamed-request body accounting.
- Add a regression test verifying that the request body size metric uses `Content-Length`.

## Testing

```sh
cd v3/otel
go test ./...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP server metrics to accurately report request body sizes using the `Content-Length` header when available.
  * Avoided unnecessary processing for multipart request bodies.

* **Tests**
  * Added coverage verifying that reported request body size metrics match the configured `Content-Length`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->