### PR TITLE
docs(contrib): update outdated zerolog link to GitHub repository

### DIFF
--- a/v3/zerolog/README.md
+++ b/v3/zerolog/README.md
@@ -8,8 +8,7 @@ id: zerolog
 [![Discord](https://img.shields.io/discord/704680098577514527?style=flat&label=%F0%9F%92%AC%20discord&color=00ACD7)](https://gofiber.io/discord)
 ![Test](https://github.com/gofiber/contrib/workflows/Test%20zerolog/badge.svg)
 
-[Zerolog](https://zerolog.io/) logging support for Fiber.
-
+[Zerolog](https://github.com/rs/zerolog/) logging support for Fiber.
 
 **Compatible with Fiber v3.**
 


### PR DESCRIPTION
This PR corrects the URL referenced for Zerolog. As noted in https://github.com/gofiber/fiber/issues/4580#issuecomment-5138314355, the URL is currently outdated and the domain appears to be now unrelated to the Zerolog project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Zerolog project link in the README to point to its GitHub repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->