### PR TITLE
Fix intField to detect out-of-range values instead of silently truncating

### DIFF
--- a/v3/uptime/internal/storage/redis.go
+++ b/v3/uptime/internal/storage/redis.go
@@ -778,9 +778,18 @@ func dailyFromRedisHash(serviceID, day string, fields map[string]string) (DailyS
 	}, nil
 }
 
+// Parsed as int rather than narrowed from int64Field, so an out-of-range value
+// reports strconv.ErrRange instead of silently truncating on 32-bit builds.
 func intField(fields map[string]string, name string) (int, error) {
-	value, err := int64Field(fields, name)
-	return int(value), err
+	raw := fields[name]
+	if raw == "" {
+		return 0, nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("redis uptime store: parse %s: %w", name, err)
+	}
+	return value, nil
 }
 
 func int64Field(fields map[string]string, name string) (int64, error) {

--- a/v3/uptime/internal/storage/redis_test.go
+++ b/v3/uptime/internal/storage/redis_test.go
@@ -529,13 +529,18 @@ func TestIntFieldRejectsOutOfRangeValue(t *testing.T) {
 	t.Parallel()
 
 	fields := map[string]string{
-		"absent":    "",
+		"empty":     "",
 		"up_slots":  "42",
 		"too_large": strconv.FormatInt(math.MaxInt64, 10) + "0",
 	}
 
-	if value, err := intField(fields, "absent"); value != 0 || err != nil {
-		t.Fatalf("intField(absent) = %d, %v, want 0, <nil>", value, err)
+	// "missing" is absent from the map, "empty" is present but blank; both must
+	// stay a plain zero rather than a parse error.
+	if value, err := intField(fields, "missing"); value != 0 || err != nil {
+		t.Fatalf("intField(missing) = %d, %v, want 0, <nil>", value, err)
+	}
+	if value, err := intField(fields, "empty"); value != 0 || err != nil {
+		t.Fatalf("intField(empty) = %d, %v, want 0, <nil>", value, err)
 	}
 	if value, err := intField(fields, "up_slots"); value != 42 || err != nil {
 		t.Fatalf("intField(up_slots) = %d, %v, want 42, <nil>", value, err)

--- a/v3/uptime/internal/storage/redis_test.go
+++ b/v3/uptime/internal/storage/redis_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -521,6 +522,31 @@ func TestRedisStoreRollupKeepsFinalizedRowWhenSamplesRemain(t *testing.T) {
 	row := queryDailyMap(t, first)["2026-06-25"]
 	if row.UpSlots != 1 || row.ExpectedSlots != 1440 || !row.Finalized {
 		t.Fatalf("daily = %+v, want the original up=1 expected=1440 finalized row", row)
+	}
+}
+
+func TestIntFieldRejectsOutOfRangeValue(t *testing.T) {
+	t.Parallel()
+
+	fields := map[string]string{
+		"absent":    "",
+		"up_slots":  "42",
+		"too_large": strconv.FormatInt(math.MaxInt64, 10) + "0",
+	}
+
+	if value, err := intField(fields, "absent"); value != 0 || err != nil {
+		t.Fatalf("intField(absent) = %d, %v, want 0, <nil>", value, err)
+	}
+	if value, err := intField(fields, "up_slots"); value != 42 || err != nil {
+		t.Fatalf("intField(up_slots) = %d, %v, want 42, <nil>", value, err)
+	}
+
+	value, err := intField(fields, "too_large")
+	if !errors.Is(err, strconv.ErrRange) {
+		t.Fatalf("intField(too_large) error = %v, want strconv.ErrRange", err)
+	}
+	if value != 0 {
+		t.Fatalf("intField(too_large) = %d, want 0", value)
 	}
 }
 


### PR DESCRIPTION
## Summary
Changed the `intField` function to parse values directly as `int` using `strconv.Atoi` instead of parsing as `int64` and then narrowing to `int`. This ensures that out-of-range values are properly detected and reported as `strconv.ErrRange` errors rather than silently truncating on 32-bit builds.

## Key Changes
- Modified `intField()` in `redis.go` to use `strconv.Atoi` for direct `int` parsing instead of converting from `int64`
- Added a comment explaining why direct `int` parsing is necessary to catch range errors
- Improved error message formatting to include context about which field failed to parse
- Added comprehensive test case `TestIntFieldRejectsOutOfRangeValue` to verify:
  - Absent fields return 0 with no error
  - Valid values parse correctly
  - Out-of-range values return `strconv.ErrRange` error

## Implementation Details
The previous implementation would silently truncate values that exceeded `math.MaxInt` on 32-bit systems. The new implementation catches these errors at parse time, providing better data integrity and clearer error reporting. The test validates all three scenarios: missing fields, valid values, and out-of-range values.

https://claude.ai/code/session_01GQgcBHKU9YCze7EBKvnr4r

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large integer values to prevent truncation on some systems.
  * Empty values continue to default to zero, while invalid or out-of-range values now retain clearer error information.

* **Tests**
  * Added coverage for missing fields, valid integers, and out-of-range values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->