### PR TITLE
ci: run every module test suite on the default branch

### DIFF
--- a/.github/workflows/test-casbin.yml
+++ b/.github/workflows/test-casbin.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/casbin/**/*.go'
-      - 'v3/casbin/go.mod'
-      - 'v3/casbin/go.sum'
   pull_request:
     paths:
       - 'v3/casbin/**/*.go'

--- a/.github/workflows/test-circuitbreaker.yml
+++ b/.github/workflows/test-circuitbreaker.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/circuitbreaker/**/*.go'
-      - 'v3/circuitbreaker/go.mod'
-      - 'v3/circuitbreaker/go.sum'
   pull_request:
     paths:
       - 'v3/circuitbreaker/**/*.go'

--- a/.github/workflows/test-coraza.yml
+++ b/.github/workflows/test-coraza.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/coraza/**/*.go'
-      - 'v3/coraza/go.mod'
-      - 'v3/coraza/go.sum'
   pull_request:
     paths:
       - 'v3/coraza/**/*.go'

--- a/.github/workflows/test-fgprof.yml
+++ b/.github/workflows/test-fgprof.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/fgprof/**/*.go'
-      - 'v3/fgprof/go.mod'
-      - 'v3/fgprof/go.sum'
   pull_request:
     paths:
       - 'v3/fgprof/**/*.go'

--- a/.github/workflows/test-hcaptcha.yml
+++ b/.github/workflows/test-hcaptcha.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/hcaptcha/**/*.go'
-      - 'v3/hcaptcha/go.mod'
-      - 'v3/hcaptcha/go.sum'
   pull_request:
     paths:
       - 'v3/hcaptcha/**/*.go'

--- a/.github/workflows/test-i18n.yml
+++ b/.github/workflows/test-i18n.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/i18n/**/*.go'
-      - 'v3/i18n/go.mod'
-      - 'v3/i18n/go.sum'
   pull_request:
     paths:
       - 'v3/i18n/**/*.go'

--- a/.github/workflows/test-jwt.yml
+++ b/.github/workflows/test-jwt.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/jwt/**/*.go'
-      - 'v3/jwt/go.mod'
-      - 'v3/jwt/go.sum'
   pull_request:
     paths:
       - 'v3/jwt/**/*.go'

--- a/.github/workflows/test-loadshed.yml
+++ b/.github/workflows/test-loadshed.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/loadshed/**/*.go'
-      - 'v3/loadshed/go.mod'
-      - 'v3/loadshed/go.sum'
   pull_request:
     paths:
       - 'v3/loadshed/**/*.go'

--- a/.github/workflows/test-monitor.yml
+++ b/.github/workflows/test-monitor.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/monitor/**/*.go'
-      - 'v3/monitor/go.mod'
-      - 'v3/monitor/go.sum'
   pull_request:
     paths:
       - 'v3/monitor/**/*.go'

--- a/.github/workflows/test-newrelic.yml
+++ b/.github/workflows/test-newrelic.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/newrelic/**/*.go'
-      - 'v3/newrelic/go.mod'
-      - 'v3/newrelic/go.sum'
   pull_request:
     paths:
       - 'v3/newrelic/**/*.go'

--- a/.github/workflows/test-opa.yml
+++ b/.github/workflows/test-opa.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/opa/**/*.go'
-      - 'v3/opa/go.mod'
-      - 'v3/opa/go.sum'
   pull_request:
     paths:
       - 'v3/opa/**/*.go'

--- a/.github/workflows/test-otel.yml
+++ b/.github/workflows/test-otel.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/otel/**/*.go'
-      - 'v3/otel/go.mod'
-      - 'v3/otel/go.sum'
   pull_request:
     paths:
       - 'v3/otel/**/*.go'

--- a/.github/workflows/test-paseto.yml
+++ b/.github/workflows/test-paseto.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/paseto/**/*.go'
-      - 'v3/paseto/go.mod'
-      - 'v3/paseto/go.sum'
   pull_request:
     paths:
       - 'v3/paseto/**/*.go'

--- a/.github/workflows/test-sentry.yml
+++ b/.github/workflows/test-sentry.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/sentry/**/*.go'
-      - 'v3/sentry/go.mod'
-      - 'v3/sentry/go.sum'
   pull_request:
     paths:
       - 'v3/sentry/**/*.go'

--- a/.github/workflows/test-socketio.yml
+++ b/.github/workflows/test-socketio.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/socketio/**/*.go'
-      - 'v3/socketio/go.mod'
-      - 'v3/socketio/go.sum'
   pull_request:
     paths:
       - 'v3/socketio/**/*.go'

--- a/.github/workflows/test-swaggerui.yml
+++ b/.github/workflows/test-swaggerui.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/swaggerui/**/*.go'
-      - 'v3/swaggerui/go.mod'
-      - 'v3/swaggerui/go.sum'
   pull_request:
     paths:
       - 'v3/swaggerui/**/*.go'

--- a/.github/workflows/test-swaggo.yml
+++ b/.github/workflows/test-swaggo.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/swaggo/**/*.go'
-      - 'v3/swaggo/go.mod'
-      - 'v3/swaggo/go.sum'
   pull_request:
     paths:
       - 'v3/swaggo/**/*.go'

--- a/.github/workflows/test-testcontainers.yml
+++ b/.github/workflows/test-testcontainers.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/testcontainers/**/*.go'
-      - 'v3/testcontainers/go.mod'
-      - 'v3/testcontainers/go.sum'
   pull_request:
     paths:
       - 'v3/testcontainers/**/*.go'

--- a/.github/workflows/test-uptime.yml
+++ b/.github/workflows/test-uptime.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/uptime/**/*.go'
-      - 'v3/uptime/dashboard.gohtml'
-      - 'v3/uptime/go.mod'
-      - 'v3/uptime/go.sum'
   pull_request:
     paths:
       - 'v3/uptime/**/*.go'

--- a/.github/workflows/test-websocket.yml
+++ b/.github/workflows/test-websocket.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/websocket/**/*.go'
-      - 'v3/websocket/go.mod'
-      - 'v3/websocket/go.sum'
   pull_request:
     paths:
       - 'v3/websocket/**/*.go'

--- a/.github/workflows/test-zap.yml
+++ b/.github/workflows/test-zap.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/zap/**/*.go'
-      - 'v3/zap/go.mod'
-      - 'v3/zap/go.sum'
   pull_request:
     paths:
       - 'v3/zap/**/*.go'

--- a/.github/workflows/test-zerolog.yml
+++ b/.github/workflows/test-zerolog.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'v3/zerolog/**/*.go'
-      - 'v3/zerolog/go.mod'
-      - 'v3/zerolog/go.sum'
   pull_request:
     paths:
       - 'v3/zerolog/**/*.go'

--- a/v3/coraza/coraza_test.go
+++ b/v3/coraza/coraza_test.go
@@ -2,6 +2,7 @@ package coraza
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"math"
 	"net/http"
@@ -18,6 +19,7 @@ import (
 	"github.com/corazawaf/coraza/v3/types"
 	"github.com/gofiber/fiber/v3"
 	fiberlog "github.com/gofiber/fiber/v3/log"
+	"github.com/valyala/fasthttp"
 )
 
 const float64Epsilon = 1e-9
@@ -315,7 +317,7 @@ SecRule REQUEST_BODY "@contains attack" "id:1002,phase:2,deny,status:403,msg:'bo
 	if err == nil {
 		t.Fatal("expected Fiber body limit error, got nil")
 	}
-	if err.Error() != "body size exceeds the given limit" {
+	if !errors.Is(err, fasthttp.ErrBodyTooLarge) {
 		t.Fatalf("expected Fiber body limit error, got %v", err)
 	}
 }


### PR DESCRIPTION
The per-module test workflows filtered their `push` trigger on
`v3/<module>/**`, so a push to main only ran the suites whose files
changed. Suites that broke through a dependency bump elsewhere stayed
red without anyone noticing. Drop the `paths` filter from the `push`
trigger of all 22 test workflows so main always runs the full matrix;
`pull_request` keeps its path filter so PRs stay cheap.

Also fix the coraza suite, which has been failing on main since the
fasthttp v1.73.0 bump: fasthttp prefixed its sentinel errors, turning
`ErrBodyTooLarge` into "fasthttp: body size exceeds the given limit",
while TestEngineMiddlewareRespectsFiberBodyLimit compared the message
for exact equality. Match with errors.Is against the sentinel instead,
which survives future message changes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011XE1LyfsSqWt5NWBK9JBJP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of oversized request body errors to reliably recognize the framework’s standard error type.
  * Prevented tests from depending on specific error message text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->