### PR TITLE
fix(uptime): redact storage errors from public status responses

### DIFF
--- a/v3/uptime/status.go
+++ b/v3/uptime/status.go
@@ -33,7 +33,7 @@ type StorageResponse struct {
 	Driver string `json:"driver"`
 	// Status is "ok" when the store is currently healthy.
 	Status string `json:"status"`
-	// LastError is the latest runtime storage error, if any.
+	// LastError is a non-sensitive indicator of the latest runtime storage error.
 	LastError string `json:"last_error,omitempty"`
 	// LastErrorAt is when LastError was recorded.
 	LastErrorAt *time.Time `json:"last_error_at,omitempty"`
@@ -78,8 +78,9 @@ type DayStatus struct {
 }
 
 const (
-	statusUp   = "up"
-	statusDown = "down"
+	statusUp                = "up"
+	statusDown              = "down"
+	storageErrorPublicLabel = "storage operation failed"
 )
 
 func (u *runtime) snapshot(ctx context.Context) (Snapshot, error) {
@@ -288,7 +289,9 @@ func (u *runtime) storageStatus() StorageResponse {
 	}
 	if err != nil {
 		storage.Status = "degraded"
-		storage.LastError = err.Error()
+		// Keep backend error details in server-side logs and expose only a stable,
+		// non-sensitive diagnostic through the public status payload.
+		storage.LastError = storageErrorPublicLabel
 		storage.LastErrorAt = &at
 	}
 	return storage

--- a/v3/uptime/uptime_test.go
+++ b/v3/uptime/uptime_test.go
@@ -307,6 +307,25 @@ func TestHandlerStatusJSON(t *testing.T) {
 	requireEqual(t, "ok", status.Storage.Status)
 }
 
+func TestHandlerStatusJSONRedactsStorageError(t *testing.T) {
+	t.Parallel()
+
+	const sensitiveDetail = "postgres://app_user:secret@db-internal.prod.local/customerdb"
+	u := newSnapshotUptime(newSnapshotStore())
+	u.setLastError(errors.New(sensitiveDetail))
+	app := newSnapshotApp(u)
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/uptime/api/status", nil))
+	requireNoError(t, err)
+	t.Cleanup(func() { requireNoError(t, resp.Body.Close()) })
+
+	body, err := io.ReadAll(resp.Body)
+	requireNoError(t, err)
+	requireEqual(t, fiber.StatusOK, resp.StatusCode)
+	requireNotContains(t, string(body), sensitiveDetail)
+	requireContains(t, string(body), `"last_error":"`+storageErrorPublicLabel+`"`)
+}
+
 func TestHandlerStatusHead(t *testing.T) {
 	t.Parallel()
 
@@ -676,7 +695,7 @@ func TestBuildStatusDoesNotClearRuntimeError(t *testing.T) {
 	status, err := u.buildStatus(context.Background(), store.now)
 	requireNoError(t, err)
 	requireEqual(t, "degraded", status.Storage.Status)
-	requireContains(t, status.Storage.LastError, "write heartbeat failed")
+	requireEqual(t, storageErrorPublicLabel, status.Storage.LastError)
 
 	_, lastErr := u.lastError()
 	if !errors.Is(lastErr, runtimeErr) {
@@ -1031,7 +1050,7 @@ func TestEndpointProbeFailureDoesNotClearStorageErrorWhenMaintenanceSkipped(t *t
 	status, err := u.buildStatus(context.Background(), store.now)
 	requireNoError(t, err)
 	requireEqual(t, "degraded", status.Storage.Status)
-	requireContains(t, status.Storage.LastError, "write heartbeat failed")
+	requireEqual(t, storageErrorPublicLabel, status.Storage.LastError)
 }
 
 func TestCustomIDGenerator(t *testing.T) {


### PR DESCRIPTION
### Motivation

- Public `/uptime/api/status` responses included raw backend store error strings in `storage.last_error`, which can leak sensitive hostnames, usernames, DB names, and paths.
- The endpoint is often mounted on unprotected routes, so the public API must not expose runtime error text.

### Description

- Introduce a stable public label `storageErrorPublicLabel` and update the `StorageResponse` comment to clarify `LastError` is non-sensitive.  
- Replace exposing raw `err.Error()` in the runtime storage status path by assigning the generic `storageErrorPublicLabel` in `storageStatus()` (`v3/uptime/status.go`).  
- Update unit tests to expect the sanitized label instead of raw error text and add `TestHandlerStatusJSONRedactsStorageError` to assert that a sensitive string is not present in the public JSON (`v3/uptime/uptime_test.go`).  
- Commit message: `fix(uptime): redact storage errors from status responses`.

### Testing

- Ran `go test ./...` in `v3/uptime` and the package tests passed.  
- Ran `gofmt` and `git diff --check` to ensure formatting and no whitespace issues.  
- Verified repository status after committing the change (`git status --short --branch`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71fae40fcc833397b9815fed7b827f)