### PR TITLE
feat(uptime): add dashboard favicon support

### DIFF
--- a/v3/uptime/README.md
+++ b/v3/uptime/README.md
@@ -200,7 +200,7 @@ app.Use(uptime.New(uptime.Config{
 }))
 ```
 
-Filesystem paths such as `/path/to/favicon.ico` are not supported directly.
+Filesystem paths such as `./favicon.ico` are not supported directly.
 Expose a local file through a Fiber route or static handler, then configure its
 URL. Remote favicon URLs cause each dashboard visitor's browser to contact that
 remote host, so a same-origin URL is preferred for private deployments.

--- a/v3/uptime/README.md
+++ b/v3/uptime/README.md
@@ -183,6 +183,28 @@ each request. Use Fiber's cache middleware around the uptime route if you want
 HTTP-level caching. The same snapshot payload is available at
 `UI.Path + "/api/status"` for custom dashboards.
 
+## Dashboard favicon
+
+The built-in dashboard includes an embedded favicon by default. Set
+`UI.FaviconURL` to override it with either a root-relative path served by the
+same application or an absolute HTTP(S) URL:
+
+```go
+app.Use(uptime.New(uptime.Config{
+	App:       app,
+	Store:     store,
+	ServiceID: "api",
+	UI: uptime.UIConfig{
+		FaviconURL: "/assets/favicon.svg",
+	},
+}))
+```
+
+Filesystem paths such as `/path/to/favicon.ico` are not supported directly.
+Expose a local file through a Fiber route or static handler, then configure its
+URL. Remote favicon URLs cause each dashboard visitor's browser to contact that
+remote host, so a same-origin URL is preferred for private deployments.
+
 ## Config
 
 | Property | Type | Description | Default |
@@ -202,7 +224,7 @@ HTTP-level caching. The same snapshot payload is available at
 | IDGenerator | `uptime.IDGenerator` | Custom instance ID generator. | `nil` |
 | Store | `*fiberredis.Storage` | Fiber Redis storage instance from `github.com/gofiber/storage/redis/v3`. | Required |
 | StorageKeyPrefix | `string` | Prefix for all uptime Redis keys. | `"fiber:uptime"` |
-| UI | `uptime.UIConfig` | Dashboard copy and thresholds. Threshold values are configurable in `(0, 1]`; zero uses the defaults. | Light English UI, green at `99.9%`, yellow at `99%` |
+| UI | `uptime.UIConfig` | Dashboard copy, favicon, and thresholds. `FaviconURL` accepts a root-relative path or absolute HTTP(S) URL. Threshold values are configurable in `(0, 1]`; zero uses the defaults. | Embedded favicon, light English UI, green at `99.9%`, yellow at `99%` |
 
 ### EndpointConfig
 

--- a/v3/uptime/config.go
+++ b/v3/uptime/config.go
@@ -239,7 +239,7 @@ func normalizeFaviconURL(rawURL string) (string, error) {
 	if err != nil {
 		return "", errors.New("uptime: ui favicon url is invalid")
 	}
-	if strings.HasPrefix(rawURL, "/") && !strings.HasPrefix(rawURL, "//") && parsed.Scheme == "" && parsed.Host == "" {
+	if strings.HasPrefix(rawURL, "/") && !strings.HasPrefix(rawURL, "//") && !strings.HasPrefix(rawURL, "/\\") && parsed.Scheme == "" && parsed.Host == "" {
 		return rawURL, nil
 	}
 	if (strings.EqualFold(parsed.Scheme, "http") || strings.EqualFold(parsed.Scheme, "https")) && parsed.Host != "" && parsed.User == nil {

--- a/v3/uptime/config.go
+++ b/v3/uptime/config.go
@@ -115,6 +115,10 @@ type UIConfig struct {
 	Description string
 	// Footer is shown at the bottom of the dashboard.
 	Footer string
+	// FaviconURL overrides the built-in dashboard favicon.
+	// It must be a root-relative path or an absolute HTTP(S) URL.
+	// Empty uses the built-in favicon.
+	FaviconURL string
 
 	// GreenThreshold is the minimum uptime ratio for a green day.
 	// Configurable values must be in (0, 1]; zero uses the default.
@@ -200,6 +204,11 @@ func (c Config) normalized() (Config, error) {
 	if c.UI.Footer == "" {
 		c.UI.Footer = defaultUIFooter
 	}
+	faviconURL, err := normalizeFaviconURL(c.UI.FaviconURL)
+	if err != nil {
+		return Config{}, err
+	}
+	c.UI.FaviconURL = faviconURL
 	if c.UI.GreenThreshold == 0 {
 		c.UI.GreenThreshold = defaultGreenThreshold
 	}
@@ -219,6 +228,24 @@ func (c Config) normalized() (Config, error) {
 		c.StorageKeyPrefix = defaultStorageKeyPrefix
 	}
 	return c, nil
+}
+
+func normalizeFaviconURL(rawURL string) (string, error) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return "", nil
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", errors.New("uptime: ui favicon url is invalid")
+	}
+	if strings.HasPrefix(rawURL, "/") && !strings.HasPrefix(rawURL, "//") && parsed.Scheme == "" && parsed.Host == "" {
+		return rawURL, nil
+	}
+	if (strings.EqualFold(parsed.Scheme, "http") || strings.EqualFold(parsed.Scheme, "https")) && parsed.Host != "" && parsed.User == nil {
+		return rawURL, nil
+	}
+	return "", errors.New("uptime: ui favicon url must be a root-relative path or an absolute http(s) url")
 }
 
 func normalizeEndpoints(serviceID string, endpoints []EndpointConfig, sampleInterval time.Duration) ([]EndpointConfig, error) {

--- a/v3/uptime/config.go
+++ b/v3/uptime/config.go
@@ -35,7 +35,7 @@ var (
 	// ErrMissingApp is returned when Config.App is not set.
 	ErrMissingApp = errors.New("uptime: fiber app is required")
 	// ErrInvalidFaviconURL is returned when UIConfig.FaviconURL is not a supported URL.
-	ErrInvalidFaviconURL = errors.New("uptime: ui favicon url must be a root-relative path or an absolute http(s) url")
+	ErrInvalidFaviconURL = errors.New("uptime: favicon url must be a root-relative path or an absolute http(s) url")
 )
 
 // Config defines the configuration for the uptime middleware.

--- a/v3/uptime/config.go
+++ b/v3/uptime/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	fiberredis "github.com/gofiber/storage/redis/v3"
+	"github.com/gofiber/utils/v2"
 )
 
 const (
@@ -33,6 +34,8 @@ var (
 	ErrMissingStore = errors.New("uptime: redis storage is required")
 	// ErrMissingApp is returned when Config.App is not set.
 	ErrMissingApp = errors.New("uptime: fiber app is required")
+	// ErrInvalidFaviconURL is returned when UIConfig.FaviconURL is not a supported URL.
+	ErrInvalidFaviconURL = errors.New("uptime: ui favicon url must be a root-relative path or an absolute http(s) url")
 )
 
 // Config defines the configuration for the uptime middleware.
@@ -231,21 +234,21 @@ func (c Config) normalized() (Config, error) {
 }
 
 func normalizeFaviconURL(rawURL string) (string, error) {
-	rawURL = strings.TrimSpace(rawURL)
+	rawURL = utils.TrimSpace(rawURL)
 	if rawURL == "" {
 		return "", nil
 	}
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
-		return "", errors.New("uptime: ui favicon url is invalid")
+		return "", ErrInvalidFaviconURL
 	}
 	if strings.HasPrefix(rawURL, "/") && !strings.HasPrefix(rawURL, "//") && !strings.HasPrefix(rawURL, "/\\") && parsed.Scheme == "" && parsed.Host == "" {
 		return rawURL, nil
 	}
-	if (strings.EqualFold(parsed.Scheme, "http") || strings.EqualFold(parsed.Scheme, "https")) && parsed.Host != "" && parsed.User == nil {
+	if (utils.EqualFold(parsed.Scheme, "http") || utils.EqualFold(parsed.Scheme, "https")) && parsed.Host != "" && parsed.User == nil {
 		return rawURL, nil
 	}
-	return "", errors.New("uptime: ui favicon url must be a root-relative path or an absolute http(s) url")
+	return "", ErrInvalidFaviconURL
 }
 
 func normalizeEndpoints(serviceID string, endpoints []EndpointConfig, sampleInterval time.Duration) ([]EndpointConfig, error) {

--- a/v3/uptime/dashboard.gohtml
+++ b/v3/uptime/dashboard.gohtml
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="{{ .Description }}">
+  <link rel="icon" href="{{ .FaviconURL }}">
   <title>{{ .Title }}</title>
   <style>
 :root {

--- a/v3/uptime/go.mod
+++ b/v3/uptime/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/gofiber/fiber/v3 v3.4.0
 	github.com/gofiber/storage/redis/v3 v3.5.1
+	github.com/gofiber/utils/v2 v2.4.1
 	github.com/redis/go-redis/v9 v9.21.0
 )
 
@@ -12,7 +13,6 @@ require (
 	github.com/andybalholm/brotli v1.2.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/gofiber/schema v1.8.3 // indirect
-	github.com/gofiber/utils/v2 v2.4.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.19.1 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect

--- a/v3/uptime/ui.go
+++ b/v3/uptime/ui.go
@@ -20,7 +20,7 @@ type dashboardPage struct {
 	Title       string
 	Description string
 	Footer      string
-	FaviconURL  template.URL
+	FaviconURL  any
 	APIPathJSON template.JS
 	RefreshMS   int64
 	StatusJSON  template.JS
@@ -29,9 +29,9 @@ type dashboardPage struct {
 var dashboardTemplate = template.Must(template.New("uptime").Parse(dashboardHTML))
 
 func renderDashboardHTML(config Config, status StatusResponse, apiPath string) (string, error) {
-	faviconURL := config.UI.FaviconURL
-	if faviconURL == "" {
-		faviconURL = defaultUIFaviconURL
+	var faviconURL any = config.UI.FaviconURL
+	if config.UI.FaviconURL == "" {
+		faviconURL = template.URL(defaultUIFaviconURL) // #nosec G203 -- this is the package-owned embedded favicon.
 	}
 	statusJSON, err := json.Marshal(status)
 	if err != nil {
@@ -45,7 +45,7 @@ func renderDashboardHTML(config Config, status StatusResponse, apiPath string) (
 		Title:       config.UI.Title,
 		Description: config.UI.Description,
 		Footer:      config.UI.Footer,
-		FaviconURL:  template.URL(faviconURL), // #nosec G203 -- URL scheme is validated during normalization.
+		FaviconURL:  faviconURL,
 		APIPathJSON: template.JS(string(apiPathJSON)),
 		RefreshMS:   max(int64(config.SampleInterval/time.Millisecond), 10000),
 		StatusJSON:  template.JS(string(statusJSON)),

--- a/v3/uptime/ui.go
+++ b/v3/uptime/ui.go
@@ -3,15 +3,24 @@ package uptime
 import (
 	"bytes"
 	_ "embed"
+	"encoding/base64"
 	"encoding/json"
 	"html/template"
 	"time"
 )
 
+const defaultUIFaviconSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<rect width="64" height="64" rx="14" fill="#0f172a"/>
+<path d="M8 34h13l6-17 11 32 7-20 4 5h7" fill="none" stroke="#67e8f9" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>`
+
+var defaultUIFaviconURL = "data:image/svg+xml;base64," + base64.StdEncoding.EncodeToString([]byte(defaultUIFaviconSVG))
+
 type dashboardPage struct {
 	Title       string
 	Description string
 	Footer      string
+	FaviconURL  template.URL
 	APIPathJSON template.JS
 	RefreshMS   int64
 	StatusJSON  template.JS
@@ -20,6 +29,10 @@ type dashboardPage struct {
 var dashboardTemplate = template.Must(template.New("uptime").Parse(dashboardHTML))
 
 func renderDashboardHTML(config Config, status StatusResponse, apiPath string) (string, error) {
+	faviconURL := config.UI.FaviconURL
+	if faviconURL == "" {
+		faviconURL = defaultUIFaviconURL
+	}
 	statusJSON, err := json.Marshal(status)
 	if err != nil {
 		return "", err
@@ -32,6 +45,7 @@ func renderDashboardHTML(config Config, status StatusResponse, apiPath string) (
 		Title:       config.UI.Title,
 		Description: config.UI.Description,
 		Footer:      config.UI.Footer,
+		FaviconURL:  template.URL(faviconURL), // #nosec G203 -- URL scheme is validated during normalization.
 		APIPathJSON: template.JS(string(apiPathJSON)),
 		RefreshMS:   max(int64(config.SampleInterval/time.Millisecond), 10000),
 		StatusJSON:  template.JS(string(statusJSON)),

--- a/v3/uptime/uptime_test.go
+++ b/v3/uptime/uptime_test.go
@@ -180,6 +180,15 @@ func TestConfigValidation(t *testing.T) {
 			},
 		},
 		{
+			name: "favicon url backslash authority",
+			config: Config{
+				ServiceID: "api",
+				UI: UIConfig{
+					FaviconURL: `/\example.com/favicon.svg`,
+				},
+			},
+		},
+		{
 			name: "endpoint id missing",
 			config: Config{
 				Endpoints: []EndpointConfig{{URL: "https://example.com/health"}},

--- a/v3/uptime/uptime_test.go
+++ b/v3/uptime/uptime_test.go
@@ -105,8 +105,9 @@ func TestConfigValidation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name   string
-		config Config
+		name    string
+		config  Config
+		wantErr error
 	}{
 		{name: "missing app", config: Config{ServiceID: "api"}},
 		{name: "missing service id", config: Config{}},
@@ -162,7 +163,8 @@ func TestConfigValidation(t *testing.T) {
 			},
 		},
 		{
-			name: "favicon url scheme invalid",
+			name:    "favicon url scheme invalid",
+			wantErr: ErrInvalidFaviconURL,
 			config: Config{
 				ServiceID: "api",
 				UI: UIConfig{
@@ -171,7 +173,8 @@ func TestConfigValidation(t *testing.T) {
 			},
 		},
 		{
-			name: "favicon url protocol relative",
+			name:    "favicon url protocol relative",
+			wantErr: ErrInvalidFaviconURL,
 			config: Config{
 				ServiceID: "api",
 				UI: UIConfig{
@@ -180,7 +183,8 @@ func TestConfigValidation(t *testing.T) {
 			},
 		},
 		{
-			name: "favicon url backslash authority",
+			name:    "favicon url backslash authority",
+			wantErr: ErrInvalidFaviconURL,
 			config: Config{
 				ServiceID: "api",
 				UI: UIConfig{
@@ -253,6 +257,9 @@ func TestConfigValidation(t *testing.T) {
 			}
 			_, err := tt.config.normalized()
 			requireError(t, err)
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
 		})
 	}
 }

--- a/v3/uptime/uptime_test.go
+++ b/v3/uptime/uptime_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -30,6 +31,7 @@ func TestConfigDefaults(t *testing.T) {
 	requireEqual(t, defaultUITitle, cfg.UI.Title)
 	requireEqual(t, defaultUIDescription, cfg.UI.Description)
 	requireEqual(t, defaultUIFooter, cfg.UI.Footer)
+	requireEqual(t, "", cfg.UI.FaviconURL)
 	requireEqual(t, defaultGreenThreshold, cfg.UI.GreenThreshold)
 	requireEqual(t, defaultYellowThreshold, cfg.UI.YellowThreshold)
 }
@@ -47,6 +49,30 @@ func TestConfigZeroThresholdsUseDefaults(t *testing.T) {
 
 	requireEqual(t, defaultGreenThreshold, cfg.UI.GreenThreshold)
 	requireEqual(t, defaultYellowThreshold, cfg.UI.YellowThreshold)
+}
+
+func TestConfigFaviconURLs(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"/assets/favicon.svg?v=1",
+		"http://127.0.0.1:8080/favicon.ico",
+		"https://cdn.example.com/favicon.png",
+		"HTTPS://cdn.example.com/favicon.svg",
+	}
+	for _, faviconURL := range tests {
+		faviconURL := faviconURL
+		t.Run(faviconURL, func(t *testing.T) {
+			t.Parallel()
+			cfg := normalizedTestConfig(t, Config{
+				ServiceID: "api",
+				UI: UIConfig{
+					FaviconURL: faviconURL,
+				},
+			})
+			requireEqual(t, faviconURL, cfg.UI.FaviconURL)
+		})
+	}
 }
 
 func TestConfigEndpointDefaults(t *testing.T) {
@@ -132,6 +158,24 @@ func TestConfigValidation(t *testing.T) {
 				UI: UIConfig{
 					GreenThreshold:  1,
 					YellowThreshold: 1.1,
+				},
+			},
+		},
+		{
+			name: "favicon url scheme invalid",
+			config: Config{
+				ServiceID: "api",
+				UI: UIConfig{
+					FaviconURL: "javascript:alert(1)",
+				},
+			},
+		},
+		{
+			name: "favicon url protocol relative",
+			config: Config{
+				ServiceID: "api",
+				UI: UIConfig{
+					FaviconURL: "//example.com/favicon.svg",
 				},
 			},
 		},
@@ -231,6 +275,7 @@ func TestHandlerDashboardHTML(t *testing.T) {
 	requireEqual(t, fiber.StatusOK, resp.StatusCode)
 	requireEqual(t, fiber.MIMETextHTMLCharsetUTF8, resp.Header.Get(fiber.HeaderContentType))
 	requireContains(t, bodyText, "<title>Fiber Uptime</title>")
+	requireContains(t, html.UnescapeString(bodyText), `<link rel="icon" href="`+defaultUIFaviconURL+`">`)
 	requireContains(t, bodyText, `const apiPath = "/uptime/api/status";`)
 	requireContains(t, bodyText, `id="summary-services"`)
 	requireContains(t, bodyText, `id="summary-up"`)
@@ -249,6 +294,28 @@ func TestHandlerDashboardHTML(t *testing.T) {
 	requireNotContains(t, bodyText, `data-background=`)
 	requireNotContains(t, bodyText, `lang-toggle`)
 	requireNotContains(t, bodyText, `theme-toggle`)
+}
+
+func TestHandlerDashboardCustomFaviconURL(t *testing.T) {
+	t.Parallel()
+
+	const faviconURL = "/assets/favicon.svg?v=1"
+	up := newSnapshotUptimeWithConfig(newSnapshotStore(), Config{
+		ServiceID:      "api",
+		SampleInterval: time.Second,
+		UI: UIConfig{
+			FaviconURL: faviconURL,
+		},
+	})
+	app := newSnapshotApp(up)
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/uptime", nil))
+	requireNoError(t, err)
+	t.Cleanup(func() { requireNoError(t, resp.Body.Close()) })
+
+	body, err := io.ReadAll(resp.Body)
+	requireNoError(t, err)
+	requireContains(t, string(body), `<link rel="icon" href="/assets/favicon.svg?v=1">`)
 }
 
 func TestHandlerHeadDashboard(t *testing.T) {

--- a/v3/uptime/uptime_test.go
+++ b/v3/uptime/uptime_test.go
@@ -327,6 +327,16 @@ func TestHandlerDashboardCustomFaviconURL(t *testing.T) {
 	requireContains(t, string(body), `<link rel="icon" href="/assets/favicon.svg?v=1">`)
 }
 
+func TestRenderDashboardHTMLSanitizesCustomFaviconURL(t *testing.T) {
+	t.Parallel()
+
+	body, err := renderDashboardHTML(Config{
+		UI: UIConfig{FaviconURL: "javascript:alert(1)"},
+	}, StatusResponse{}, "/uptime/api/status")
+	requireNoError(t, err)
+	requireContains(t, body, `<link rel="icon" href="#ZgotmplZ">`)
+}
+
 func TestHandlerHeadDashboard(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adds favicon support to the uptime dashboard.

- Provides an embedded default favicon.
- Adds `UIConfig.FaviconURL` for root-relative or absolute HTTP(S) URLs.
- Validates custom favicon URLs and rejects unsupported schemes.
- Adds tests and documentation for default, local, and remote favicons.

<img width="153" height="57" alt="image" src="https://github.com/user-attachments/assets/59b261d1-cba1-4fde-93a5-09618b5c6290" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a default favicon to the built-in dashboard.
  * Added support for configuring a custom favicon URL.
  * Supports root-relative paths and absolute HTTP(S) URLs.
  * Rejects invalid or unsafe favicon URLs.
  * Displays the selected favicon in the dashboard browser tab.

* **Documentation**
  * Documented default favicon behavior, supported formats, and customization options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->