### PR TITLE
fix(prometheus): bound in-flight method label cardinality

### DIFF
--- a/v3/prometheus/prometheus.go
+++ b/v3/prometheus/prometheus.go
@@ -615,7 +615,7 @@ func (m *middleware) instrument(ctx fiber.Ctx) error {
 	method := ctx.Method()
 
 	if m.requestInFlight != nil {
-		inFlight := m.requestInFlight.WithLabelValues(method)
+		inFlight := m.requestInFlight.WithLabelValues(inFlightMethod(method))
 		inFlight.Inc()
 		defer inFlight.Dec()
 	}
@@ -752,6 +752,21 @@ func (m *middleware) instrument(ctx fiber.Ctx) error {
 	}
 
 	return nil
+}
+
+// inFlightMethod bounds the gauge's method label to Fiber's finite set of
+// built-in methods. Unlike the route metrics, this gauge is created before
+// routing, so retaining an arbitrary request method here would let remote
+// clients create an unbounded number of zero-valued time series.
+func inFlightMethod(method string) string {
+	switch method {
+	case fiber.MethodGet, fiber.MethodHead, fiber.MethodPost, fiber.MethodPut,
+		fiber.MethodDelete, fiber.MethodConnect, fiber.MethodOptions,
+		fiber.MethodTrace, fiber.MethodPatch, fiber.MethodQuery:
+		return method
+	default:
+		return "OTHER"
+	}
 }
 
 // exemplarFor returns the trace exemplar for this request, or nil when exemplars

--- a/v3/prometheus/prometheus.go
+++ b/v3/prometheus/prometheus.go
@@ -64,6 +64,10 @@ type dynamicLabel struct {
 	fn   func(fiber.Ctx) string
 }
 
+// otherMethodLabel is the single method series every request the app is not
+// configured to route collapses onto - see inFlightMethod.
+const otherMethodLabel = "OTHER"
+
 // reservedLabels are the names Labels and DynamicLabels may not use: the four set
 // here, plus "le", which Prometheus keeps for histogram bucket bounds.
 var reservedLabels = map[string]struct{}{
@@ -615,7 +619,7 @@ func (m *middleware) instrument(ctx fiber.Ctx) error {
 	method := ctx.Method()
 
 	if m.requestInFlight != nil {
-		inFlight := m.requestInFlight.WithLabelValues(inFlightMethod(method))
+		inFlight := m.requestInFlight.WithLabelValues(inFlightMethod(ctx.App().Config().RequestMethods, method))
 		inFlight.Inc()
 		defer inFlight.Dec()
 	}
@@ -754,19 +758,18 @@ func (m *middleware) instrument(ctx fiber.Ctx) error {
 	return nil
 }
 
-// inFlightMethod bounds the gauge's method label to Fiber's finite set of
-// built-in methods. Unlike the route metrics, this gauge is created before
-// routing, so retaining an arbitrary request method here would let remote
-// clients create an unbounded number of zero-valued time series.
-func inFlightMethod(method string) string {
-	switch method {
-	case fiber.MethodGet, fiber.MethodHead, fiber.MethodPost, fiber.MethodPut,
-		fiber.MethodDelete, fiber.MethodConnect, fiber.MethodOptions,
-		fiber.MethodTrace, fiber.MethodPatch, fiber.MethodQuery:
+// inFlightMethod bounds the gauge's method label to the finite set of methods the
+// app is configured to route - Config.RequestMethods, which Fiber fills with its
+// built-ins when the caller leaves it unset, and which an app serving WebDAV or
+// another extension has already extended. Unlike the route metrics, this gauge is
+// created before routing, so retaining an arbitrary request method here would let
+// remote clients create an unbounded number of zero-valued time series; anything
+// the app cannot route - Fiber answers those with 501 - shares one series instead.
+func inFlightMethod(configured []string, method string) string {
+	if slices.Contains(configured, method) {
 		return method
-	default:
-		return "OTHER"
 	}
+	return otherMethodLabel
 }
 
 // exemplarFor returns the trace exemplar for this request, or nil when exemplars

--- a/v3/prometheus/prometheus_test.go
+++ b/v3/prometheus/prometheus_test.go
@@ -321,6 +321,21 @@ func TestInFlightGaugeIsBalanced(t *testing.T) {
 	}
 }
 
+func TestInFlightMethodCardinalityIsBounded(t *testing.T) {
+	for i := range 1000 {
+		method := "ATTACK" + strconv.Itoa(i)
+		if got := inFlightMethod(method); got != "OTHER" {
+			t.Fatalf("expected arbitrary method %q to use OTHER, got %q", method, got)
+		}
+	}
+
+	for _, method := range fiber.DefaultMethods {
+		if got := inFlightMethod(method); got != method {
+			t.Fatalf("expected built-in method %q to be preserved, got %q", method, got)
+		}
+	}
+}
+
 func TestCustomHistogramBuckets(t *testing.T) {
 	cfg := Config{
 		RequestDurationBuckets: []float64{0.1, 0.2},

--- a/v3/prometheus/prometheus_test.go
+++ b/v3/prometheus/prometheus_test.go
@@ -324,15 +324,44 @@ func TestInFlightGaugeIsBalanced(t *testing.T) {
 func TestInFlightMethodCardinalityIsBounded(t *testing.T) {
 	for i := range 1000 {
 		method := "ATTACK" + strconv.Itoa(i)
-		if got := inFlightMethod(method); got != "OTHER" {
+		if got := inFlightMethod(fiber.DefaultMethods, method); got != "OTHER" {
 			t.Fatalf("expected arbitrary method %q to use OTHER, got %q", method, got)
 		}
 	}
 
 	for _, method := range fiber.DefaultMethods {
-		if got := inFlightMethod(method); got != method {
+		if got := inFlightMethod(fiber.DefaultMethods, method); got != method {
 			t.Fatalf("expected built-in method %q to be preserved, got %q", method, got)
 		}
+	}
+}
+
+// TestInFlightMethodKeepsConfiguredMethods covers an app that extends Fiber's
+// method set: a method it routes has to keep its own series, so the gauge stays
+// joinable with the metric families that label the raw method.
+func TestInFlightMethodKeepsConfiguredMethods(t *testing.T) {
+	methods := append(slices.Clone(fiber.DefaultMethods), "PROPFIND")
+
+	if got := inFlightMethod(methods, "PROPFIND"); got != "PROPFIND" {
+		t.Fatalf("expected configured method PROPFIND to be preserved, got %q", got)
+	}
+	if got := inFlightMethod(methods, "PROPPATCH"); got != "OTHER" {
+		t.Fatalf("expected unconfigured method PROPPATCH to use OTHER, got %q", got)
+	}
+
+	app := fiber.New(fiber.Config{RequestMethods: methods})
+	app.Use(New(Config{}))
+	app.Add([]string{"PROPFIND"}, "/dav", func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	if _, err := app.Test(httptest.NewRequest("PROPFIND", "/dav", nil), noTimeoutConfig); err != nil {
+		t.Fatalf("requesting /dav: %v", err)
+	}
+
+	metrics := getMetrics(t, app, "")
+	if !strings.Contains(metrics, "http_requests_in_progress{method=\"PROPFIND\"}") {
+		t.Fatalf("expected an in-flight series for PROPFIND, got %q", metrics)
 	}
 }
 


### PR DESCRIPTION
### Motivation

- The in-flight Prometheus gauge was labeled with the raw, attacker-controlled HTTP method, allowing remote clients to create an unbounded number of zero-valued time series and causing resource/DoS risk. The change bounds that cardinality.

### Description

- Use a normalized label when creating the in-flight gauge child by replacing direct `ctx.Method()` usage with `inFlightMethod(method)` in `v3/prometheus/prometheus.go`.
- Add `inFlightMethod` which preserves Fiber's built-in methods and collapses all other method tokens to a constant `"OTHER"` series to prevent unbounded label cardinality. (New helper in `v3/prometheus/prometheus.go`.)
- Add `TestInFlightMethodCardinalityIsBounded` to `v3/prometheus/prometheus_test.go` to assert arbitrary methods map to `OTHER` and built-in methods remain unchanged.
- Preserve the existing increment/decrement behavior for the in-flight gauge so runtime semantics remain unchanged other than label normalization.

### Testing

- Ran `go test ./...` and all tests passed.
- Ran the focused tests `go test -run 'TestInFlight(GaugeIsBalanced|MethodCardinalityIsBounded)$' .` and they passed, confirming both the in-flight gauge balancing and the new cardinality bounding behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75e9a955bc8333ab88ac339a066460)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request metrics by grouping unknown HTTP methods under a single `OTHER` category.
  * Preserved separate tracking for recognized HTTP methods, preventing excessive metric label growth.

* **Tests**
  * Added coverage to verify bounded method cardinality and correct handling of known and unknown methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->