### PR TITLE
fix(prometheus): fail closed when Config.Next panics

### DIFF
--- a/v3/prometheus/README.md
+++ b/v3/prometheus/README.md
@@ -254,8 +254,10 @@ the sample is dropped, the response is unaffected, and the drop is reported to
 a line per request would funnel every connection through the log sink. The
 middleware cannot do better than drop it, because these run after the handler
 chain has unwound, past any `recover` the application mounted. `Config.Next` is
-guarded the same way and treated as having returned false. Guard your type
-assertions rather than relying on either.
+guarded the same way, but treated as having returned true: the middleware stands
+aside, leaving the request — `MetricsPath` included — to the rest of the chain,
+rather than serving an endpoint the panicking filter may have meant to withhold.
+Guard your type assertions rather than relying on either.
 
 ### Filtering
 

--- a/v3/prometheus/README.md
+++ b/v3/prometheus/README.md
@@ -63,7 +63,7 @@ prometheus.New(config ...prometheus.Config) fiber.Handler
 | SkipStatusCodes | `[]int` | Response status codes excluded from metrics. Codes are three digits; anything else panics. | `nil` |
 | SkipStatusClasses | `[]string` | Status classes excluded from metrics, `"1xx"` through `"5xx"` or `"unknown"`. Anything else panics. | `nil` |
 | DynamicLabels | `map[string]func(fiber.Ctx) string` | Extra labels computed per request. Names follow the same rules as `Labels`. A panicking function drops the sample. | `nil` |
-| Next | `func(fiber.Ctx) bool` | Skips the middleware when it returns true, including for `MetricsPath`. A panicking function is read as false. | `nil` |
+| Next | `func(fiber.Ctx) bool` | Skips the middleware when it returns true, including for `MetricsPath`. A panicking function is read as true. | `nil` |
 
 ## Default Config
 

--- a/v3/prometheus/config.go
+++ b/v3/prometheus/config.go
@@ -180,7 +180,7 @@ type Config struct {
 	DynamicLabels map[string]func(fiber.Ctx) string
 
 	// Next skips the middleware when it returns true, including for MetricsPath, and
-	// the chain's error is then returned unchanged. A panic is read as false and
+	// the chain's error is then returned unchanged. A panic is read as true and
 	// reported once to MetricsErrorLog. Optional. Default: nil.
 	Next func(fiber.Ctx) bool
 }

--- a/v3/prometheus/prometheus.go
+++ b/v3/prometheus/prometheus.go
@@ -580,16 +580,17 @@ func (m *middleware) handle(ctx fiber.Ctx) error {
 }
 
 // skipRequested asks Config.Next whether to stand aside, reading a panic there as
-// "no". It runs before the handler chain, so an escaping panic would reach the
-// connection goroutine that neither fasthttp nor Fiber guards.
+// "yes". It runs before the handler chain, so an escaping panic would reach the
+// connection goroutine that neither fasthttp nor Fiber guards. Standing aside also
+// prevents a panic from accidentally exposing the metrics endpoint.
 func (m *middleware) skipRequested(ctx fiber.Ctx) (skip bool) {
 	defer func() {
 		if r := recover(); r != nil {
-			skip = false
+			skip = true
 			m.reportNextPanic.Do(func() {
 				if m.errorLog != nil {
 					m.errorLog.Println("prometheus middleware: Config.Next panicked; "+
-						"instrumenting the request anyway, reported only once:", r)
+						"skipping the middleware, reported only once:", r)
 				}
 			})
 		}

--- a/v3/prometheus/prometheus_test.go
+++ b/v3/prometheus/prometheus_test.go
@@ -983,6 +983,25 @@ func TestNextSkipsMetricsEndpoint(t *testing.T) {
 	}
 }
 
+func TestPanickingNextSkipsMetricsEndpoint(t *testing.T) {
+	app := newAppWithMiddleware(Config{
+		Next: func(_ fiber.Ctx) bool {
+			panic("bad request data")
+		},
+	}, "")
+	app.Get("/metrics", func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusUnauthorized)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/metrics", nil), noTimeoutConfig)
+	if err != nil {
+		t.Fatalf("unexpected request error: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Fatalf("expected a Next panic to leave the metrics endpoint gated, got status %d", resp.StatusCode)
+	}
+}
+
 func TestMetricsPathConfig(t *testing.T) {
 	app := newAppWithMiddleware(Config{MetricsPath: "internal/metrics"}, "")
 	app.Get("/hello", func(c fiber.Ctx) error {
@@ -4024,7 +4043,8 @@ func TestPanickingDynamicLabelIsReportedOnce(t *testing.T) {
 
 // TestPanickingNextIsContained covers a Config.Next that panics. It runs before the
 // handler chain, so nothing downstream can catch it and the panic would reach the
-// connection goroutine and take the process with it.
+// connection goroutine and take the process with it. The middleware stands aside
+// because that is also the safe default for its potentially sensitive endpoint.
 func TestPanickingNextIsContained(t *testing.T) {
 	logger := &recordingLogger{}
 
@@ -4044,16 +4064,10 @@ func TestPanickingNextIsContained(t *testing.T) {
 			t.Fatalf("unexpected request error: %v", err)
 		}
 		if resp.StatusCode != fiber.StatusOK {
-			t.Fatalf("expected the request to be served, got %d", resp.StatusCode)
+			t.Fatalf("expected the downstream handler to serve the request, got %d", resp.StatusCode)
 		}
 	}
 
-	// Undecidable means instrument: dropping the sample would hide the traffic
-	// on top of hiding the fault.
-	metrics := getMetrics(t, app, "")
-	if !strings.Contains(metrics, `http_requests_total{method="GET",path="/hello",status_code="200"} 3`) {
-		t.Fatalf("expected the requests to be instrumented anyway, got %q", metrics)
-	}
 	if lines := logger.count(); lines != 1 {
 		t.Fatalf("expected the repeated panic to be reported once, got %d lines", lines)
 	}
@@ -4068,7 +4082,10 @@ func TestPanickingNextAndLabelAreReportedSeparately(t *testing.T) {
 	app := newAppWithMiddleware(Config{
 		MetricsErrorLog: logger,
 		Next: func(c fiber.Ctx) bool {
-			return c.Locals("skip").(bool)
+			if c.Path() == "/next" {
+				panic("next")
+			}
+			return false
 		},
 		DynamicLabels: map[string]func(fiber.Ctx) string{
 			"tenant": func(c fiber.Ctx) string { return c.Locals("tenant").(string) },
@@ -4078,9 +4095,8 @@ func TestPanickingNextAndLabelAreReportedSeparately(t *testing.T) {
 		return c.SendString("hi")
 	})
 
-	for range 3 {
-		get(t, app, "/hello")
-	}
+	get(t, app, "/next")
+	get(t, app, "/hello")
 
 	if lines := logger.count(); lines != 2 {
 		t.Fatalf("expected each fault to be reported once, got %d lines", lines)


### PR DESCRIPTION
### Motivation

- A recovered panic in `Config.Next` was previously treated as `false`, which could let the middleware serve `MetricsPath` and bypass downstream authentication, causing information disclosure or auth bypass for `/metrics`.
- The change aims to make the safe choice by default for a potentially sensitive endpoint: a panic in `Next` should cause the middleware to stand aside (fail closed) so downstream handlers remain responsible for the request.

### Description

- Treat a panic from `Config.Next` as `skip = true` in `skipRequested`, so the middleware stands aside instead of instrumenting or serving the metrics endpoint. (`v3/prometheus/prometheus.go`)
- Update the panic log text to reflect that the middleware is being skipped rather than instrumenting the request. (`v3/prometheus/prometheus.go`)
- Update documentation to state that a panicking `Next` is read as `true` (i.e. the middleware is skipped). (`v3/prometheus/config.go`, `v3/prometheus/README.md`)
- Add `TestPanickingNextSkipsMetricsEndpoint` and adjust related tests to assert the new fail-closed behavior and that separate faults are reported independently. (`v3/prometheus/prometheus_test.go`)

### Testing

- Ran package tests with `go test ./...` inside `v3/prometheus` and the test suite passed, including the new `TestPanickingNextSkipsMetricsEndpoint` and the updated panic-reporting tests. 
- Formatting ensured with `gofmt -w` on modified files and no test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75ec1e2b08833388eabfe4f6f9d1bb)