### PR TITLE
fix(prometheus): honor ConfigDefault in zero-argument New

### DIFF
--- a/v3/prometheus/config.go
+++ b/v3/prometheus/config.go
@@ -191,8 +191,9 @@ var (
 	defaultResponseSizeBuckets    = []float64{256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 5242880}
 )
 
-// ConfigDefault holds the default middleware configuration. Copy it as a starting
-// point and treat it as read-only: the bucket slices are shared with every copy.
+// ConfigDefault holds the default middleware configuration. New uses it when no
+// Config is supplied. Copy it as a starting point and treat its bucket slices as
+// read-only because they are shared with every copy.
 var ConfigDefault = Config{
 	Namespace:           "http",
 	MetricsPath:         "/metrics",
@@ -219,9 +220,9 @@ func cloneBuckets(supplied, defaults []float64) []float64 {
 
 // configDefault fills in the defaults and copies the two things that outlive the
 // call: the bucket bounds, which client_golang aliases, and Labels, which New
-// writes "service" into. A missing config is the zero config.
+// writes "service" into.
 func configDefault(config ...Config) Config {
-	var cfg Config
+	cfg := ConfigDefault
 	if len(config) > 0 {
 		cfg = config[0]
 	}

--- a/v3/prometheus/config.go
+++ b/v3/prometheus/config.go
@@ -191,9 +191,12 @@ var (
 	defaultResponseSizeBuckets    = []float64{256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 5242880}
 )
 
-// ConfigDefault holds the default middleware configuration. New uses it when no
-// Config is supplied. Copy it as a starting point and treat its bucket slices as
-// read-only because they are shared with every copy.
+// ConfigDefault holds the default middleware configuration. New reads it when no
+// Config is supplied, so a package-level edit - a Next gating the metrics
+// endpoint, say - reaches the argument-less call. The bucket fields are the one
+// exception: they are shared with every copy taken from here, so an argument-less
+// New takes its bounds from the package's own arrays rather than from whatever
+// those fields now hold. Pass a Config to choose different buckets.
 var ConfigDefault = Config{
 	Namespace:           "http",
 	MetricsPath:         "/metrics",
@@ -225,6 +228,16 @@ func configDefault(config ...Config) Config {
 	cfg := ConfigDefault
 	if len(config) > 0 {
 		cfg = config[0]
+	} else {
+		// ConfigDefault is exported, and its bucket slices are shared with every
+		// copy a caller made from it, so one bound edited in place on any of those
+		// copies is a bound edited here. Dropping them sends the fallback below to
+		// the private arrays, so that "no config" keeps meaning the package
+		// defaults - a caller who edited one into a non-increasing sequence gets a
+		// panic on their own New, not on everyone else's.
+		cfg.RequestDurationBuckets = nil
+		cfg.RequestSizeBuckets = nil
+		cfg.ResponseSizeBuckets = nil
 	}
 
 	// Trimmed and cloned: this becomes a const label on every family, so a trailing

--- a/v3/prometheus/prometheus_test.go
+++ b/v3/prometheus/prometheus_test.go
@@ -2055,6 +2055,28 @@ func TestNewWithoutConfigUsesDefaults(t *testing.T) {
 	}
 }
 
+// TestNewWithoutConfigHonorsConfigDefault ensures package-level defaults such
+// as an access-control gate are not discarded by the argument-less call.
+func TestNewWithoutConfigHonorsConfigDefault(t *testing.T) {
+	original := ConfigDefault
+	ConfigDefault.Next = func(fiber.Ctx) bool { return true }
+	t.Cleanup(func() { ConfigDefault = original })
+
+	app := fiber.New()
+	app.Use(New())
+	app.Get("/metrics", func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusForbidden)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/metrics", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != fiber.StatusForbidden {
+		t.Fatalf("expected ConfigDefault.Next to pass the scrape downstream, got status %d", resp.StatusCode)
+	}
+}
+
 // nilRouteCtx reports a match without exposing a route, which DefaultCtx never
 // does but a Ctx supplied through fiber.NewWithCustomCtx may.
 type nilRouteCtx struct {

--- a/v3/prometheus/prometheus_test.go
+++ b/v3/prometheus/prometheus_test.go
@@ -3815,6 +3815,14 @@ func TestConfigDefaultBucketsAreNotShared(t *testing.T) {
 	if resolved.RequestDurationBuckets[0] != want {
 		t.Fatalf("expected the defaults to survive, got %v", resolved.RequestDurationBuckets[0])
 	}
+
+	// The argument-less path starts from ConfigDefault so that a Next set there
+	// still gates the endpoint, which puts the edited slice back in reach: the
+	// bounds are no longer increasing, so a New that took them would panic.
+	if resolved := configDefault(); resolved.RequestDurationBuckets[0] != want {
+		t.Fatalf("expected the defaults to survive the argument-less call, got %v", resolved.RequestDurationBuckets[0])
+	}
+	New()
 }
 
 // TestRoutePatternTrailingSlashIsTrimmed pins the trimming that lets a SkipURIs


### PR DESCRIPTION
### Motivation
- A recent change made the zero-argument `New()` start from a zero `Config` and only copy a small set of defaults, which caused package-level mutations to the exported `ConfigDefault` (notably `ConfigDefault.Next`) to be ignored and allowed the middleware to serve the unauthenticated `/metrics` endpoint directly. 
- The intent of this change is to restore the previous behavior where `New()` without arguments inherits `ConfigDefault` so callers that adjust global defaults (for example to gate access) keep having effect.

### Description
- Initialize the internal defaulting path from the exported `ConfigDefault` by changing `configDefault` to start with `cfg := ConfigDefault` when no explicit `Config` is supplied. 
- Clarify comments to document that `New()` uses `ConfigDefault` when no argument is provided and that bucket slices are shared/read-only. 
- Add a regression test `TestNewWithoutConfigHonorsConfigDefault` that mutates `ConfigDefault.Next` and verifies a `/metrics` request is passed to the downstream handler (expecting a forbidden response) rather than exposing Prometheus metrics. 
- Preserve the defensive copying behavior for buckets and labels so runtime safety and existing behavior remain unchanged.

### Testing
- Ran the package test suite with `go test ./...` from `v3/prometheus` and the tests passed. 
- Ran the focused test selection `go test ./... -run 'TestNewWithoutConfig(UsesDefaults|HonorsConfigDefault)$'` in `v3/prometheus` and the targeted tests passed. 
- Applied `gofmt -w` to the changed files as a formatting check and the workspace was updated cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75eca33ee88333aece059461f581f8)