### PR TITLE
fix(prometheus): validate wrapped Registerer/Gatherer pairs to prevent silent metric omission

### DIFF
--- a/v3/prometheus/README.md
+++ b/v3/prometheus/README.md
@@ -348,12 +348,12 @@ the same metrics source (for example, a `*prometheus.Registry`). Supplying only
 one that does not implement the other interface panics during initialization so
 metrics are not silently dropped.
 
-Supplying both is trusted, because that is how you pair a wrapper such as
-`prometheus.WrapRegistererWithPrefix` with the registry it wraps — and such a
-wrapper is not itself a `Gatherer`, so there is nothing to compare it against.
-Only a pair that is provably distinct, two different `*prometheus.Registry`
-values, is rejected. Pairing a wrapper with an unrelated registry is accepted
-and scrapes will return nothing.
+Supplying both also supports pairing a wrapper such as
+`prometheus.WrapRegistererWithPrefix` with the registry it wraps. Because such
+a wrapper is not itself a `Gatherer`, the middleware temporarily registers a
+probe collector and verifies that the configured Gatherer can see it. A
+mismatched pair panics during initialization rather than silently omitting the
+middleware's metrics from scrapes.
 
 ```go
 registry := prometheus.NewRegistry()

--- a/v3/prometheus/README.md
+++ b/v3/prometheus/README.md
@@ -350,20 +350,23 @@ metrics are not silently dropped.
 
 Supplying both also supports pairing a wrapper such as
 `prometheus.WrapRegistererWithPrefix` with the registry it wraps. Such a wrapper
-is not itself a `Gatherer`, so it is unwrapped — through as many nested
-client_golang wrappers as it has — down to the `Registerer` it hands
-registrations to, and that is what the `Gatherer` is compared against. Pairing a
-wrapper with an unrelated registry panics during initialization rather than
-silently omitting the middleware's metrics from scrapes.
+is not itself a `Gatherer`, so it is unwrapped — through its nested
+client_golang wrappers — down to the `Registerer` it hands registrations to, and
+that is what the `Gatherer` is compared against. A wrapper the walk resolves to
+an unrelated registry panics during initialization rather than silently omitting
+the middleware's metrics from scrapes.
 
-The comparison is deliberately one of provable inequality, and two shapes stay
-undecidable and are therefore accepted. A `Registerer` that is neither a
-`Gatherer` nor a client_golang wrapper keeps its destination to itself — reading
-any type that merely holds another `Registerer` as a delegation chain would
-reject valid pairings. And a `Gatherer` that hides its source behind a wrapper,
-`prometheus.GathererFunc(other.Gather)` for instance, is opaque in the same way
-even when the `Registerer` is a plain registry. Neither is checked, so pairing
-either with an unrelated source still scrapes nothing.
+The comparison is deliberately one of provable inequality, so a pair the walk
+cannot resolve is accepted, and three shapes are undecidable. A `Registerer`
+that is neither a `Gatherer` nor a client_golang wrapper keeps its destination
+to itself — reading any type that merely holds another `Registerer` as a
+delegation chain would reject valid pairings. A `Gatherer` that hides its source
+behind a wrapper, `prometheus.GathererFunc(other.Gather)` for instance, is
+opaque in the same way even when the `Registerer` is a plain registry. And the
+walk itself is depth-bounded, so a chain of wrappers longer than the bound ends
+undecided rather than resolved — a bound no real configuration reaches, since
+wrappers are nested by hand. None of the three is checked, so pairing one with
+an unrelated source still scrapes nothing.
 
 ```go
 registry := prometheus.NewRegistry()

--- a/v3/prometheus/README.md
+++ b/v3/prometheus/README.md
@@ -349,11 +349,21 @@ one that does not implement the other interface panics during initialization so
 metrics are not silently dropped.
 
 Supplying both also supports pairing a wrapper such as
-`prometheus.WrapRegistererWithPrefix` with the registry it wraps. Because such
-a wrapper is not itself a `Gatherer`, the middleware temporarily registers a
-probe collector and verifies that the configured Gatherer can see it. A
-mismatched pair panics during initialization rather than silently omitting the
-middleware's metrics from scrapes.
+`prometheus.WrapRegistererWithPrefix` with the registry it wraps. Such a wrapper
+is not itself a `Gatherer`, so it is unwrapped — through as many nested
+client_golang wrappers as it has — down to the `Registerer` it hands
+registrations to, and that is what the `Gatherer` is compared against. Pairing a
+wrapper with an unrelated registry panics during initialization rather than
+silently omitting the middleware's metrics from scrapes.
+
+The comparison is deliberately one of provable inequality, and two shapes stay
+undecidable and are therefore accepted. A `Registerer` that is neither a
+`Gatherer` nor a client_golang wrapper keeps its destination to itself — reading
+any type that merely holds another `Registerer` as a delegation chain would
+reject valid pairings. And a `Gatherer` that hides its source behind a wrapper,
+`prometheus.GathererFunc(other.Gather)` for instance, is opaque in the same way
+even when the `Registerer` is a plain registry. Neither is checked, so pairing
+either with an unrelated source still scrapes nothing.
 
 ```go
 registry := prometheus.NewRegistry()

--- a/v3/prometheus/config.go
+++ b/v3/prometheus/config.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/utils/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -243,13 +244,13 @@ func configDefault(config ...Config) Config {
 	// Trimmed and cloned: this becomes a const label on every family, so a trailing
 	// newline would leave the metrics matching no dashboard, and TrimSpace returns a
 	// view that would pin whatever blob the value was sliced out of.
-	cfg.ServiceName = strings.Clone(strings.TrimSpace(cfg.ServiceName))
+	cfg.ServiceName = strings.Clone(utils.TrimSpace(cfg.ServiceName))
 
 	// Trimmed like the others: these prefix every metric name, and under the
 	// default UTF-8 validation scheme a stray newline is accepted rather than
 	// rejected, so it silently renames all six families instead of failing.
-	cfg.Namespace = strings.TrimSpace(cfg.Namespace)
-	cfg.Subsystem = strings.TrimSpace(cfg.Subsystem)
+	cfg.Namespace = utils.TrimSpace(cfg.Namespace)
+	cfg.Subsystem = utils.TrimSpace(cfg.Subsystem)
 
 	if cfg.Namespace == "" {
 		cfg.Namespace = ConfigDefault.Namespace
@@ -258,7 +259,7 @@ func configDefault(config ...Config) Config {
 	// Trimmed like the list-valued options, so that a value carrying the
 	// trailing newline an environment variable or mounted secret picks up does
 	// not silently make the scrape endpoint unreachable.
-	cfg.MetricsPath = strings.TrimSpace(cfg.MetricsPath)
+	cfg.MetricsPath = utils.TrimSpace(cfg.MetricsPath)
 	if cfg.MetricsPath == "" {
 		cfg.MetricsPath = ConfigDefault.MetricsPath
 	} else {
@@ -274,7 +275,7 @@ func configDefault(config ...Config) Config {
 	// Trimmed for the same reason as MetricsPath: a value carrying a trailing
 	// newline would become part of every unmatched series' label, valid UTF-8
 	// and matched by no dashboard, recording rule or SkipURIs entry.
-	cfg.UnmatchedRouteLabel = strings.TrimSpace(cfg.UnmatchedRouteLabel)
+	cfg.UnmatchedRouteLabel = utils.TrimSpace(cfg.UnmatchedRouteLabel)
 	if cfg.UnmatchedRouteLabel == "" {
 		cfg.UnmatchedRouteLabel = ConfigDefault.UnmatchedRouteLabel
 	} else {

--- a/v3/prometheus/prometheus.go
+++ b/v3/prometheus/prometheus.go
@@ -171,7 +171,7 @@ func New(config ...Config) fiber.Handler {
 	for _, entry := range cfg.DisabledMetrics {
 		// Trimmed and blank-skipped as the skip lists are, so that splitting an
 		// environment variable on "," works whether it is unset or padded.
-		metric := Metric(strings.TrimSpace(string(entry)))
+		metric := utils.TrimSpace(entry)
 		if metric == "" {
 			continue
 		}
@@ -306,7 +306,7 @@ func (m *middleware) resolveFilters(cfg Config) bool {
 	skipAll := false
 
 	for _, path := range cfg.SkipURIs {
-		path = strings.TrimSpace(path)
+		path = utils.TrimSpace(path)
 		if path == "" {
 			continue
 		}
@@ -316,7 +316,7 @@ func (m *middleware) resolveFilters(cfg Config) bool {
 		// must not collide. Deliberately not a "continue": an entry may mean both.
 		normalizedEntry := normalizePath(path)
 		if normalizedEntry == m.unmatchedLabel ||
-			strings.TrimRight(normalizedEntry, "*") == m.unmatchedLabel {
+			utils.TrimRight(normalizedEntry, '*') == m.unmatchedLabel {
 			m.recordUnmatched = false
 		}
 
@@ -338,7 +338,7 @@ func (m *middleware) resolveFilters(cfg Config) bool {
 		// Trailing stars are stripped as a group, so that the "/**" an operator
 		// reaches for out of glob habit means what "/*" means rather than
 		// quietly excluding almost nothing.
-		prefix := strings.TrimRight(normalized, "*")
+		prefix := utils.TrimRight(normalized, '*')
 		if prefix == normalized {
 			continue
 		}
@@ -370,7 +370,7 @@ func (m *middleware) resolveFilters(cfg Config) bool {
 	}
 
 	for _, class := range cfg.SkipStatusClasses {
-		normalized := strings.ToLower(strings.TrimSpace(class))
+		normalized := strings.ToLower(utils.TrimSpace(class))
 		if normalized == "" {
 			continue
 		}

--- a/v3/prometheus/prometheus.go
+++ b/v3/prometheus/prometheus.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -56,8 +55,6 @@ type middleware struct {
 	records           bool
 	observes          bool
 }
-
-var registryProbeID atomic.Uint64
 
 // dynamicLabel binds a configured label name to the function producing its
 // value. The slice held by middleware is sorted by name so that the label order
@@ -545,60 +542,105 @@ func resolveRegistry(cfg Config) (prometheus.Registerer, prometheus.Gatherer) {
 
 	// Both were supplied. Wrapping Registerers - WrapRegistererWith and friends - are
 	// not Gatherers, so requiring one would reject the very pairing the panic above
-	// recommends. Only provably distinct pairs are rejected.
-	if regGatherer, ok := registerer.(prometheus.Gatherer); ok {
-		if differentSource(regGatherer, gatherer) {
-			panic("prometheus middleware: Registerer and Gatherer must reference the same metrics source")
+	// recommends. Such a wrapper is unwrapped to the Registerer it hands
+	// registrations to, and that is what gets compared. Only provably distinct
+	// pairs are rejected.
+	source := reflect.ValueOf(registerer)
+	if _, ok := registerer.(prometheus.Gatherer); !ok {
+		unwrapped, ok := unwrapRegisterer(source)
+		if !ok {
+			return registerer, gatherer
 		}
-	} else if !sameRegistryThroughProbe(registerer, gatherer) {
+		source = unwrapped
+	}
+
+	if differentSource(source, reflect.ValueOf(gatherer)) {
 		panic("prometheus middleware: Registerer and Gatherer must reference the same metrics source")
 	}
 
 	return registerer, gatherer
 }
 
-// sameRegistryThroughProbe verifies an opaque Registerer (such as one returned
-// by WrapRegistererWithPrefix) by temporarily registering a uniquely named
-// collector and checking that the configured Gatherer can see it.
-func sameRegistryThroughProbe(registerer prometheus.Registerer, gatherer prometheus.Gatherer) bool {
-	id := registryProbeID.Add(1)
-	help := "Fiber Prometheus registry pairing probe " + strconv.FormatUint(id, 10)
-	probe := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "fiber_prometheus_registry_pairing_probe_" + strconv.FormatUint(id, 10),
-		Help: help,
-	})
-	if err := registerer.Register(probe); err != nil {
-		panic("prometheus middleware: could not verify Registerer and Gatherer pairing: " + err.Error())
-	}
-	defer registerer.Unregister(probe)
+// clientGolangPackage scopes wrapper unwrapping to client_golang's own types. A
+// user-defined Registerer that happens to hold another one is not necessarily
+// delegating to it, so reading it as a chain could reject a valid pair.
+const clientGolangPackage = "github.com/prometheus/client_golang/prometheus"
 
-	families, err := gatherer.Gather()
-	if err != nil {
-		panic("prometheus middleware: could not verify Registerer and Gatherer pairing: " + err.Error())
-	}
-	for _, family := range families {
-		if family.GetHelp() == help {
-			return true
+// maxRegistererUnwraps bounds the walk below. Wrappers are immutable once
+// constructed, so a cycle cannot occur; the bound only keeps a hostile or
+// future implementation from spinning forever.
+const maxRegistererUnwraps = 32
+
+// unwrapRegisterer follows a chain of client_golang Registerer wrappers down to
+// the Registerer they ultimately register with. ok is false when nothing was
+// unwrapped, either because the value is not one of those wrappers or because
+// the chain does not end - in both cases the destination is unknowable and the
+// pair has to be accepted.
+//
+// The walk reads unexported fields, so the result stays a reflect.Value:
+// calling Interface on it would panic. Everything differentSource needs - the
+// dynamic type and the pointer - is readable without it.
+func unwrapRegisterer(v reflect.Value) (reflect.Value, bool) {
+	unwrapped := false
+
+	for range maxRegistererUnwraps {
+		field, ok := wrappedRegisterer(v)
+		if !ok {
+			return v, unwrapped
 		}
+
+		// Wrapping nil is client_golang's documented no-op Registerer. Nothing
+		// is registered anywhere, so there is no source to compare.
+		if field.IsNil() {
+			return reflect.Value{}, false
+		}
+
+		v = field.Elem()
+		unwrapped = true
 	}
-	return false
+
+	return reflect.Value{}, false
 }
 
-// differentSource reports whether two gatherers provably reference distinct
-// sources. Identity goes through reflection because comparing interface values
-// panics on an uncomparable dynamic type; undecidable cases are accepted.
-func differentSource(a, b prometheus.Gatherer) bool {
-	// Both interfaces are non-nil here, so neither Value can be invalid.
-	av, bv := reflect.ValueOf(a), reflect.ValueOf(b)
+// wrappedRegisterer returns the Registerer field a client_golang wrapper
+// delegates to, and whether v is such a wrapper at all.
+func wrappedRegisterer(v reflect.Value) (reflect.Value, bool) {
+	if v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return reflect.Value{}, false
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct || v.Type().PkgPath() != clientGolangPackage {
+		return reflect.Value{}, false
+	}
+
+	registererType := reflect.TypeFor[prometheus.Registerer]()
+	for i := range v.NumField() {
+		if v.Type().Field(i).Type == registererType {
+			return v.Field(i), true
+		}
+	}
+
+	return reflect.Value{}, false
+}
+
+// differentSource reports whether two values provably reference distinct
+// metrics sources. Identity goes through reflection because comparing interface
+// values panics on an uncomparable dynamic type, and because an unwrapped
+// Registerer comes from an unexported field; undecidable cases are accepted.
+func differentSource(a, b reflect.Value) bool {
+	// Both interfaces were non-nil, and unwrapping only ever returns the
+	// dynamic value of a non-nil field, so neither Value can be invalid.
 
 	// Mismatched dynamic types say nothing: a wrapper delegating to the registry it
 	// was handed is a different type, same source. Pointer identity is then the only
 	// safe comparison - equality on a struct holding an interface can panic.
-	if av.Type() != bv.Type() || av.Kind() != reflect.Pointer {
+	if a.Type() != b.Type() || a.Kind() != reflect.Pointer {
 		return false
 	}
 
-	return av.Pointer() != bv.Pointer()
+	return a.Pointer() != b.Pointer()
 }
 
 // handle serves the metrics endpoint or instruments the request, depending on

--- a/v3/prometheus/prometheus.go
+++ b/v3/prometheus/prometheus.go
@@ -572,9 +572,9 @@ const clientGolangPackage = "github.com/prometheus/client_golang/prometheus"
 const maxRegistererUnwraps = 32
 
 // unwrapRegisterer follows a chain of client_golang Registerer wrappers down to
-// the Registerer they ultimately register with. ok is false when nothing was
-// unwrapped, either because the value is not one of those wrappers or because
-// the chain does not end - in both cases the destination is unknowable and the
+// the Registerer they ultimately register with. ok is false whenever that
+// destination cannot be established - the value is not one of those wrappers,
+// it wraps nil, or the chain runs past maxRegistererUnwraps - and every such
 // pair has to be accepted.
 //
 // The walk reads unexported fields, so the result stays a reflect.Value:

--- a/v3/prometheus/prometheus.go
+++ b/v3/prometheus/prometheus.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -55,6 +56,8 @@ type middleware struct {
 	records           bool
 	observes          bool
 }
+
+var registryProbeID atomic.Uint64
 
 // dynamicLabel binds a configured label name to the function producing its
 // value. The slice held by middleware is sorted by name so that the label order
@@ -547,9 +550,38 @@ func resolveRegistry(cfg Config) (prometheus.Registerer, prometheus.Gatherer) {
 		if differentSource(regGatherer, gatherer) {
 			panic("prometheus middleware: Registerer and Gatherer must reference the same metrics source")
 		}
+	} else if !sameRegistryThroughProbe(registerer, gatherer) {
+		panic("prometheus middleware: Registerer and Gatherer must reference the same metrics source")
 	}
 
 	return registerer, gatherer
+}
+
+// sameRegistryThroughProbe verifies an opaque Registerer (such as one returned
+// by WrapRegistererWithPrefix) by temporarily registering a uniquely named
+// collector and checking that the configured Gatherer can see it.
+func sameRegistryThroughProbe(registerer prometheus.Registerer, gatherer prometheus.Gatherer) bool {
+	id := registryProbeID.Add(1)
+	help := "Fiber Prometheus registry pairing probe " + strconv.FormatUint(id, 10)
+	probe := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "fiber_prometheus_registry_pairing_probe_" + strconv.FormatUint(id, 10),
+		Help: help,
+	})
+	if err := registerer.Register(probe); err != nil {
+		panic("prometheus middleware: could not verify Registerer and Gatherer pairing: " + err.Error())
+	}
+	defer registerer.Unregister(probe)
+
+	families, err := gatherer.Gather()
+	if err != nil {
+		panic("prometheus middleware: could not verify Registerer and Gatherer pairing: " + err.Error())
+	}
+	for _, family := range families {
+		if family.GetHelp() == help {
+			return true
+		}
+	}
+	return false
 }
 
 // differentSource reports whether two gatherers provably reference distinct

--- a/v3/prometheus/prometheus_test.go
+++ b/v3/prometheus/prometheus_test.go
@@ -1619,6 +1619,76 @@ func TestWrappingRegistererWithMismatchedGathererPanics(t *testing.T) {
 	})
 }
 
+// TestNestedWrappingRegistererIsUnwrapped pins that the walk follows a chain of
+// wrappers, not just the outermost one.
+func TestNestedWrappingRegistererIsUnwrapped(t *testing.T) {
+	registered := prometheus.NewRegistry()
+	gathered := prometheus.NewRegistry()
+
+	matching := prometheus.WrapRegistererWith(
+		prometheus.Labels{"instance": "one"},
+		prometheus.WrapRegistererWithPrefix("app_", registered),
+	)
+	mismatched := prometheus.WrapRegistererWith(
+		prometheus.Labels{"instance": "one"},
+		prometheus.WrapRegistererWithPrefix("app_", gathered),
+	)
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("expected nested wrappers around the paired registry to be accepted, got %v", r)
+			}
+		}()
+
+		_ = New(Config{Registerer: matching, Gatherer: registered})
+	}()
+
+	defer func() {
+		if r := recover(); r != nil {
+			if message := fmt.Sprint(r); !strings.Contains(message, "must reference the same metrics source") {
+				t.Fatalf("expected panic about mismatched sources, got %q", message)
+			}
+			return
+		}
+		t.Fatal("expected panic when nested wrappers end at a different registry")
+	}()
+
+	_ = New(Config{Registerer: mismatched, Gatherer: registered})
+}
+
+// TestOpaqueRegistererIsAccepted pins the limit of the check: a Registerer that
+// is not one of client_golang's wrappers keeps its delegation target to itself,
+// so the pair is accepted rather than guessed at. Reading such a type as a
+// wrapper would reject valid pairings.
+func TestOpaqueRegistererIsAccepted(t *testing.T) {
+	registry := prometheus.NewRegistry()
+
+	cases := map[string]prometheus.Registerer{
+		"custom type":       delegatingRegisterer{Registerer: prometheus.NewRegistry()},
+		"wrapping nil":      prometheus.WrapRegistererWithPrefix("app_", nil),
+		"wrapping a custom": prometheus.WrapRegistererWithPrefix("app_", delegatingRegisterer{Registerer: prometheus.NewRegistry()}),
+	}
+
+	for name, registerer := range cases {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("expected an opaque Registerer to be accepted, got %v", r)
+				}
+			}()
+
+			_ = New(Config{Registerer: registerer, Gatherer: registry})
+		})
+	}
+}
+
+// delegatingRegisterer stands in for a Registerer outside client_golang that
+// holds another one without necessarily registering through it.
+type delegatingRegisterer struct {
+	prometheus.Registerer
+}
+
 // TestEmptyBucketsWithoutNativeHistogramsKeepsDefaults pins the documented
 // caveat: client_golang substitutes its own defaults rather than leave a
 // histogram with no buckets, so an empty slice alone does not drop them.

--- a/v3/prometheus/prometheus_test.go
+++ b/v3/prometheus/prometheus_test.go
@@ -1599,6 +1599,26 @@ func TestWrappingRegistererWithMatchingGatherer(t *testing.T) {
 	}
 }
 
+func TestWrappingRegistererWithMismatchedGathererPanics(t *testing.T) {
+	registered := prometheus.NewRegistry()
+	gathered := prometheus.NewRegistry()
+
+	defer func() {
+		if r := recover(); r != nil {
+			if message := fmt.Sprint(r); !strings.Contains(message, "must reference the same metrics source") {
+				t.Fatalf("expected panic about mismatched sources, got %q", message)
+			}
+			return
+		}
+		t.Fatal("expected panic when a wrapping Registerer and Gatherer differ")
+	}()
+
+	_ = New(Config{
+		Registerer: prometheus.WrapRegistererWithPrefix("app_", registered),
+		Gatherer:   gathered,
+	})
+}
+
 // TestEmptyBucketsWithoutNativeHistogramsKeepsDefaults pins the documented
 // caveat: client_golang substitutes its own defaults rather than leave a
 // histogram with no buckets, so an empty slice alone does not drop them.


### PR DESCRIPTION
### Motivation

- A wrapped `prometheus.Registerer` (for example `WrapRegistererWithPrefix`) could be paired with an unrelated `Gatherer` and be accepted, which lets metrics be registered into one source but scraped from another, silently omitting middleware metrics.
- The change aims to ensure operator-provided `Registerer`/`Gatherer` pairs actually reference the same underlying metrics source and to fail fast on mismatches to avoid silent observability gaps.

### Description

- Add a probe-based verification in `resolveRegistry` that temporarily registers a uniquely named collector when the `Registerer` does not itself implement `prometheus.Gatherer` and ensures the configured `Gatherer` can see it.
- Introduce an atomic probe id (`registryProbeID`) and a helper function `sameRegistryThroughProbe` that registers a probe gauge, invokes `Gather()`, and compares the probe presence via the probe's `Help` text.
- Preserve existing fast-path checks (`differentSource`) for comparable gatherers, and panic if either the reflection-based check or the probe verification determines the pair is mismatched.
- Add a regression test `TestWrappingRegistererWithMismatchedGathererPanics` and update the README to document the probe-based validation and that mismatched pairs now panic during initialization.

### Testing

- Ran `gofmt -w` on the changed files and ensured there were no formatting issues.
- Ran `go test ./...` (from the `v3/prometheus` package) which executed the existing suite plus the new regression test and completed successfully (tests passed).
- Ran `git diff --check` to verify no whitespace/errors introduced by the change (no issues found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76880b18f88333813ed1e4673f0dd6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of Prometheus registerer and gatherer configurations during initialization.
  - Detects mismatched metrics sources, including nested and prefixed registerer wrappers, and reports configuration errors immediately.
  - Avoids false failures for opaque or custom integrations whose compatibility cannot be determined.
  - Improved whitespace normalization for metric names, paths, namespaces, service labels, and unmatched-route labels.

- **Documentation**
  - Clarified compatibility requirements and validation behavior for registerers and gatherers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->