### PR TITLE
fix(socketio): acquire postGate before copying polling POST body

### DIFF
--- a/v3/socketio/polling.go
+++ b/v3/socketio/polling.go
@@ -523,6 +523,12 @@ func ingestPolling(c fiber.Ctx, kws *Websocket) error {
 		return writePollingError(c, 3)
 	}
 
+	// Serialise POSTs per session before copying the request body. This
+	// prevents concurrent requests from allocating a full body copy while
+	// they wait for an earlier POST to finish.
+	kws.postGate.Lock()
+	defer kws.postGate.Unlock()
+
 	// Copy the body once into a fresh buffer. fasthttp recycles the
 	// request body buffer when the handler returns; without an owned
 	// copy, listener callbacks that stash EventPayload.Data into a
@@ -531,12 +537,6 @@ func ingestPolling(c fiber.Ctx, kws *Websocket) error {
 	// slices of body across goroutine boundaries.
 	body := make([]byte, len(src))
 	copy(body, src)
-
-	// Serialise POSTs per session so dispatched packets across
-	// overlapping POSTs preserve FIFO order. Held only for the parse
-	// loop; never across user-callback locks.
-	kws.postGate.Lock()
-	defer kws.postGate.Unlock()
 
 	// Any inbound HTTP body counts as proof of life for the heartbeat
 	// enforcer, mirroring the WebSocket read-loop behaviour at

--- a/v3/socketio/polling.go
+++ b/v3/socketio/polling.go
@@ -511,6 +511,17 @@ func encodePollingFrames(frames [][]byte) []byte {
 // pipeline used by the WebSocket read loop, and responds with the
 // engine.io literal "ok" body.
 func ingestPolling(c fiber.Ctx, kws *Websocket) error {
+	// Serialise POSTs per session before the body is materialised, not
+	// after. Body() is not a free read of what fasthttp already holds: a
+	// Content-Encoding body is decompressed into a fresh buffer sized by
+	// the app's BodyLimit rather than PollingMaxBufferSize, and
+	// fiber.Config.Immutable copies even an identity body. Taking the gate
+	// first means overlapping POSTs for one session queue before paying
+	// for that buffer, so a hostile client cannot multiply it by firing
+	// requests in parallel while an earlier one sits in a callback.
+	kws.postGate.Lock()
+	defer kws.postGate.Unlock()
+
 	src := c.Body()
 	if PollingMaxBufferSize > 0 && len(src) > PollingMaxBufferSize {
 		// Tear the session down: matching the WebSocket SetReadLimit
@@ -522,12 +533,6 @@ func ingestPolling(c fiber.Ctx, kws *Websocket) error {
 		kws.disconnected(ErrPollingBodyTooLarge)
 		return writePollingError(c, 3)
 	}
-
-	// Serialise POSTs per session before copying the request body. This
-	// prevents concurrent requests from allocating a full body copy while
-	// they wait for an earlier POST to finish.
-	kws.postGate.Lock()
-	defer kws.postGate.Unlock()
 
 	// Copy the body once into a fresh buffer. fasthttp recycles the
 	// request body buffer when the handler returns; without an owned

--- a/v3/socketio/polling_test.go
+++ b/v3/socketio/polling_test.go
@@ -2,6 +2,7 @@ package socketio
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -1033,6 +1034,63 @@ func TestPollingMaxBufferSizeTearsDown(t *testing.T) {
 	// Subsequent GET sees the session gone.
 	_, status := pollGet(t, c, sid)
 	require.Equal(t, http.StatusBadRequest, status)
+}
+
+// TestPollingMaxBufferSizeCountsDecodedBody pins that the limit is applied to
+// what Body() returns, not to what arrived on the wire. A Content-Encoding body
+// is decompressed into a buffer bounded by the app's BodyLimit, so a small
+// compressed POST can expand past PollingMaxBufferSize - which is why
+// ingestPolling takes postGate before materialising it.
+func TestPollingMaxBufferSizeCountsDecodedBody(t *testing.T) {
+	resetSIOGlobals(t)
+
+	prev := PollingMaxBufferSize
+	PollingMaxBufferSize = 64
+	t.Cleanup(func() { PollingMaxBufferSize = prev })
+
+	disconnectErr := make(chan error, 1)
+	On(EventDisconnect, func(p *EventPayload) {
+		select {
+		case disconnectErr <- p.Error:
+		default:
+		}
+	})
+
+	_, c, td := newPollingTestServer(t, func(_ *Websocket) {})
+	defer td()
+
+	sid, _, _ := pollOpen(t, c)
+
+	plain := append([]byte(`42["big","`), bytes.Repeat([]byte{'x'}, 4096)...)
+	plain = append(plain, []byte(`"]`)...)
+
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	_, err := zw.Write(plain)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	require.Less(t, compressed.Len(), PollingMaxBufferSize,
+		"the compressed body must fit under the limit for this test to mean anything")
+
+	url := "http://test/?EIO=4&transport=polling&sid=" + sid
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(compressed.Bytes()))
+	require.NoError(t, err)
+	req.Header.Set(fiber.HeaderContentEncoding, "gzip")
+	resp, err := c.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.Contains(t, string(respBody), `"code":3`)
+
+	select {
+	case err := <-disconnectErr:
+		require.ErrorIs(t, err, ErrPollingBodyTooLarge)
+	case <-time.After(2 * time.Second):
+		t.Fatal("oversize decompressed POST did not tear session down")
+	}
 }
 
 // TestPollingErrorBodyAllCodes covers the pollingErrorBody mapping for

--- a/v3/socketio/socketio.go
+++ b/v3/socketio/socketio.go
@@ -782,9 +782,10 @@ type Websocket struct {
 	// clients send POSTs sequentially, but a misbehaving or hostile
 	// client could fire two simultaneously; without serialisation the
 	// dispatch order across the two POSTs would race and break the
-	// per-session FIFO guarantee that user listeners rely on. Held only
-	// for the duration of ingestPolling's parse loop; never held across
-	// other locks.
+	// per-session FIFO guarantee that user listeners rely on. Held for
+	// the whole of ingestPolling - the body is materialised under it, so
+	// queued POSTs wait before allocating rather than after - but never
+	// held across other locks.
 	postGate sync.Mutex
 	// handshakeTimer is the time.AfterFunc scheduled by openPollingSession
 	// to enforce HandshakeTimeout on polling sessions. Stopped in


### PR DESCRIPTION
### Motivation
- `ingestPolling` copied the entire request body into an owned buffer before acquiring the per-session POST serialization lock, which allowed concurrent POSTs for the same polling session to each allocate up to `PollingMaxBufferSize` and risk memory amplification (remote availability/DoS).

### Description
- Update `v3/socketio/polling.go` so `kws.postGate.Lock()` / `defer kws.postGate.Unlock()` are acquired before copying the request body in `ingestPolling`.
- Preserve the existing `PollingMaxBufferSize` validation and the owned-buffer semantics that allow listeners to safely retain slices of the payload.
- The change is a single-site reordering that keeps FIFO parsing, event dispatch, and caller-visible behavior unchanged while preventing concurrent queued requests from pre-allocating large buffers.

### Testing
- Ran `gofmt -w v3/socketio/polling.go` and `git diff --check` with no reported issues.
- Attempted `go test` runs in the `v3/socketio` module in this environment, but the test runner terminated without producing a normal exit status so full automated test verification could not be completed here.
- The edit is minimal and localized to `ingestPolling`, and static formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a772d8b170c833383122f115cb326d0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of overlapping polling requests to preserve request order and reduce unnecessary memory allocation.
  * Enforced maximum request-body limits after decompression, preventing oversized compressed requests from bypassing limits.
  * Oversized requests now return the appropriate error response and terminate the affected session.

* **Documentation**
  * Clarified polling request synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->