### PR TITLE
fix(otel): use semconv-advised bucket boundaries for http.server.request.duration

### DIFF
--- a/v3/otel/fiber.go
+++ b/v3/otel/fiber.go
@@ -51,6 +51,11 @@ const (
 	UnitMilliseconds = "ms"
 )
 
+// httpServerRequestDurationBoundaries is the ExplicitBucketBoundaries advisory
+// parameter recommended by the semantic conventions for the
+// http.server.request.duration metric, expressed in seconds.
+var httpServerRequestDurationBoundaries = []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10}
+
 type bodyStreamSizeReader struct {
 	reader io.Reader
 	onEOF  func(read int64)
@@ -128,7 +133,12 @@ func Middleware(opts ...Option) fiber.Handler {
 		)
 
 		var err error
-		httpServerDuration, err = meter.Float64Histogram(MetricNameHTTPServerRequestDuration, metric.WithUnit(UnitSeconds), metric.WithDescription("Duration of HTTP server requests."))
+		httpServerDuration, err = meter.Float64Histogram(
+			MetricNameHTTPServerRequestDuration,
+			metric.WithUnit(UnitSeconds),
+			metric.WithDescription("Duration of HTTP server requests."),
+			metric.WithExplicitBucketBoundaries(httpServerRequestDurationBoundaries...),
+		)
 		if err != nil {
 			otel.Handle(err)
 		}

--- a/v3/otel/otel_test/fiber_test.go
+++ b/v3/otel/otel_test/fiber_test.go
@@ -396,6 +396,8 @@ func assertScopeMetrics(t *testing.T, sm metricdata.ScopeMetrics, route string, 
 	require.Len(t, hist.DataPoints, 1)
 	dp := hist.DataPoints[0]
 	assert.Equal(t, attribute.NewSet(responseAttrs...), dp.Attributes, "attributes")
+	// Buckets advised by the semantic conventions, in seconds.
+	assert.Equal(t, []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10}, dp.Bounds, "bounds")
 	assert.Equal(t, uint64(1), dp.Count, "count")
 	assert.Less(t, dp.Sum, 0.01) // test shouldn't take longer than 10 milliseconds (0.01 seconds)
 


### PR DESCRIPTION
`http.server.request.duration` is recorded in seconds, but the histogram was created without an ExplicitBucketBoundaries advisory. The metric SDK fell back to its default boundaries (0, 5, 10, 25, … 10000), which are sized for milliseconds. So, virtually every request landed in the first bucket and the histogram could not produce meaningful latency percentiles.

The [HTTP semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration) state this metric SHOULD be specified with the ExplicitBucketBoundaries advisory parameter of [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]. This PR passes those boundaries via metric.WithExplicitBucketBoundaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved HTTP request duration metrics with standardized histogram bucket boundaries measured in seconds.
  * Enhanced metric accuracy and consistency for monitoring request performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->