### PR TITLE
fix(uptime): let page description use full width

### DIFF
--- a/v3/uptime/dashboard.gohtml
+++ b/v3/uptime/dashboard.gohtml
@@ -264,7 +264,6 @@ button:hover:not(.bar) {
 }
 .description-card p {
   margin: 0;
-  max-width: 78ch;
 }
 .services {
   display: grid;


### PR DESCRIPTION
Remove the fixed width limit from the dashboard description so text uses the full card width before wrapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Expanded description text to use the available width within uptime dashboard cards.
  * Improved readability for longer descriptions by removing the previous narrow text constraint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->