### PR TITLE
feat(uptime): Support custom storage backends

### DIFF
--- a/v3/uptime/README.md
+++ b/v3/uptime/README.md
@@ -156,13 +156,14 @@ never expired. A service that has never recorded a successful heartbeat also
 keeps its (small) service hash without a TTL. Use `RemoveService` to clear
 either.
 
-## Removing a service
+### Removing a service
 
-The dashboard lists every service found under `StorageKeyPrefix`, not just the
-ones in the current config. Services are never dropped automatically while
-their retention window keeps being refreshed, so renaming `ServiceID` or an
-endpoint `ID`, or removing an endpoint, leaves the old identifier behind as a
-row that reports down forever. Delete it explicitly:
+When using the built-in Redis `Store` path, the dashboard lists every service
+found under `StorageKeyPrefix`, not just the ones in the current config.
+Services are never dropped automatically while their retention window keeps
+being refreshed, so renaming `ServiceID` or an endpoint `ID`, or removing an
+endpoint, leaves the old identifier behind as a row that reports down forever.
+Delete it explicitly:
 
 ```go
 err := uptime.RemoveService(context.Background(), store, "fiber:uptime", "old-endpoint-id")
@@ -181,7 +182,9 @@ expose their own removal operation.
 
 ## Custom storage
 
-Provide an implementation of
+For most users, the built-in Redis `Store` path remains the simplest and
+default integration. `Storage` is the advanced extension point for applications
+that need a custom persistence backend. Provide an implementation of
 `github.com/gofiber/contrib/v3/uptime/storage.Store` through `Storage`:
 
 ```go

--- a/v3/uptime/README.md
+++ b/v3/uptime/README.md
@@ -176,6 +176,29 @@ while the service is still being recorded takes it off the dashboard for good,
 but in-flight heartbeats will recreate partial keys; those carry the TTL above
 and expire on their own.
 
+`RemoveService` applies to the built-in Redis path. Custom storage backends may
+expose their own removal operation.
+
+## Custom storage
+
+Provide an implementation of
+`github.com/gofiber/contrib/v3/uptime/storage.Store` through `Storage`:
+
+```go
+app.Use(uptime.New(uptime.Config{
+	App:       app,
+	Storage:   myStore,
+	ServiceID: "api",
+}))
+```
+
+Custom stores must be ready before calling `uptime.New` and safe for concurrent
+use. The caller owns their lifecycle and should close underlying resources
+after the Fiber application has shut down; uptime does not close custom stores.
+`Store` and `Storage` are mutually exclusive, and `StorageKeyPrefix` applies
+only to the built-in Redis `Store` path. Redis remains the built-in storage
+integration.
+
 ## Snapshots and custom UI
 
 The dashboard and JSON API share an in-memory snapshot, limiting backing-store
@@ -232,8 +255,9 @@ remote host, so a same-origin URL is preferred for private deployments.
 | NodeID | `int64` | Optional node value used for generated instance IDs. | `0` |
 | InstanceID | `int64` | Explicit process instance ID. | Generated |
 | IDGenerator | `uptime.IDGenerator` | Custom instance ID generator. | `nil` |
-| Store | `*fiberredis.Storage` | Fiber Redis storage instance from `github.com/gofiber/storage/redis/v3`. | Required |
-| StorageKeyPrefix | `string` | Prefix for all uptime Redis keys. | `"fiber:uptime"` |
+| Store | `*fiberredis.Storage` | Fiber Redis storage instance from `github.com/gofiber/storage/redis/v3`. | Required unless `Storage` is set. |
+| Storage | `storage.Store` | Custom uptime storage backend. | Required unless `Store` is set. |
+| StorageKeyPrefix | `string` | Prefix for uptime Redis keys. Applies only when `Store` is used. | `"fiber:uptime"` |
 | UI | `uptime.UIConfig` | Dashboard copy, favicon, and thresholds. `FaviconURL` accepts a root-relative path or absolute HTTP(S) URL. Threshold values are configurable in `(0, 1]`; zero uses the defaults. | Embedded favicon, light English UI, green at `99.9%`, yellow at `99%` |
 
 ### EndpointConfig

--- a/v3/uptime/README.md
+++ b/v3/uptime/README.md
@@ -182,8 +182,8 @@ expose their own removal operation.
 
 ## Custom storage
 
-For most users, the built-in Redis `Store` path remains the simplest and
-default integration. `Storage` is the advanced extension point for applications
+For most users, the built-in Redis `Store` path remains the simplest
+integration. `Storage` is the advanced extension point for applications
 that need a custom persistence backend. Provide an implementation of
 `github.com/gofiber/contrib/v3/uptime/storage.Store` through `Storage`:
 

--- a/v3/uptime/config.go
+++ b/v3/uptime/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	uptimestorage "github.com/gofiber/contrib/v3/uptime/storage"
 	"github.com/gofiber/fiber/v3"
 	fiberredis "github.com/gofiber/storage/redis/v3"
 	"github.com/gofiber/utils/v2"
@@ -30,8 +31,10 @@ const (
 var (
 	// ErrMissingServiceID is returned when neither Config.ServiceID nor Config.Endpoints is set.
 	ErrMissingServiceID = errors.New("uptime: service id or endpoint is required")
-	// ErrMissingStore is returned when Config.Store is not set.
-	ErrMissingStore = errors.New("uptime: redis storage is required")
+	// ErrMissingStore is returned when neither Config.Store nor Config.Storage is set.
+	ErrMissingStore = errors.New("uptime: storage is required")
+	// ErrConflictingStorage is returned when Config.Store and Config.Storage are both set.
+	ErrConflictingStorage = errors.New("uptime: Store and Storage are mutually exclusive")
 	// ErrMissingApp is returned when Config.App is not set.
 	ErrMissingApp = errors.New("uptime: fiber app is required")
 	// ErrInvalidFaviconURL is returned when UIConfig.FaviconURL is not a supported URL.
@@ -76,8 +79,16 @@ type Config struct {
 
 	// Store is the Fiber Redis storage instance used for uptime state.
 	// The caller owns the storage lifecycle and should close it when the app stops.
+	// Store and Storage are mutually exclusive.
 	Store *fiberredis.Storage
-	// StorageKeyPrefix namespaces all uptime keys inside the selected Redis database.
+	// Storage is an optional custom uptime storage backend.
+	//
+	// Storage must be ready for use when New is called and safe for concurrent use.
+	// The caller owns its lifecycle and should close underlying resources after
+	// the Fiber app has shut down. Store and Storage are mutually exclusive.
+	Storage uptimestorage.Store
+	// StorageKeyPrefix namespaces Redis keys when Store is used. Custom storage
+	// backends own their namespacing and configuration.
 	StorageKeyPrefix string
 	// UI configures the built-in dashboard.
 	UI UIConfig

--- a/v3/uptime/custom_storage_test.go
+++ b/v3/uptime/custom_storage_test.go
@@ -1,0 +1,251 @@
+package uptime_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofiber/contrib/v3/uptime"
+	uptimestorage "github.com/gofiber/contrib/v3/uptime/storage"
+	"github.com/gofiber/fiber/v3"
+)
+
+var _ uptimestorage.Store = (*customStore)(nil)
+
+func TestCustomStorageBackend(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	store := &closableCustomStore{customStore: newCustomStore(uptimestorage.Service{
+		ID:             "z",
+		Name:           "Z",
+		CreatedAt:      now.Add(-time.Hour),
+		LastSeenAt:     now,
+		SampleInterval: time.Hour,
+	})}
+	app := fiber.New()
+	app.Use(uptime.New(uptime.Config{
+		App:              app,
+		Storage:          store,
+		ServiceID:        "a",
+		ServiceName:      "A",
+		SampleInterval:   time.Hour,
+		RetentionDays:    1,
+		DaysToShow:       1,
+		Timezone:         time.UTC,
+		StorageKeyPrefix: "ignored-by-custom-storage",
+	}))
+	t.Cleanup(func() { _ = app.Shutdown() })
+
+	service, heartbeatSlots := store.serviceState("a")
+	if service.ID != "a" {
+		t.Fatalf("registered service = %+v, want a", service)
+	}
+	if heartbeatSlots != 1 {
+		t.Fatalf("initial heartbeat slots = %d, want 1", heartbeatSlots)
+	}
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/uptime/api/status", nil))
+	if err != nil {
+		t.Fatalf("status request: %v", err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status code = %d, want %d", resp.StatusCode, fiber.StatusOK)
+	}
+
+	var status uptime.StatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if status.Storage.Driver != "custom-test" {
+		t.Fatalf("storage driver = %q, want custom-test", status.Storage.Driver)
+	}
+	if len(status.Services) != 2 || status.Services[0].ID != "a" || status.Services[1].ID != "z" {
+		t.Fatalf("services = %+v, want deterministic order [a z]", status.Services)
+	}
+
+	if err := app.Shutdown(); err != nil {
+		t.Fatalf("shutdown app: %v", err)
+	}
+	if store.closeCount() != 0 {
+		t.Fatal("uptime closed caller-owned custom storage")
+	}
+}
+
+type sampleKey struct {
+	serviceID string
+	day       string
+}
+
+type customStore struct {
+	mu        sync.Mutex
+	services  map[string]uptimestorage.Service
+	instances map[int64]uptimestorage.Instance
+	slots     map[sampleKey]map[int64]struct{}
+}
+
+func newCustomStore(services ...uptimestorage.Service) *customStore {
+	store := &customStore{
+		services:  make(map[string]uptimestorage.Service, len(services)),
+		instances: make(map[int64]uptimestorage.Instance),
+		slots:     make(map[sampleKey]map[int64]struct{}),
+	}
+	for _, service := range services {
+		store.services[service.ID] = service
+	}
+	return store
+}
+
+func (*customStore) Name() string {
+	return "custom-test"
+}
+
+func (s *customStore) UpsertService(_ context.Context, service uptimestorage.Service) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	current, ok := s.services[service.ID]
+	if ok {
+		if !current.CreatedAt.IsZero() {
+			service.CreatedAt = current.CreatedAt
+		}
+		if current.LastSeenAt.After(service.LastSeenAt) {
+			service.LastSeenAt = current.LastSeenAt
+		}
+	}
+	s.services[service.ID] = service
+	return nil
+}
+
+func (s *customStore) UpsertInstance(_ context.Context, instance uptimestorage.Instance) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	current, ok := s.instances[instance.ID]
+	if ok {
+		if !current.StartedAt.IsZero() {
+			instance.StartedAt = current.StartedAt
+		}
+		if current.LastSeenAt.After(instance.LastSeenAt) {
+			instance.LastSeenAt = current.LastSeenAt
+		}
+	}
+	s.instances[instance.ID] = instance
+	return nil
+}
+
+func (s *customStore) WriteHeartbeat(_ context.Context, heartbeat uptimestorage.Heartbeat) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	service := s.services[heartbeat.ServiceID]
+	if heartbeat.SeenAt.After(service.LastSeenAt) {
+		service.LastSeenAt = heartbeat.SeenAt
+		s.services[heartbeat.ServiceID] = service
+	}
+	instance := s.instances[heartbeat.InstanceID]
+	if heartbeat.SeenAt.After(instance.LastSeenAt) {
+		instance.LastSeenAt = heartbeat.SeenAt
+		s.instances[heartbeat.InstanceID] = instance
+	}
+	key := sampleKey{serviceID: heartbeat.ServiceID, day: heartbeat.Day}
+	if s.slots[key] == nil {
+		s.slots[key] = make(map[int64]struct{})
+	}
+	s.slots[key][heartbeat.Slot] = struct{}{}
+	return nil
+}
+
+func (*customStore) RollupDaily(context.Context, uptimestorage.RollupOptions) error {
+	return nil
+}
+
+func (*customStore) Cleanup(context.Context, uptimestorage.CleanupOptions) error {
+	return nil
+}
+
+func (s *customStore) ListServices(context.Context) ([]uptimestorage.Service, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	services := make([]uptimestorage.Service, 0, len(s.services))
+	for _, service := range s.services {
+		services = append(services, service)
+	}
+	sort.Slice(services, func(i, j int) bool {
+		return services[i].ID > services[j].ID
+	})
+	return services, nil
+}
+
+func (*customStore) QueryDaily(context.Context, uptimestorage.QueryDailyOptions) ([]uptimestorage.DailyStatus, error) {
+	return nil, nil
+}
+
+func (s *customStore) QueryTodaySamples(_ context.Context, options uptimestorage.QueryTodaySamplesOptions) ([]uptimestorage.TodaySampleStatus, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var statuses []uptimestorage.TodaySampleStatus
+	for key, slots := range s.slots {
+		if key.day != options.Day || !serviceSelected(options.ServiceIDs, key.serviceID) {
+			continue
+		}
+		statuses = append(statuses, uptimestorage.TodaySampleStatus{
+			ServiceID: key.serviceID,
+			Day:       key.day,
+			UpSlots:   len(slots),
+		})
+	}
+	return statuses, nil
+}
+
+func (s *customStore) serviceState(serviceID string) (uptimestorage.Service, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	service := s.services[serviceID]
+	heartbeatSlots := 0
+	for key, slots := range s.slots {
+		if key.serviceID == serviceID {
+			heartbeatSlots += len(slots)
+		}
+	}
+	return service, heartbeatSlots
+}
+
+type closableCustomStore struct {
+	*customStore
+	closeMu sync.Mutex
+	closes  int
+}
+
+func (s *closableCustomStore) Close() error {
+	s.closeMu.Lock()
+	defer s.closeMu.Unlock()
+	s.closes++
+	return nil
+}
+
+func (s *closableCustomStore) closeCount() int {
+	s.closeMu.Lock()
+	defer s.closeMu.Unlock()
+	return s.closes
+}
+
+func serviceSelected(serviceIDs []string, serviceID string) bool {
+	if serviceIDs == nil {
+		return true
+	}
+	for _, selected := range serviceIDs {
+		if selected == serviceID {
+			return true
+		}
+	}
+	return false
+}

--- a/v3/uptime/internal/storage/external.go
+++ b/v3/uptime/internal/storage/external.go
@@ -1,0 +1,36 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	uptimestorage "github.com/gofiber/contrib/v3/uptime/storage"
+)
+
+type externalStore struct {
+	uptimestorage.Store
+}
+
+// NewExternalStore adapts a caller-owned public store to the runtime's internal
+// lifecycle contract without initializing or closing the caller's resources.
+func NewExternalStore(store uptimestorage.Store) Store {
+	return &externalStore{Store: store}
+}
+
+func (*externalStore) Init(context.Context) error {
+	return nil
+}
+
+func (*externalStore) Close() error {
+	return nil
+}
+
+func (s *externalStore) Name() string {
+	type named interface {
+		Name() string
+	}
+	if store, ok := s.Store.(named); ok {
+		return store.Name()
+	}
+	return fmt.Sprintf("%T", s.Store)
+}

--- a/v3/uptime/internal/storage/redis.go
+++ b/v3/uptime/internal/storage/redis.go
@@ -295,10 +295,8 @@ func (s *RedisStore) RollupDaily(ctx context.Context, options RollupOptions) err
 				continue
 			}
 			expectedSlots := 0
-			if options.ExpectedSlotsForServiceDay != nil {
-				expectedSlots = options.ExpectedSlotsForServiceDay(service.ID, day)
-			} else if options.ExpectedSlotsForDay != nil {
-				expectedSlots = options.ExpectedSlotsForDay(day)
+			if options.ExpectedSlots != nil {
+				expectedSlots = options.ExpectedSlots(service, day)
 			}
 			if err := s.writeDaily(ctx, DailyStatus{
 				ServiceID:     service.ID,

--- a/v3/uptime/internal/storage/redis_test.go
+++ b/v3/uptime/internal/storage/redis_test.go
@@ -38,8 +38,13 @@ func TestRedisStoreRollupAndCleanupLifecycle(t *testing.T) {
 	writeHeartbeat("2026-06-25", 1) // duplicate slot must collapse to one up slot
 
 	mustNoErr(t, store.RollupDaily(ctx, RollupOptions{
-		BeforeDay:                  "2026-06-26",
-		ExpectedSlotsForServiceDay: func(string, string) int { return 1440 },
+		BeforeDay: "2026-06-26",
+		ExpectedSlots: func(service Service, _ string) int {
+			if service.ID != "api" || !service.CreatedAt.Equal(created) || service.SampleInterval != time.Minute {
+				t.Fatalf("rollup service = %+v, want persisted api metadata", service)
+			}
+			return 1440
+		},
 	}))
 
 	daily := queryDailyMap(t, store)
@@ -75,6 +80,25 @@ func TestRedisStoreRollupAndCleanupLifecycle(t *testing.T) {
 	}
 }
 
+func TestRedisStoreRollupAllowsNilExpectedSlots(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := &RedisStore{config: RedisConfig{KeyPrefix: "test:uptime"}, client: newFakeRedisClient()}
+	mustNoErr(t, store.Init(ctx))
+	t.Cleanup(func() { mustNoErr(t, store.Close()) })
+
+	created := time.Date(2026, 6, 25, 0, 0, 0, 0, time.UTC)
+	mustNoErr(t, store.UpsertService(ctx, Service{ID: "api", Name: "API", CreatedAt: created, LastSeenAt: created, SampleInterval: time.Minute}))
+	mustNoErr(t, store.WriteHeartbeat(ctx, Heartbeat{ServiceID: "api", InstanceID: 1, Day: "2026-06-25", Slot: 0, SeenAt: created}))
+	mustNoErr(t, store.RollupDaily(ctx, RollupOptions{BeforeDay: "2026-06-26"}))
+
+	row := queryDailyMap(t, store)["2026-06-25"]
+	if row.ExpectedSlots != 0 || !row.Finalized {
+		t.Fatalf("daily = %+v, want expected=0 finalized=true", row)
+	}
+}
+
 func TestRedisStoreRollupDoesNotOverwriteFinalizedDailyWhenSamplesAreGone(t *testing.T) {
 	t.Parallel()
 
@@ -94,8 +118,8 @@ func TestRedisStoreRollupDoesNotOverwriteFinalizedDailyWhenSamplesAreGone(t *tes
 	mustNoErr(t, first.WriteHeartbeat(ctx, Heartbeat{ServiceID: "api", InstanceID: 1, Day: "2026-06-25", Slot: 1, SeenAt: created}))
 
 	mustNoErr(t, first.RollupDaily(ctx, RollupOptions{
-		BeforeDay:                  "2026-06-26",
-		ExpectedSlotsForServiceDay: func(string, string) int { return 1440 },
+		BeforeDay:     "2026-06-26",
+		ExpectedSlots: func(Service, string) int { return 1440 },
 	}))
 	before := queryDailyMap(t, first)["2026-06-25"]
 	if before.UpSlots != 2 || before.ExpectedSlots != 1440 || !before.Finalized {
@@ -104,8 +128,8 @@ func TestRedisStoreRollupDoesNotOverwriteFinalizedDailyWhenSamplesAreGone(t *tes
 
 	mustNoErr(t, client.Del(ctx, first.sampleKey("api", "2026-06-25")).Err())
 	mustNoErr(t, second.RollupDaily(ctx, RollupOptions{
-		BeforeDay:                  "2026-06-26",
-		ExpectedSlotsForServiceDay: func(string, string) int { return 1440 },
+		BeforeDay:     "2026-06-26",
+		ExpectedSlots: func(Service, string) int { return 1440 },
 	}))
 
 	after := queryDailyMap(t, first)["2026-06-25"]
@@ -135,8 +159,8 @@ func TestRedisStoreCleanupKeepsSamplesUntilDailyFinalized(t *testing.T) {
 	}
 
 	mustNoErr(t, store.RollupDaily(ctx, RollupOptions{
-		BeforeDay:                  "2026-06-26",
-		ExpectedSlotsForServiceDay: func(string, string) int { return 1440 },
+		BeforeDay:     "2026-06-26",
+		ExpectedSlots: func(Service, string) int { return 1440 },
 	}))
 	mustNoErr(t, store.Cleanup(ctx, CleanupOptions{SamplesBeforeDay: "2026-06-26"}))
 
@@ -147,7 +171,7 @@ func TestRedisStoreCleanupKeepsSamplesUntilDailyFinalized(t *testing.T) {
 	}
 }
 
-func TestRedisStoreQueriesUseProvidedServiceIDs(t *testing.T) {
+func TestRedisStoreQueryServiceIDSemantics(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -156,6 +180,10 @@ func TestRedisStoreQueriesUseProvidedServiceIDs(t *testing.T) {
 	mustNoErr(t, store.Init(ctx))
 	t.Cleanup(func() { mustNoErr(t, store.Close()) })
 
+	created := time.Date(2026, 6, 25, 0, 0, 0, 0, time.UTC)
+	for _, serviceID := range []string{"api", "worker"} {
+		mustNoErr(t, store.UpsertService(ctx, Service{ID: serviceID, Name: serviceID, CreatedAt: created, LastSeenAt: created, SampleInterval: time.Minute}))
+	}
 	mustNoErr(t, store.writeDaily(ctx, DailyStatus{
 		ServiceID:     "api",
 		Day:           "2026-06-25",
@@ -163,7 +191,15 @@ func TestRedisStoreQueriesUseProvidedServiceIDs(t *testing.T) {
 		ExpectedSlots: 1440,
 		Finalized:     true,
 	}))
+	mustNoErr(t, store.writeDaily(ctx, DailyStatus{
+		ServiceID:     "worker",
+		Day:           "2026-06-25",
+		UpSlots:       1,
+		ExpectedSlots: 1440,
+		Finalized:     true,
+	}))
 	mustNoErr(t, client.SAdd(ctx, store.sampleKey("api", "2026-06-26"), "1", "2").Err())
+	mustNoErr(t, client.SAdd(ctx, store.sampleKey("worker", "2026-06-26"), "1").Err())
 
 	daily, err := store.QueryDaily(ctx, QueryDailyOptions{
 		ServiceIDs: []string{"api"},
@@ -182,6 +218,40 @@ func TestRedisStoreQueriesUseProvidedServiceIDs(t *testing.T) {
 	mustNoErr(t, err)
 	if len(today) != 1 || today[0].ServiceID != "api" || today[0].UpSlots != 2 {
 		t.Fatalf("today with provided service ids = %+v, want one api row", today)
+	}
+
+	daily, err = store.QueryDaily(ctx, QueryDailyOptions{
+		FromDay: "2026-06-25",
+		ToDay:   "2026-06-25",
+	})
+	mustNoErr(t, err)
+	if len(daily) != 2 {
+		t.Fatalf("daily with nil service ids = %+v, want all services", daily)
+	}
+
+	daily, err = store.QueryDaily(ctx, QueryDailyOptions{
+		ServiceIDs: []string{},
+		FromDay:    "2026-06-25",
+		ToDay:      "2026-06-25",
+	})
+	mustNoErr(t, err)
+	if len(daily) != 0 {
+		t.Fatalf("daily with empty service ids = %+v, want no services", daily)
+	}
+
+	today, err = store.QueryTodaySamples(ctx, QueryTodaySamplesOptions{Day: "2026-06-26"})
+	mustNoErr(t, err)
+	if len(today) != 2 {
+		t.Fatalf("today with nil service ids = %+v, want all services", today)
+	}
+
+	today, err = store.QueryTodaySamples(ctx, QueryTodaySamplesOptions{
+		ServiceIDs: []string{},
+		Day:        "2026-06-26",
+	})
+	mustNoErr(t, err)
+	if len(today) != 0 {
+		t.Fatalf("today with empty service ids = %+v, want no services", today)
 	}
 }
 
@@ -398,8 +468,8 @@ func TestRedisStoreRemoveServiceDropsAllState(t *testing.T) {
 		mustNoErr(t, store.WriteHeartbeat(ctx, Heartbeat{ServiceID: id, InstanceID: 1, Day: "2026-06-25", Slot: 0, SeenAt: created}))
 	}
 	mustNoErr(t, store.RollupDaily(ctx, RollupOptions{
-		BeforeDay:                  "2026-06-26",
-		ExpectedSlotsForServiceDay: func(string, string) int { return 1440 },
+		BeforeDay:     "2026-06-26",
+		ExpectedSlots: func(Service, string) int { return 1440 },
 	}))
 
 	mustNoErr(t, store.RemoveService(ctx, "api"))
@@ -444,8 +514,8 @@ func TestRedisStoreHeartbeatArmsStateTTL(t *testing.T) {
 	mustNoErr(t, store.UpsertService(ctx, Service{ID: "api", Name: "API", CreatedAt: created, LastSeenAt: created, SampleInterval: time.Minute}))
 	mustNoErr(t, store.WriteHeartbeat(ctx, Heartbeat{ServiceID: "api", InstanceID: 1, Day: "2026-06-25", Slot: 0, SeenAt: created}))
 	mustNoErr(t, store.RollupDaily(ctx, RollupOptions{
-		BeforeDay:                  "2026-06-26",
-		ExpectedSlotsForServiceDay: func(string, string) int { return 1440 },
+		BeforeDay:     "2026-06-26",
+		ExpectedSlots: func(Service, string) int { return 1440 },
 	}))
 
 	for _, key := range []string{
@@ -499,8 +569,8 @@ func TestRedisStoreRollupSkipsDayWithExpiredSamples(t *testing.T) {
 	// samples gone, index entry still there: the TTL backstop outlived cleanup
 	mustNoErr(t, client.Del(ctx, store.sampleKey("api", "2026-06-25")).Err())
 	mustNoErr(t, store.RollupDaily(ctx, RollupOptions{
-		BeforeDay:                  "2026-06-26",
-		ExpectedSlotsForServiceDay: func(string, string) int { return 1440 },
+		BeforeDay:     "2026-06-26",
+		ExpectedSlots: func(Service, string) int { return 1440 },
 	}))
 
 	if row, ok := queryDailyMap(t, store)["2026-06-25"]; ok {
@@ -528,15 +598,15 @@ func TestRedisStoreRollupKeepsFinalizedRowWhenSamplesRemain(t *testing.T) {
 	mustNoErr(t, first.UpsertService(ctx, Service{ID: "api", Name: "API", CreatedAt: created, LastSeenAt: created, SampleInterval: time.Minute}))
 	mustNoErr(t, first.WriteHeartbeat(ctx, Heartbeat{ServiceID: "api", InstanceID: 1, Day: "2026-06-25", Slot: 0, SeenAt: created}))
 	mustNoErr(t, first.RollupDaily(ctx, RollupOptions{
-		BeforeDay:                  "2026-06-26",
-		ExpectedSlotsForServiceDay: func(string, string) int { return 1440 },
+		BeforeDay:     "2026-06-26",
+		ExpectedSlots: func(Service, string) int { return 1440 },
 	}))
 
 	// second instance disagrees on expected slots; samples still exist so only
 	// the Lua guard can stop it from rewriting the finalized row
 	mustNoErr(t, second.RollupDaily(ctx, RollupOptions{
-		BeforeDay:                  "2026-06-26",
-		ExpectedSlotsForServiceDay: func(string, string) int { return 96 },
+		BeforeDay:     "2026-06-26",
+		ExpectedSlots: func(Service, string) int { return 96 },
 	}))
 
 	row := queryDailyMap(t, first)["2026-06-25"]

--- a/v3/uptime/internal/storage/types.go
+++ b/v3/uptime/internal/storage/types.go
@@ -2,91 +2,24 @@ package storage
 
 import (
 	"context"
-	"time"
+
+	uptimestorage "github.com/gofiber/contrib/v3/uptime/storage"
 )
 
 // Store persists uptime state. Implementations must be safe for concurrent use.
 type Store interface {
+	uptimestorage.Store
+
 	Init(ctx context.Context) error
-
-	UpsertService(ctx context.Context, service Service) error
-	UpsertInstance(ctx context.Context, instance Instance) error
-
-	WriteHeartbeat(ctx context.Context, heartbeat Heartbeat) error
-
-	RollupDaily(ctx context.Context, options RollupOptions) error
-	Cleanup(ctx context.Context, options CleanupOptions) error
-
-	ListServices(ctx context.Context) ([]Service, error)
-	QueryDaily(ctx context.Context, options QueryDailyOptions) ([]DailyStatus, error)
-	QueryTodaySamples(ctx context.Context, options QueryTodaySamplesOptions) ([]TodaySampleStatus, error)
-
 	Close() error
 }
 
-// Service is the logical service identity shown on the dashboard.
-type Service struct {
-	ID             string
-	Name           string
-	Description    string
-	CreatedAt      time.Time
-	LastSeenAt     time.Time
-	SampleInterval time.Duration
-}
-
-// Instance describes one process lifetime of a service.
-type Instance struct {
-	ID         int64
-	ServiceID  string
-	Hostname   string
-	PID        int
-	StartedAt  time.Time
-	LastSeenAt time.Time
-}
-
-// Heartbeat records that one instance was alive during a day slot.
-type Heartbeat struct {
-	ServiceID  string
-	InstanceID int64
-	Day        string
-	Slot       int64
-	SeenAt     time.Time
-}
-
-// DailyStatus is a finalized service-level day snapshot.
-type DailyStatus struct {
-	ServiceID     string
-	Day           string
-	UpSlots       int
-	ExpectedSlots int
-	Finalized     bool
-}
-
-// TodaySampleStatus is the current raw service-level summary for one day.
-type TodaySampleStatus struct {
-	ServiceID string
-	Day       string
-	UpSlots   int
-}
-
-type RollupOptions struct {
-	BeforeDay                  string
-	ExpectedSlotsForDay        func(day string) int
-	ExpectedSlotsForServiceDay func(serviceID, day string) int
-}
-
-type CleanupOptions struct {
-	DailyBeforeDay   string
-	SamplesBeforeDay string
-}
-
-type QueryDailyOptions struct {
-	ServiceIDs []string
-	FromDay    string
-	ToDay      string
-}
-
-type QueryTodaySamplesOptions struct {
-	ServiceIDs []string
-	Day        string
-}
+type Service = uptimestorage.Service
+type Instance = uptimestorage.Instance
+type Heartbeat = uptimestorage.Heartbeat
+type DailyStatus = uptimestorage.DailyStatus
+type TodaySampleStatus = uptimestorage.TodaySampleStatus
+type RollupOptions = uptimestorage.RollupOptions
+type CleanupOptions = uptimestorage.CleanupOptions
+type QueryDailyOptions = uptimestorage.QueryDailyOptions
+type QueryTodaySamplesOptions = uptimestorage.QueryTodaySamplesOptions

--- a/v3/uptime/status.go
+++ b/v3/uptime/status.go
@@ -421,15 +421,6 @@ func expectedSlotsSoFarSince(now, createdAt time.Time, interval time.Duration, l
 	return expectedSlotsForWindow(dayOf(now, loc), createdAt, currentSlotStart(now, interval, loc), interval, loc, false)
 }
 
-func expectedSlotsForDay(day string, interval time.Duration, loc *time.Location) int {
-	start, err := parseDay(day, loc)
-	if err != nil || interval <= 0 {
-		return 0
-	}
-	end := start.AddDate(0, 0, 1)
-	return ceilDuration(end.Sub(start), interval)
-}
-
 func expectedSlotsForServiceDay(day string, createdAt time.Time, interval time.Duration, loc *time.Location) int {
 	return expectedSlotsForWindow(day, createdAt, time.Time{}, interval, loc, false)
 }

--- a/v3/uptime/status.go
+++ b/v3/uptime/status.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"time"
 
 	"github.com/gofiber/contrib/v3/uptime/internal/storage"
@@ -156,6 +157,10 @@ func (u *runtime) buildStatus(ctx context.Context, now time.Time) (StatusRespons
 		u.setLastError(err)
 		return StatusResponse{}, err
 	}
+	services = append([]storage.Service(nil), services...)
+	sort.Slice(services, func(i, j int) bool {
+		return services[i].ID < services[j].ID
+	})
 
 	days := dayRange(now, u.config.DaysToShow, u.config.Timezone)
 	fromDay := days[0]

--- a/v3/uptime/status_test.go
+++ b/v3/uptime/status_test.go
@@ -88,21 +88,21 @@ func TestExpectedSlotsSoFarSinceExcludesInProgressSlot(t *testing.T) {
 	}
 }
 
-func TestExpectedSlotsForDayCountsWholeDay(t *testing.T) {
+func TestExpectedSlotsForServiceDayCountsWholeDay(t *testing.T) {
 	t.Parallel()
 
-	requireEqual(t, 24, expectedSlotsForDay("2026-06-26", time.Hour, time.UTC))
-	requireEqual(t, 1440, expectedSlotsForDay("2026-06-26", time.Minute, time.UTC))
-	requireEqual(t, 0, expectedSlotsForDay("not-a-day", time.Minute, time.UTC))
+	requireEqual(t, 24, expectedSlotsForServiceDay("2026-06-26", time.Time{}, time.Hour, time.UTC))
+	requireEqual(t, 1440, expectedSlotsForServiceDay("2026-06-26", time.Time{}, time.Minute, time.UTC))
+	requireEqual(t, 0, expectedSlotsForServiceDay("not-a-day", time.Time{}, time.Minute, time.UTC))
 }
 
-func TestExpectedSlotsForDayHandlesDSTTransitions(t *testing.T) {
+func TestExpectedSlotsForServiceDayHandlesDSTTransitions(t *testing.T) {
 	t.Parallel()
 
 	loc, err := time.LoadLocation("America/New_York")
 	requireNoError(t, err)
 
-	requireEqual(t, 23, expectedSlotsForDay("2026-03-08", time.Hour, loc))
-	requireEqual(t, 25, expectedSlotsForDay("2026-11-01", time.Hour, loc))
-	requireEqual(t, 24, expectedSlotsForDay("2026-06-26", time.Hour, loc))
+	requireEqual(t, 23, expectedSlotsForServiceDay("2026-03-08", time.Time{}, time.Hour, loc))
+	requireEqual(t, 25, expectedSlotsForServiceDay("2026-11-01", time.Time{}, time.Hour, loc))
+	requireEqual(t, 24, expectedSlotsForServiceDay("2026-06-26", time.Time{}, time.Hour, loc))
 }

--- a/v3/uptime/storage/storage.go
+++ b/v3/uptime/storage/storage.go
@@ -15,6 +15,9 @@ import (
 // Store does not define resource initialization or shutdown. A store must be
 // ready for use before it is passed to uptime.New, and its caller owns its
 // lifecycle.
+//
+// Implementations may optionally provide Name() string to customize the
+// storage driver name exposed by uptime status responses.
 type Store interface {
 	// UpsertService creates or refreshes a logical service according to the
 	// timestamp and metadata semantics documented by Service.
@@ -123,8 +126,13 @@ type RollupOptions struct {
 // Boundary days themselves are retained, and samples required by an
 // unfinalized daily row must not be removed.
 type CleanupOptions struct {
-	DailyBeforeDay   string
-	SamplesBeforeDay string
+    // DailyBeforeDay is an exclusive upper bound for daily status cleanup.
+    // Empty disables daily status cleanup.
+    DailyBeforeDay string
+
+    // SamplesBeforeDay is an exclusive upper bound for raw sample cleanup.
+    // Empty disables raw sample cleanup.
+    SamplesBeforeDay string
 }
 
 // QueryDailyOptions selects persisted daily status rows.
@@ -139,8 +147,10 @@ type QueryDailyOptions struct {
 
 // QueryTodaySamplesOptions selects raw service-level summaries for one day.
 type QueryTodaySamplesOptions struct {
-	// ServiceIDs selects services. Nil means all services; a non-nil empty slice
-	// means no services.
-	ServiceIDs []string
-	Day        string
+    // ServiceIDs selects services. Nil means all services; a non-nil empty
+    // slice means no services.
+    ServiceIDs []string
+
+    // Day is the local calendar day to query. Empty returns no rows.
+    Day string
 }

--- a/v3/uptime/storage/storage.go
+++ b/v3/uptime/storage/storage.go
@@ -1,0 +1,141 @@
+// Package storage defines the persistence contract for Fiber Uptime backends.
+package storage
+
+import (
+	"context"
+	"time"
+)
+
+// Store persists uptime state. Implementations must be safe for concurrent use.
+//
+// Store does not define resource initialization or shutdown. A store must be
+// ready for use before it is passed to uptime.New, and its caller owns its
+// lifecycle.
+type Store interface {
+	// UpsertService creates or refreshes a logical service according to the
+	// timestamp and metadata semantics documented by Service.
+	UpsertService(ctx context.Context, service Service) error
+	// UpsertInstance creates or refreshes one process instance according to the
+	// timestamp and metadata semantics documented by Instance.
+	UpsertInstance(ctx context.Context, instance Instance) error
+	// WriteHeartbeat records one up slot and refreshes the referenced service and
+	// instance last-seen timestamps monotonically.
+	WriteHeartbeat(ctx context.Context, heartbeat Heartbeat) error
+
+	// RollupDaily finalizes raw samples for days before the exclusive boundary.
+	// Repeated or concurrent rollups must not overwrite a finalized daily row.
+	RollupDaily(ctx context.Context, options RollupOptions) error
+	// Cleanup removes expired daily and raw sample data according to the
+	// exclusive boundaries in CleanupOptions.
+	Cleanup(ctx context.Context, options CleanupOptions) error
+
+	// ListServices returns all persisted services. Result ordering is unspecified.
+	ListServices(ctx context.Context) ([]Service, error)
+	// QueryDaily returns daily rows matching the requested services and day range.
+	// Result ordering is unspecified.
+	QueryDaily(ctx context.Context, options QueryDailyOptions) ([]DailyStatus, error)
+	// QueryTodaySamples returns raw service-level summaries for one day. Result
+	// ordering is unspecified.
+	QueryTodaySamples(ctx context.Context, options QueryTodaySamplesOptions) ([]TodaySampleStatus, error)
+}
+
+// Service is the stable logical service identity shown on the dashboard.
+type Service struct {
+	// ID is the stable logical service identity.
+	ID string
+	// Name and Description are refreshable display metadata.
+	Name        string
+	Description string
+	// CreatedAt is initialized when the service is first observed and must not
+	// replace an existing non-zero value. A later non-zero value may fill an
+	// initially zero value.
+	CreatedAt time.Time
+	// LastSeenAt must advance monotonically and never move backwards.
+	LastSeenAt time.Time
+	// SampleInterval is refreshable service metadata.
+	SampleInterval time.Duration
+}
+
+// Instance describes one process lifetime of a service.
+type Instance struct {
+	// ID identifies one process lifetime.
+	ID int64
+	// ServiceID, Hostname, and PID are refreshable instance metadata.
+	ServiceID string
+	Hostname  string
+	PID       int
+	// StartedAt is initialized once and must not replace an existing non-zero
+	// value.
+	StartedAt time.Time
+	// LastSeenAt must advance monotonically and never move backwards.
+	LastSeenAt time.Time
+}
+
+// Heartbeat records that one service was up during a day slot.
+//
+// Writes are idempotent by (ServiceID, Day, Slot): repeated writes, including
+// writes from different instances, count as exactly one service-level up slot.
+// SeenAt refreshes the referenced service and instance last-seen timestamps
+// monotonically.
+type Heartbeat struct {
+	ServiceID  string
+	InstanceID int64
+	Day        string
+	Slot       int64
+	SeenAt     time.Time
+}
+
+// DailyStatus is a finalized service-level day snapshot.
+type DailyStatus struct {
+	ServiceID     string
+	Day           string
+	UpSlots       int
+	ExpectedSlots int
+	Finalized     bool
+}
+
+// TodaySampleStatus is the current raw service-level summary for one day.
+type TodaySampleStatus struct {
+	ServiceID string
+	Day       string
+	UpSlots   int
+}
+
+// ExpectedSlotsFunc returns the expected slot count for one service day.
+type ExpectedSlotsFunc func(service Service, day string) int
+
+// RollupOptions controls daily sample finalization.
+type RollupOptions struct {
+	// BeforeDay is an exclusive upper bound. Days less than BeforeDay are
+	// eligible for rollup. An empty value performs no rollup.
+	BeforeDay string
+	// ExpectedSlots computes the expected slot count for a service day. A nil
+	// callback means zero expected slots.
+	ExpectedSlots ExpectedSlotsFunc
+}
+
+// CleanupOptions controls retention cleanup using exclusive day boundaries.
+// Boundary days themselves are retained, and samples required by an
+// unfinalized daily row must not be removed.
+type CleanupOptions struct {
+	DailyBeforeDay   string
+	SamplesBeforeDay string
+}
+
+// QueryDailyOptions selects finalized daily rows.
+type QueryDailyOptions struct {
+	// ServiceIDs selects services. Nil means all services; a non-nil empty slice
+	// means no services.
+	ServiceIDs []string
+	// FromDay and ToDay are inclusive. Empty values leave that end unbounded.
+	FromDay string
+	ToDay   string
+}
+
+// QueryTodaySamplesOptions selects raw service-level summaries for one day.
+type QueryTodaySamplesOptions struct {
+	// ServiceIDs selects services. Nil means all services; a non-nil empty slice
+	// means no services.
+	ServiceIDs []string
+	Day        string
+}

--- a/v3/uptime/storage/storage.go
+++ b/v3/uptime/storage/storage.go
@@ -1,4 +1,8 @@
 // Package storage defines the persistence contract for Fiber Uptime backends.
+//
+// All day strings are local calendar dates formatted as YYYY-MM-DD in the
+// timezone configured for Uptime. This representation sorts chronologically
+// when compared lexicographically.
 package storage
 
 import (
@@ -46,9 +50,8 @@ type Service struct {
 	// Name and Description are refreshable display metadata.
 	Name        string
 	Description string
-	// CreatedAt is initialized when the service is first observed and must not
-	// replace an existing non-zero value. A later non-zero value may fill an
-	// initially zero value.
+	// CreatedAt is when the service was first observed. It remains stable across
+	// later upserts.
 	CreatedAt time.Time
 	// LastSeenAt must advance monotonically and never move backwards.
 	LastSeenAt time.Time
@@ -64,8 +67,8 @@ type Instance struct {
 	ServiceID string
 	Hostname  string
 	PID       int
-	// StartedAt is initialized once and must not replace an existing non-zero
-	// value.
+	// StartedAt is when this process instance started. It remains stable across
+	// later upserts.
 	StartedAt time.Time
 	// LastSeenAt must advance monotonically and never move backwards.
 	LastSeenAt time.Time
@@ -73,9 +76,10 @@ type Instance struct {
 
 // Heartbeat records that one service was up during a day slot.
 //
-// Writes are idempotent by (ServiceID, Day, Slot): repeated writes, including
-// writes from different instances, count as exactly one service-level up slot.
-// SeenAt refreshes the referenced service and instance last-seen timestamps
+// Slot is the zero-based sample interval within Day. The tuple (ServiceID, Day,
+// Slot) is the deduplication identity: repeated writes, including writes from
+// different instances, count as exactly one service-level up slot. SeenAt
+// refreshes the referenced service and instance last-seen timestamps
 // monotonically.
 type Heartbeat struct {
 	ServiceID  string
@@ -109,8 +113,9 @@ type RollupOptions struct {
 	// BeforeDay is an exclusive upper bound. Days less than BeforeDay are
 	// eligible for rollup. An empty value performs no rollup.
 	BeforeDay string
-	// ExpectedSlots computes the expected slot count for a service day. A nil
-	// callback means zero expected slots.
+	// ExpectedSlots computes the expected slot count for a service day. A backend
+	// may call it while RollupDaily is executing, but must not retain or invoke it
+	// after RollupDaily returns. A nil callback means zero expected slots.
 	ExpectedSlots ExpectedSlotsFunc
 }
 
@@ -122,7 +127,7 @@ type CleanupOptions struct {
 	SamplesBeforeDay string
 }
 
-// QueryDailyOptions selects finalized daily rows.
+// QueryDailyOptions selects persisted daily status rows.
 type QueryDailyOptions struct {
 	// ServiceIDs selects services. Nil means all services; a non-nil empty slice
 	// means no services.

--- a/v3/uptime/uptime.go
+++ b/v3/uptime/uptime.go
@@ -92,12 +92,24 @@ func newRuntime(config ...Config) (*runtime, error) {
 	if err != nil {
 		return nil, err
 	}
-	if cfg.Store == nil {
+	store, err := configuredStore(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return newWithStore(cfg, store, time.Now())
+}
+
+func configuredStore(cfg Config) (storage.Store, error) {
+	switch {
+	case cfg.Store != nil && cfg.Storage != nil:
+		return nil, ErrConflictingStorage
+	case cfg.Storage != nil:
+		return storage.NewExternalStore(cfg.Storage), nil
+	case cfg.Store != nil:
+		return storage.NewRedisStore(newRedisStoreConfig(cfg)), nil
+	default:
 		return nil, ErrMissingStore
 	}
-
-	store := storage.NewRedisStore(newRedisStoreConfig(cfg))
-	return newWithStore(cfg, store, time.Now())
 }
 
 func newRedisStoreConfig(cfg Config) storage.RedisConfig {
@@ -580,26 +592,13 @@ func (u *runtime) runMaintenance(ctx context.Context, now time.Time, force bool)
 		return err
 	}
 
-	expected := func(day string) int {
-		return expectedSlotsForDay(day, u.config.SampleInterval, u.config.Timezone)
-	}
-	services, err := u.serviceRollupMetadata(ctx)
-	if err != nil {
-		u.setLastError(err)
-		fiberlog.Errorf("uptime: list services for maintenance: %v", err)
-		return err
-	}
-	expectedForService := func(serviceID, day string) int {
-		service, ok := services[serviceID]
-		if !ok {
-			return expected(day)
-		}
-		return expectedSlotsForServiceDay(day, service.createdAt, service.interval, u.config.Timezone)
+	expectedSlots := func(service storage.Service, day string) int {
+		interval := u.serviceSampleInterval(service)
+		return expectedSlotsForServiceDay(day, service.CreatedAt, interval, u.config.Timezone)
 	}
 	if err := u.store.RollupDaily(ctx, storage.RollupOptions{
-		BeforeDay:                  today,
-		ExpectedSlotsForDay:        expected,
-		ExpectedSlotsForServiceDay: expectedForService,
+		BeforeDay:     today,
+		ExpectedSlots: expectedSlots,
 	}); err != nil {
 		u.setLastError(err)
 		fiberlog.Errorf("uptime: rollup daily: %v", err)
@@ -620,26 +619,6 @@ func (u *runtime) runMaintenance(ctx context.Context, now time.Time, force bool)
 	u.lastMaintenance = now
 	u.lastMaintenanceDay = today
 	return nil
-}
-
-type serviceRollupMetadata struct {
-	createdAt time.Time
-	interval  time.Duration
-}
-
-func (u *runtime) serviceRollupMetadata(ctx context.Context) (map[string]serviceRollupMetadata, error) {
-	services, err := u.store.ListServices(ctx)
-	if err != nil {
-		return nil, err
-	}
-	metadata := make(map[string]serviceRollupMetadata, len(services))
-	for _, service := range services {
-		metadata[service.ID] = serviceRollupMetadata{
-			createdAt: service.CreatedAt,
-			interval:  u.serviceSampleInterval(service),
-		}
-	}
-	return metadata, nil
 }
 
 func (u *runtime) setLastError(err error) {

--- a/v3/uptime/uptime.go
+++ b/v3/uptime/uptime.go
@@ -122,12 +122,13 @@ func newRedisStoreConfig(cfg Config) storage.RedisConfig {
 	}
 }
 
-// RemoveService deletes all stored uptime state for serviceID, including its
-// history. Services are never removed automatically while their retention
+// RemoveService deletes all Redis-backed uptime state for serviceID,
+// including its history. Services are never removed automatically while their retention
 // window is refreshed, so call this after retiring or renaming a service or an
 // endpoint ID. Otherwise the old ID keeps its dashboard row and reports down.
 //
-// keyPrefix must match Config.StorageKeyPrefix; empty uses the default.
+// keyPrefix must match Config.StorageKeyPrefix used with Config.Store;
+// empty uses the default.
 func RemoveService(ctx context.Context, store *fiberredis.Storage, keyPrefix, serviceID string) error {
 	if store == nil {
 		return ErrMissingStore

--- a/v3/uptime/uptime_test.go
+++ b/v3/uptime/uptime_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gofiber/contrib/v3/uptime/internal/storage"
 	"github.com/gofiber/fiber/v3"
+	fiberredis "github.com/gofiber/storage/redis/v3"
 )
 
 func TestConfigDefaults(t *testing.T) {
@@ -623,6 +624,45 @@ func TestNewPanicsWithoutStore(t *testing.T) {
 	_ = New(Config{App: fiber.New(), ServiceID: "api"})
 }
 
+func TestConfiguredStoreSelection(t *testing.T) {
+	t.Parallel()
+
+	redisStorage := new(fiberredis.Storage)
+
+	selected, err := configuredStore(Config{Store: redisStorage})
+	requireNoError(t, err)
+	if _, ok := selected.(*storage.RedisStore); !ok {
+		t.Fatalf("store = %T, want *storage.RedisStore", selected)
+	}
+
+	custom := newSnapshotStore()
+	selected, err = configuredStore(Config{Storage: custom})
+	requireNoError(t, err)
+	requireNoError(t, selected.Init(context.Background()))
+	requireNoError(t, selected.Close())
+	requireEqual(t, 0, custom.initCalls)
+	requireEqual(t, 0, custom.closeCalls)
+
+	_, err = configuredStore(Config{Store: redisStorage, Storage: custom})
+	if !errors.Is(err, ErrConflictingStorage) {
+		t.Fatalf("error = %v, want %v", err, ErrConflictingStorage)
+	}
+	_, err = newRuntime(Config{
+		App:       fiber.New(),
+		Store:     redisStorage,
+		Storage:   custom,
+		ServiceID: "api",
+	})
+	if !errors.Is(err, ErrConflictingStorage) {
+		t.Fatalf("newRuntime error = %v, want %v", err, ErrConflictingStorage)
+	}
+
+	_, err = configuredStore(Config{})
+	if !errors.Is(err, ErrMissingStore) {
+		t.Fatalf("error = %v, want %v", err, ErrMissingStore)
+	}
+}
+
 func TestSnapshotBuildsFreshStatus(t *testing.T) {
 	t.Parallel()
 
@@ -777,6 +817,23 @@ func TestBuildStatusPassesKnownServiceIDsToQueries(t *testing.T) {
 	requireEqual(t, "api", store.queryTodayOptions.ServiceIDs[0])
 }
 
+func TestBuildStatusSortsServicesByID(t *testing.T) {
+	t.Parallel()
+
+	store := newSnapshotStore()
+	store.services = []storage.Service{
+		{ID: "z", Name: "Z", CreatedAt: store.now.Add(-time.Hour), LastSeenAt: store.now, SampleInterval: time.Second},
+		{ID: "a", Name: "A", CreatedAt: store.now.Add(-time.Hour), LastSeenAt: store.now, SampleInterval: time.Second},
+	}
+	u := newSnapshotUptime(store)
+
+	status, err := u.buildStatus(context.Background(), store.now)
+	requireNoError(t, err)
+	requireLen(t, status.Services, 2)
+	requireEqual(t, "a", status.Services[0].ID)
+	requireEqual(t, "z", status.Services[1].ID)
+}
+
 func TestDayStatusUsesServiceCreatedAtForToday(t *testing.T) {
 	t.Parallel()
 
@@ -877,12 +934,12 @@ func TestRollupExpectedSlotsUsesServiceCreatedAt(t *testing.T) {
 
 	requireNoError(t, u.runMaintenance(context.Background(), now, true))
 	requireEqual(t, 1, store.rollupCalls)
-	if store.rollupOptions.ExpectedSlotsForServiceDay == nil {
+	if store.rollupOptions.ExpectedSlots == nil {
 		t.Fatal("service-aware expected slots callback is nil")
 	}
 
-	requireEqual(t, 540, store.rollupOptions.ExpectedSlotsForServiceDay("api", "2026-06-25"))
-	requireEqual(t, 0, store.rollupOptions.ExpectedSlotsForServiceDay("api", "2026-06-24"))
+	requireEqual(t, 540, store.rollupOptions.ExpectedSlots(store.services[0], "2026-06-25"))
+	requireEqual(t, 0, store.rollupOptions.ExpectedSlots(store.services[0], "2026-06-24"))
 }
 
 func TestBuildStatusDoesNotClearRuntimeError(t *testing.T) {
@@ -1562,7 +1619,7 @@ func (s *snapshotStore) QueryDaily(_ context.Context, options storage.QueryDaily
 	var statuses []storage.DailyStatus
 	serviceIDs := stringSet(options.ServiceIDs)
 	for _, status := range s.daily {
-		if len(serviceIDs) > 0 {
+		if options.ServiceIDs != nil {
 			if _, ok := serviceIDs[status.ServiceID]; !ok {
 				continue
 			}
@@ -1582,7 +1639,7 @@ func (s *snapshotStore) QueryTodaySamples(_ context.Context, options storage.Que
 	var statuses []storage.TodaySampleStatus
 	serviceIDs := stringSet(options.ServiceIDs)
 	for _, status := range s.today {
-		if len(serviceIDs) > 0 {
+		if options.ServiceIDs != nil {
 			if _, ok := serviceIDs[status.ServiceID]; !ok {
 				continue
 			}


### PR DESCRIPTION
- Exposes a public `uptime/storage.Store` contract for custom storage backends.
- Adds `Config.Storage` while keeping the existing Redis `Config.Store` path unchanged.
- Keeps Redis as the simple built-in integration and preserves backward compatibility.

I'm planning to build a small, local, out-of-the-box tool on top of Fiber Uptime and wanted to use bbolt for persistence.

Uptime is currently tightly coupled to Redis, which makes using bbolt or another storage backend impractical without emulating Redis behavior.

This change keeps the existing Redis experience simple for most users, while providing an extension point for users who need a different persistence model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for custom storage backends alongside Redis.
  - Added configuration options and validation for selecting a storage backend.
  - Added a documented storage interface for uptime data and status operations.

- **Bug Fixes**
  - Status results now use deterministic service ordering.
  - Improved service filtering and daily rollup handling.
  - Custom storage resources remain under the caller’s control during shutdown.

- **Documentation**
  - Expanded uptime configuration guidance for custom storage and Redis-specific settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->