### PR TITLE
⚡ perf(websocket): cut hot-path allocations and fix RFC 6455 compliance gaps

### DIFF
--- a/v3/websocket/README.md
+++ b/v3/websocket/README.md
@@ -154,12 +154,11 @@ itself, so it can write whatever the application considers safe.
 Once the recover handler returns, the connection is closed: a handler that panicked
 cannot be assumed to still own it, and nothing else closes a hijacked connection.
 
-A handler that returns normally leaves the socket open. If it needs to keep writing
-from another goroutine after returning, it must capture the embedded connection,
-`c.Conn` (a `*github.com/fasthttp/websocket.Conn`), before it returns. The
-`*websocket.Conn` the handler receives is pooled: it is taken back the moment the
-handler returns and reissued to the next upgrade, so a goroutine that keeps using it
-would first see failed writes and then another client's socket and request data.
+A handler that returns normally leaves the socket open, so it may hand the
+connection to another goroutine before returning and keep writing after. The
+`*websocket.Conn` it receives is allocated for that upgrade alone and never reused,
+so `Locals`, `Params`, `Query`, `Cookies`, `Headers` and `IP` keep answering with
+that connection's own data for as long as anything holds it.
 
 ```go
 app := fiber.New()

--- a/v3/websocket/README.md
+++ b/v3/websocket/README.md
@@ -108,7 +108,8 @@ func main() {
 
 ## Handshake rejections
 
-A request that does not ask to switch protocols at all is answered with `426 Upgrade Required`.
+A request that carries neither an `Upgrade` header nor an `upgrade` token in
+`Connection` never asked to switch protocols and is answered with `426 Upgrade Required`.
 
 A request that *does* ask to upgrade but whose handshake is rejected is returned as a
 `*fiber.Error` carrying the status RFC 6455 defines for that failure, so it reaches
@@ -118,7 +119,7 @@ there:
 | Reason                                                     | Status                    |
 |:-----------------------------------------------------------|:--------------------------|
 | Origin not in `Origins` (RFC 6455 section 4.2.2)            | `403 Forbidden`           |
-| Missing/blank `Sec-WebSocket-Key`, unsupported version      | `400 Bad Request`         |
+| Missing/blank `Sec-WebSocket-Key`, unsupported version, or only one of the `Upgrade`/`Connection` signals | `400 Bad Request` |
 | Request method is not `GET`                                 | `405 Method Not Allowed`  |
 
 Rejected handshakes also carry `Sec-WebSocket-Version: 13` so a client that asked for

--- a/v3/websocket/README.md
+++ b/v3/websocket/README.md
@@ -37,8 +37,8 @@ func New(handler func(*websocket.Conn), config ...websocket.Config) fiber.Handle
 |:--------------------|:-----------------------------|:------------------------------------------------------------------------------------------------------------------------------|:-----------------------|
 | Next                | `func(fiber.Ctx) bool`       | Defines a function to skip this middleware when it returns true.                                                              | `nil`                  |
 | HandshakeTimeout    | `time.Duration`              | HandshakeTimeout specifies the duration for the handshake to complete.                                                        | `0` (No timeout)       |
-| Subprotocols        | `[]string`                   | Subprotocols specifies the client's requested subprotocols.                                                                   | `nil`                  |
-| Origins             | `[]string`                   | Allowed Origins based on the Origin header. If empty, everything is allowed.                                                  | `nil`                  |
+| Subprotocols        | `[]string`                   | Subprotocols this server supports, in order of preference. The first entry the client also offers is negotiated.               | `nil`                  |
+| Origins             | `[]string`                   | Allowed Origins based on the Origin header, compared case-insensitively. If empty, everything is allowed.                     | `nil`                  |
 | AllowEmptyOrigin    | `bool`                       | Allows connections without an Origin header when Origins is configured. Useful for non-browser clients.                       | `false`                |
 | ReadBufferSize      | `int`                        | ReadBufferSize specifies the I/O buffer size in bytes for incoming messages.                                                  | `0` (Use default size) |
 | WriteBufferSize     | `int`                        | WriteBufferSize specifies the I/O buffer size in bytes for outgoing messages.                                                 | `0` (Use default size) |
@@ -105,6 +105,22 @@ func main() {
 }
 
 ```
+
+## Handshake rejections
+
+A request that does not ask to switch protocols at all is answered with `426 Upgrade Required`.
+
+A request that *does* ask to upgrade but whose handshake is rejected keeps the status
+RFC 6455 defines for that failure instead:
+
+| Reason                                                     | Status                    |
+|:-----------------------------------------------------------|:--------------------------|
+| Origin not in `Origins` (RFC 6455 section 4.2.2)            | `403 Forbidden`           |
+| Missing/blank `Sec-WebSocket-Key`, unsupported version      | `400 Bad Request`         |
+| Request method is not `GET`                                 | `405 Method Not Allowed`  |
+
+Rejected handshakes also carry `Sec-WebSocket-Version: 13` so a client that asked for
+another version learns which one the server speaks (RFC 6455 section 4.4).
 
 ## Note with cache middleware
 

--- a/v3/websocket/README.md
+++ b/v3/websocket/README.md
@@ -142,6 +142,12 @@ app.Get("/ws/:id", websocket.New(func(c *websocket.Conn) {}))
 For internal implementation reasons, currently recover middleware does not work with websocket middleware, please use `config.RecoverHandler` to add recover handler to websocket endpoints.
 By default, config `RecoverHandler` recovers from panic and writes stack trace to stderr, also returns a response that contains panic message in **error** field.
 
+The recovered value is handed to the JSON encoder unrendered, so `panic("boom")`
+puts `{"error":"boom"}` on the wire while `panic(err)` encodes as `{"error":{}}`
+and the error text stays on stderr. If your handlers can panic with values that
+carry internal detail, supply a `RecoverHandler` that sends a constant message to
+the peer instead.
+
 Once the recover handler returns, the connection is closed: a handler that panicked
 cannot be assumed to still own it, and nothing else closes a hijacked connection. A
 handler that returns normally keeps its connection open, so it can hand the raw

--- a/v3/websocket/README.md
+++ b/v3/websocket/README.md
@@ -110,8 +110,10 @@ func main() {
 
 A request that does not ask to switch protocols at all is answered with `426 Upgrade Required`.
 
-A request that *does* ask to upgrade but whose handshake is rejected keeps the status
-RFC 6455 defines for that failure instead:
+A request that *does* ask to upgrade but whose handshake is rejected is returned as a
+`*fiber.Error` carrying the status RFC 6455 defines for that failure, so it reaches
+the app's `ErrorHandler` like any other error and takes its body and format from
+there:
 
 | Reason                                                     | Status                    |
 |:-----------------------------------------------------------|:--------------------------|
@@ -120,7 +122,8 @@ RFC 6455 defines for that failure instead:
 | Request method is not `GET`                                 | `405 Method Not Allowed`  |
 
 Rejected handshakes also carry `Sec-WebSocket-Version: 13` so a client that asked for
-another version learns which one the server speaks (RFC 6455 section 4.4).
+another version learns which one the server speaks (RFC 6455 section 4.4). Headers set
+by earlier middleware are left in place.
 
 ## Note with cache middleware
 
@@ -149,9 +152,14 @@ own `RecoverHandler` — it receives the `*websocket.Conn` and calls `recover()`
 itself, so it can write whatever the application considers safe.
 
 Once the recover handler returns, the connection is closed: a handler that panicked
-cannot be assumed to still own it, and nothing else closes a hijacked connection. A
-handler that returns normally keeps its connection open, so it can hand the raw
-`*websocket.Conn` to another goroutine and keep writing after the handler returns.
+cannot be assumed to still own it, and nothing else closes a hijacked connection.
+
+A handler that returns normally leaves the socket open. If it needs to keep writing
+from another goroutine after returning, it must capture the embedded connection,
+`c.Conn` (a `*github.com/fasthttp/websocket.Conn`), before it returns. The
+`*websocket.Conn` the handler receives is pooled: it is taken back the moment the
+handler returns and reissued to the next upgrade, so a goroutine that keeps using it
+would first see failed writes and then another client's socket and request data.
 
 ```go
 app := fiber.New()

--- a/v3/websocket/README.md
+++ b/v3/websocket/README.md
@@ -142,6 +142,11 @@ app.Get("/ws/:id", websocket.New(func(c *websocket.Conn) {}))
 For internal implementation reasons, currently recover middleware does not work with websocket middleware, please use `config.RecoverHandler` to add recover handler to websocket endpoints.
 By default, config `RecoverHandler` recovers from panic and writes stack trace to stderr, also returns a response that contains panic message in **error** field.
 
+Once the recover handler returns, the connection is closed: a handler that panicked
+cannot be assumed to still own it, and nothing else closes a hijacked connection. A
+handler that returns normally keeps its connection open, so it can hand the raw
+`*websocket.Conn` to another goroutine and keep writing after the handler returns.
+
 ```go
 app := fiber.New()
 

--- a/v3/websocket/README.md
+++ b/v3/websocket/README.md
@@ -140,13 +140,13 @@ app.Get("/ws/:id", websocket.New(func(c *websocket.Conn) {}))
 ## Note with recover middleware
 
 For internal implementation reasons, currently recover middleware does not work with websocket middleware, please use `config.RecoverHandler` to add recover handler to websocket endpoints.
-By default, config `RecoverHandler` recovers from panic and writes stack trace to stderr, also returns a response that contains panic message in **error** field.
+By default, config `RecoverHandler` recovers from panic, writes the value and stack trace to stderr, and sends the peer a fixed `{"error":"internal error"}`.
 
-The recovered value is handed to the JSON encoder unrendered, so `panic("boom")`
-puts `{"error":"boom"}` on the wire while `panic(err)` encodes as `{"error":{}}`
-and the error text stays on stderr. If your handlers can panic with values that
-carry internal detail, supply a `RecoverHandler` that sends a constant message to
-the peer instead.
+Nothing derived from the panic reaches the client: the operator already has the
+full detail on stderr, and a panic value can carry internal paths, connection
+strings or schema names. If you want the peer told more than that, supply your
+own `RecoverHandler` — it receives the `*websocket.Conn` and calls `recover()`
+itself, so it can write whatever the application considers safe.
 
 Once the recover handler returns, the connection is closed: a handler that panicked
 cannot be assumed to still own it, and nothing else closes a hijacked connection. A

--- a/v3/websocket/event/README.md
+++ b/v3/websocket/event/README.md
@@ -174,10 +174,15 @@ app.Hooks().OnShutdown(func() error {
 If `ctx` expires before every goroutine exits, `CloseAll` force-closes the
 remaining underlying connections and returns `ctx.Err()`.
 
-The close frame is normalised before it goes on the wire: a `code` reserved for
-local use (`1006`, `1015`) or outside `1000-4999` is replaced with
-`1000 Normal Closure` (RFC 6455 section 7.4), and `reason` is scrubbed to valid
-UTF-8 and cut back to 123 bytes on a rune boundary (RFC 6455 section 5.5.1).
+The close frame is normalised before it goes on the wire. Only a `code` a
+conformant peer accepts on receive is forwarded — `1000-1003`, `1007-1013`, and
+the `3000-4999` application range; anything else is replaced with
+`1000 Normal Closure`. That covers the codes RFC 6455 section 7.4.1 reserves for
+locally observed conditions (`1005`, `1006`, `1015`), `1004` (reserved with no
+meaning assigned), and `1014` and `1016-2999`, all of which would otherwise make
+the peer fail the connection with a protocol error instead of reading a close.
+`reason` is scrubbed to valid UTF-8 and cut back to 123 bytes on a rune boundary
+(RFC 6455 section 5.5.1).
 
 `Drain` only flips the draining flag; it does **not** refuse new connections by
 itself. Gate the upgrade route on `IsDraining` to stop accepting clients during

--- a/v3/websocket/event/README.md
+++ b/v3/websocket/event/README.md
@@ -171,18 +171,19 @@ app.Hooks().OnShutdown(func() error {
 })
 ```
 
-If `ctx` expires before every goroutine exits, `CloseAll` force-closes the
-remaining underlying connections and returns `ctx.Err()`.
+`CloseAll` returns once every connection has been sent its close frame and marked
+disconnected; the connections' own goroutines then wind down by themselves. If
+`ctx` expires before that point, `CloseAll` force-closes the connections still in
+the pool and returns `ctx.Err()`.
 
 The close frame is normalised before it goes on the wire. Only a `code` a
-conformant peer accepts on receive is forwarded — `1000-1003`, `1007-1013`, and
-the `3000-4999` application range; anything else is replaced with
-`1000 Normal Closure`. That covers the codes RFC 6455 section 7.4.1 reserves for
-locally observed conditions (`1005`, `1006`, `1015`), `1004` (reserved with no
-meaning assigned), and `1014` and `1016-2999`, all of which would otherwise make
-the peer fail the connection with a protocol error instead of reading a close.
-`reason` is scrubbed to valid UTF-8 and cut back to 123 bytes on a rune boundary
-(RFC 6455 section 5.5.1).
+conformant peer accepts on receive is forwarded — `1000-1003`, `1007-1013` and
+the `3000-4999` application range — and anything else is replaced with
+`1000 Normal Closure`, since a peer answers such codes with a protocol error
+instead of reading a close. `1005` is the exception: it is sent as an empty close
+frame, which is how "no status" is expressed on the wire, so a `reason` passed
+with it is necessarily dropped. `reason` is otherwise scrubbed to valid UTF-8 and
+cut back to 123 bytes on a rune boundary (RFC 6455 section 5.5.1).
 
 `Drain` only flips the draining flag; it does **not** refuse new connections by
 itself. Gate the upgrade route on `IsDraining` to stop accepting clients during

--- a/v3/websocket/event/README.md
+++ b/v3/websocket/event/README.md
@@ -174,6 +174,11 @@ app.Hooks().OnShutdown(func() error {
 If `ctx` expires before every goroutine exits, `CloseAll` force-closes the
 remaining underlying connections and returns `ctx.Err()`.
 
+The close frame is normalised before it goes on the wire: a `code` reserved for
+local use (`1006`, `1015`) or outside `1000-4999` is replaced with
+`1000 Normal Closure` (RFC 6455 section 7.4), and `reason` is scrubbed to valid
+UTF-8 and cut back to 123 bytes on a rune boundary (RFC 6455 section 5.5.1).
+
 `Drain` only flips the draining flag; it does **not** refuse new connections by
 itself. Gate the upgrade route on `IsDraining` to stop accepting clients during
 shutdown:

--- a/v3/websocket/event/event.go
+++ b/v3/websocket/event/event.go
@@ -1014,11 +1014,11 @@ func stopTimer(timer *time.Timer) {
 }
 
 func fireGlobalEvent(event string, data []byte, err error) {
-	// One copy of the caller's bytes for the whole fan-out, not one per
-	// connection.
-	data = cloneBytes(data)
+	// Every connection gets its own copy of the bytes: Data is a mutable slice
+	// with no read-only contract, so a listener that changes or retains it for
+	// one connection must not touch what another connection's listeners see.
 	for _, kws := range pool.snapshot() {
-		kws.fireOwnedEvent(event, data, err)
+		kws.fireEvent(event, data, err)
 	}
 }
 

--- a/v3/websocket/event/event.go
+++ b/v3/websocket/event/event.go
@@ -96,9 +96,7 @@ type message struct {
 	retries int
 }
 
-// EventPayload stores information about an event and its connection. One value
-// is shared by every listener of a fired event, so listeners must treat it as
-// read-only; the same already held for Data and SocketAttributes.
+// EventPayload stores information about an event and its connection.
 type EventPayload struct {
 	// Kws is the connection object.
 	Kws *Websocket
@@ -391,11 +389,11 @@ func NewWithConfig(callback func(kws *Websocket), eventCfg Config, wsConfig ...w
 		kws.UUID = kws.createUUID()
 		pool.set(kws)
 
-		// run leaves the pool and the socket clean on the normal path; this
-		// covers the abnormal one. Without it a panic in callback would strand a
-		// pool entry whose done channel is never closed, so the connection would
-		// keep accepting queued messages nobody reads and every later Broadcast
-		// would end up blocked on the full queue.
+		// run leaves the pool clean on the normal path; this covers the abnormal
+		// one. Without it a panic in callback would strand a pool entry whose
+		// done channel is never closed, so the connection would keep accepting
+		// queued messages nobody reads and every later Broadcast would end up
+		// blocked on the full queue.
 		defer kws.shutdown()
 
 		callback(kws)
@@ -949,13 +947,14 @@ func (kws *Websocket) unblockRead() {
 	}
 }
 
-// shutdown makes sure a connection leaves the pool and its socket is closed
-// even when the user callback or the read loop panicked. Both steps are
-// idempotent, so on the normal path, where run already performed them, it costs
-// nothing.
+// shutdown makes sure a connection leaves the pool even when the user callback
+// or the read loop panicked, so no later Broadcast can queue into a connection
+// nobody reads. It is idempotent, so on the normal path, where run already did
+// it, it costs nothing. The socket itself is deliberately left alone: the
+// middleware closes a panicked handler's connection once its RecoverHandler has
+// written the error frame.
 func (kws *Websocket) shutdown() {
 	kws.disconnected(nil)
-	kws.closeConn()
 }
 
 func (kws *Websocket) closeConn() {
@@ -1005,12 +1004,9 @@ func (kws *Websocket) fireEvent(event string, data []byte, err error) {
 	}
 
 	kws.mu.RLock()
-	var attrs map[string]any
-	if len(kws.attributes) > 0 {
-		attrs = make(map[string]any, len(kws.attributes))
-		for key, value := range kws.attributes {
-			attrs[key] = value
-		}
+	attrs := make(map[string]any, len(kws.attributes))
+	for key, value := range kws.attributes {
+		attrs[key] = value
 	}
 	socketUUID := kws.UUID
 	kws.mu.RUnlock()
@@ -1019,12 +1015,14 @@ func (kws *Websocket) fireEvent(event string, data []byte, err error) {
 	// slice are not exposed to the read buffer being reused by the next
 	// frame.
 	var payloadData []byte
-	if len(data) > 0 {
+	if data != nil {
 		payloadData = make([]byte, len(data))
 		copy(payloadData, data)
 	}
 
-	payload := &EventPayload{
+	// Each listener gets its own payload value: one listener mutating the
+	// struct must not be visible to the ones that run after it.
+	payload := EventPayload{
 		Kws:              kws,
 		Name:             event,
 		SocketUUID:       socketUUID,
@@ -1033,10 +1031,12 @@ func (kws *Websocket) fireEvent(event string, data []byte, err error) {
 		Error:            err,
 	}
 	for _, callback := range globalCallbacks {
-		kws.invokeCallback(event, callback, payload)
+		p := payload
+		kws.invokeCallback(event, callback, &p)
 	}
 	for _, callback := range localCallbacks {
-		kws.invokeCallback(event, callback, payload)
+		p := payload
+		kws.invokeCallback(event, callback, &p)
 	}
 }
 

--- a/v3/websocket/event/event.go
+++ b/v3/websocket/event/event.go
@@ -67,11 +67,9 @@ var (
 	ErrorInvalidConnection = errors.New("message cannot be delivered invalid/gone connection")
 	// ErrorUUIDDuplication indicates that the UUID already exists in the pool.
 	ErrorUUIDDuplication = errors.New("UUID already exists in the available connections pool")
-	// ErrorCallbackPanic is carried by the EventError fired when the connection
-	// callback passed to New or NewWithConfig panics, and by the
-	// EventDisconnect fired with it unless the callback had already closed the
-	// connection itself. The panic value goes to the middleware's
-	// RecoverHandler.
+	// ErrorCallbackPanic is carried by the EventError fired when a connection
+	// callback panics, and by the EventDisconnect fired with it unless the
+	// callback had already closed the connection.
 	ErrorCallbackPanic = errors.New("connection callback panicked")
 )
 
@@ -274,8 +272,7 @@ type Websocket struct {
 type safePool struct {
 	sync.RWMutex
 	conn map[string]ws
-	// snap is the last snapshot, kept until the next change to conn so a
-	// burst of broadcasts shares one slice instead of rebuilding it per call.
+	// snap caches the last snapshot until conn changes.
 	snap []ws
 }
 
@@ -290,9 +287,8 @@ func (p *safePool) set(ws ws) {
 	p.Unlock()
 }
 
-// snapshot returns the live connections as a slice. Callers only ever iterate
-// the result and must not modify it: the same slice is handed out until a
-// connection joins or leaves.
+// snapshot returns the live connections. The slice is shared until membership
+// changes and must not be modified.
 func (p *safePool) snapshot() []ws {
 	p.RLock()
 	s := p.snap
@@ -332,16 +328,13 @@ func (p *safePool) delete(key string) {
 
 type safeListeners struct {
 	mu sync.Mutex
-	// list is replaced wholesale on every registration and removal, so a
-	// reader only loads a pointer. Every connection's read goroutine consults
-	// the global registry on every frame, and a read lock there is an atomic
-	// on one cache line that all of them would fight over.
+	// list is replaced wholesale on every change, so readers load a pointer
+	// instead of taking a lock on every frame.
 	list atomic.Pointer[map[string][]EventCallback]
 }
 
-// set registers callback for event. The map and the slices in it are never
-// modified once published, so get can hand a slice straight to the caller:
-// registration is rare, firing is not.
+// set registers callback for event. Published maps and slices are never
+// modified, so get hands them out without copying.
 func (l *safeListeners) set(event string, callback EventCallback) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -420,13 +413,10 @@ func NewWithConfig(callback func(kws *Websocket), eventCfg Config, wsConfig ...w
 		kws.UUID = kws.createUUID()
 		pool.set(kws)
 
-		// run tears the connection down on the normal path. If callback panics
-		// before run starts nothing else would: the pool entry would keep its
-		// done channel open forever, so every later Broadcast would queue into
-		// a connection nobody reads until the queue filled and blocked. The
-		// connection is detached so conn() and IsAlive agree that it is gone;
-		// the socket is left to the middleware, which closes it once
-		// RecoverHandler has written the error frame.
+		// If callback panics before run starts, the pool entry would keep its done
+		// channel open forever and every later Broadcast would block on its queue.
+		// Detach and disconnect; the middleware closes the socket after
+		// RecoverHandler.
 		completed := false
 		defer func() {
 			if completed {
@@ -435,9 +425,8 @@ func NewWithConfig(callback func(kws *Websocket), eventCfg Config, wsConfig ...w
 			kws.mu.Lock()
 			kws.Conn = nil
 			kws.mu.Unlock()
-			// A callback that closed the connection itself before panicking
-			// has already spent the one disconnect; the crash is still
-			// reported rather than folded into that clean close.
+			// A callback that closed the connection before panicking already spent the
+			// one disconnect; still report the crash.
 			if !kws.disconnected(ErrorCallbackPanic) {
 				kws.fireEvent(EventError, nil, ErrorCallbackPanic)
 			}
@@ -481,8 +470,7 @@ func (kws *Websocket) SetUUID(uuid string) error {
 		delete(pool.conn, prevUUID)
 	}
 	pool.conn[uuid] = kws
-	// The set of connections is unchanged, but every write to conn drops the
-	// cached snapshot so the rule stays simple.
+	// Every write to conn drops the cached snapshot.
 	pool.snap = nil
 	return nil
 }
@@ -590,14 +578,12 @@ func EmitTo(uuid string, message []byte, mType ...int) error {
 // kws; the package-level Broadcast does not.
 func (kws *Websocket) Broadcast(message []byte, except bool, mType ...int) {
 	for _, conn := range pool.snapshot() {
-		// Identity rather than UUID: it needs no lock, and it stays right when
-		// SetUUID runs concurrently.
+		// Identity rather than UUID: no lock, and right under a concurrent SetUUID.
 		if except && conn == ws(kws) {
 			continue
 		}
-		// The snapshot already resolved every target, so unlike EmitTo this
-		// costs no second pool lookup per connection. A target that died in the
-		// meantime still reports EventError on the originating connection.
+		// The snapshot already resolved every target; one that died meanwhile still
+		// reports EventError on kws.
 		if !conn.IsAlive() {
 			kws.fireOwnedEvent(EventError, []byte(conn.GetUUID()), ErrorInvalidConnection)
 			continue
@@ -678,19 +664,12 @@ func (kws *Websocket) writeClose(code int, reason string) {
 	_ = conn.WriteControl(CloseMessage, payload, deadline)
 }
 
-// sanitizeCloseCode keeps a status code the peer would reject off the wire,
-// replacing it with a normal closure.
-//
-// RFC 6455 section 7.4.1 reserves 1005, 1006 and 1015 for conditions an
-// endpoint observes locally and says they must never appear in a close frame,
-// and lists 1004 as reserved with no meaning assigned. Endpoints are stricter
-// still: the receive side of this library accepts only 1000-1003, 1007-1013 and
-// the 3000-4999 application range, so 1004, 1014 and 1016-2999 make a
-// conformant peer fail the connection with a protocol error rather than read a
-// close. Only codes that survive that check are forwarded.
-//
-// CloseNoStatusReceived is the one exception: FormatCloseMessage renders it as
-// the empty payload, which is how "no status" is expressed on the wire.
+// sanitizeCloseCode replaces a status code the peer would reject with a normal
+// closure. RFC 6455 section 7.4.1 forbids sending 1005, 1006 and 1015 and
+// leaves 1004 reserved, and this library accepts only 1000-1003, 1007-1013 and
+// 3000-4999 on receive, so anything else fails the connection with a protocol
+// error. 1005 passes through: FormatCloseMessage renders it as the empty
+// payload, which is how "no status" is expressed.
 func sanitizeCloseCode(code int) int {
 	switch code {
 	case websocket.CloseNoStatusReceived:
@@ -716,11 +695,8 @@ func sanitizeCloseCode(code int) int {
 	return websocket.CloseNormalClosure
 }
 
-// closeReason makes reason safe to carry in a close frame. RFC 6455 section
-// 5.5.1 requires the reason to be valid UTF-8 and section 5.5 leaves it
-// closeFrameMaxReason bytes once the status code is accounted for, so invalid
-// input is scrubbed and an over-long reason is cut back to a rune boundary
-// rather than through the middle of a multi-byte sequence.
+// closeReason makes reason valid UTF-8 (RFC 6455 section 5.5.1) and cuts it
+// back to closeFrameMaxReason bytes on a rune boundary.
 func closeReason(reason string) string {
 	reason = strings.ToValidUTF8(reason, "")
 	if len(reason) <= closeFrameMaxReason {
@@ -797,9 +773,8 @@ func (kws *Websocket) send(ctx context.Context) {
 	for {
 		select {
 		case msg := <-kws.queue:
-			// One observation of the connection per message: the old pair of
-			// reads could disagree with each other and drop the message
-			// between them without retrying or reporting it.
+			// One observation of the connection per message, so a message cannot be
+			// dropped between two disagreeing reads.
 			conn := kws.conn()
 			if conn == nil {
 				if msg.retries <= kws.settings.maxSendRetry {
@@ -858,9 +833,8 @@ func (kws *Websocket) drainQueue() {
 }
 
 func (kws *Websocket) run() {
-	// The control frame handlers close over the connection value rather than
-	// the field: they run on the read goroutine while closeConn may be
-	// clearing kws.Conn.
+	// The handlers close over the connection value: they run on the read
+	// goroutine while closeConn may clear kws.Conn.
 	if conn := kws.conn(); conn != nil {
 		if kws.settings.maxMessageSize > 0 {
 			conn.SetReadLimit(kws.settings.maxMessageSize)
@@ -881,9 +855,8 @@ func (kws *Websocket) run() {
 			return nil
 		})
 		conn.SetPingHandler(func(data string) error {
-			// Same short circuit as the pong handler: once shutdown has started
-			// no event is owed, and RFC 6455 section 5.5.2 lets an endpoint
-			// skip the pong reply once a close is under way.
+			// Same short circuit as the pong handler; RFC 6455 section 5.5.2 lets an
+			// endpoint skip the pong once a close is under way.
 			select {
 			case <-kws.done:
 				return nil
@@ -934,20 +907,16 @@ func (kws *Websocket) run() {
 
 func (kws *Websocket) read(ctx context.Context) {
 	// run installs the connection before this goroutine starts and closeConn
-	// only clears it once the goroutine has exited, so it is read once here
-	// instead of behind the mutex on every single frame. A close racing with
-	// this loop surfaces as a read error and is handled below.
+	// clears it only after it exits, so read it once rather than under the mutex
+	// on every frame.
 	conn := kws.conn()
 	if conn == nil {
 		return
 	}
 
-	// A complete frame is proof the peer is alive, so the idle deadline is
-	// pushed out on data as well as on pongs; relying on pongs alone would drop
-	// a peer that talks steadily but never answers a server ping. Moving the
-	// deadline is a runtime timer update, so it is done at most once per
-	// quarter of the idle timeout rather than on every frame: after any frame
-	// the deadline is still at least three quarters of the timeout away.
+	// A frame proves the peer is alive, so the idle deadline moves on data as
+	// well as on pongs, but only once per quarter of the timeout: moving it is a
+	// runtime timer update.
 	refreshEvery := kws.settings.readIdleTimeout / 4
 	var nextRefresh time.Time
 
@@ -980,9 +949,7 @@ func (kws *Websocket) read(ctx context.Context) {
 
 		switch mType {
 		case TextMessage, BinaryMessage:
-			// readFrame returns a copy made for this frame alone, so the
-			// fan-out owns it and skips the copy fireEvent makes for
-			// caller-provided data.
+			// readFrame returns a copy made for this frame, so the fan-out owns it.
 			kws.fireOwnedEvent(EventMessage, msg, nil)
 		default:
 			// Defensive: NextReader never delivers control frames.
@@ -990,14 +957,10 @@ func (kws *Websocket) read(ctx context.Context) {
 	}
 }
 
-// frameReader reads one data message into a growable buffer and hands it out
-// as an exact-size copy. ReadMessage does the same job through io.ReadAll,
-// which starts at 512 bytes and doubles as it goes, so a 64 KB frame costs it
-// seventeen allocations and twice the frame in garbage. Readers live in
-// framePool, so an idle connection holds no buffer at all: one is taken when
-// a frame starts arriving and returned once its copy is handed out, memory
-// follows the frames in flight rather than the number of connections, and the
-// GC trims what the pool keeps.
+// frameReader reads one message into a growable buffer and returns an
+// exact-size copy, where ReadMessage's io.ReadAll starts at 512 bytes and
+// doubles. Readers are pooled: an idle connection holds no buffer and the GC
+// trims the pool.
 type frameReader struct {
 	buf   []byte
 	probe [1]byte
@@ -1007,9 +970,8 @@ const (
 	// frameBufferInitial is what a fresh buffer starts at, io.ReadAll's own
 	// figure.
 	frameBufferInitial = 512
-	// frameBufferRetained caps what goes back into the pool. A buffer that
-	// grew past it is dropped after use, so one big frame does not leave its
-	// size behind for every later reader.
+	// frameBufferRetained caps what goes back into the pool, so one big frame does
+	// not leave its size behind.
 	frameBufferRetained = 64 << 10
 )
 
@@ -1035,9 +997,8 @@ func (fr *frameReader) readAll(r io.Reader) ([]byte, error) {
 	}
 	for {
 		if len(buf) == cap(buf) {
-			// Full. A one-byte probe tells a message that exactly fills the
-			// buffer apart from one that continues, so the former does not
-			// double the buffer for nothing.
+			// Full: probe one byte so a message that exactly fills the buffer does not
+			// double it.
 			n, err := r.Read(fr.probe[:])
 			if n > 0 {
 				grown := make([]byte, len(buf), 2*cap(buf))
@@ -1152,9 +1113,8 @@ func stopTimer(timer *time.Timer) {
 }
 
 func fireGlobalEvent(event string, data []byte, err error) {
-	// Every connection gets its own copy of the bytes: Data is a mutable slice
-	// with no read-only contract, so a listener that changes or retains it for
-	// one connection must not touch what another connection's listeners see.
+	// Every connection gets its own copy: Data is mutable, and one listener must
+	// not change what another connection's listeners see.
 	for _, kws := range pool.snapshot() {
 		kws.fireEvent(event, data, err)
 	}
@@ -1166,18 +1126,15 @@ func (kws *Websocket) fireEvent(event string, data []byte, err error) {
 	kws.fire(event, data, err, true)
 }
 
-// fireOwnedEvent is fireEvent for data the fan-out already owns: a slice
-// ReadMessage allocated for this frame alone, a fresh []byte(uuid), or one
-// fireGlobalEvent has just copied.
+// fireOwnedEvent is fireEvent for data the fan-out already owns and need not
+// copy.
 func (kws *Websocket) fireOwnedEvent(event string, data []byte, err error) {
 	kws.fire(event, data, err, false)
 }
 
 func (kws *Websocket) fire(event string, data []byte, err error, clone bool) {
-	// Both registries hand back immutable snapshots, so the fan-out below runs
-	// without holding either lock and without copying the callback lists. An
-	// event nobody listens for costs two map lookups and nothing else, which
-	// matters because every inbound frame fires one.
+	// Both registries hand back immutable snapshots: no locks, no copies, and an
+	// event nobody listens for costs two map lookups.
 	globalCallbacks := listeners.get(event)
 	localCallbacks := kws.localListeners.get(event)
 	if len(globalCallbacks) == 0 && len(localCallbacks) == 0 {
@@ -1192,9 +1149,8 @@ func (kws *Websocket) fire(event string, data []byte, err error, clone bool) {
 	socketUUID := kws.UUID
 	kws.mu.RUnlock()
 
-	// Each listener gets its own EventPayload value, so a field one listener
-	// reassigns is not seen by the next. The map behind SocketAttributes and
-	// the bytes behind Data are shared across the fan-out, as they always were.
+	// Each listener gets its own EventPayload value; the attribute map and the
+	// Data bytes are shared, as they always were.
 	payload := EventPayload{
 		Kws:              kws,
 		Name:             event,
@@ -1269,14 +1225,12 @@ func Drain() {
 	draining.Store(true)
 }
 
-// CloseAll sends every active connection in the in-process pool a close
-// control frame with the supplied code and reason, fires EventClose on it and
-// marks it disconnected, and returns once those steps have finished for all of
-// them. Each connection's own goroutines then wind down on their own; CloseAll
-// does not wait for that. If ctx expires first, the connections still in the
-// pool are force closed via Conn.Close.
+// CloseAll sends every connection in the pool a close frame with code and
+// reason, fires EventClose and marks it disconnected, and returns once that is
+// done for all of them; each connection's goroutines then wind down on their
+// own. If ctx expires first, the remaining connections are force closed.
 //
-// The typical usage is from a Fiber shutdown hook:
+// Typical usage from a Fiber shutdown hook:
 //
 //	app.Hooks().OnShutdown(func() error {
 //	    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/v3/websocket/event/event.go
+++ b/v3/websocket/event/event.go
@@ -67,9 +67,11 @@ var (
 	ErrorInvalidConnection = errors.New("message cannot be delivered invalid/gone connection")
 	// ErrorUUIDDuplication indicates that the UUID already exists in the pool.
 	ErrorUUIDDuplication = errors.New("UUID already exists in the available connections pool")
-	// ErrorCallbackPanic is carried by the EventDisconnect and EventError fired
-	// when the connection callback passed to New or NewWithConfig panics. The
-	// panic value itself goes to the middleware's RecoverHandler.
+	// ErrorCallbackPanic is carried by the EventError fired when the connection
+	// callback passed to New or NewWithConfig panics, and by the
+	// EventDisconnect fired with it unless the callback had already closed the
+	// connection itself. The panic value goes to the middleware's
+	// RecoverHandler.
 	ErrorCallbackPanic = errors.New("connection callback panicked")
 )
 
@@ -227,7 +229,7 @@ type ws interface {
 	write(messageType int, messageBytes []byte)
 	run()
 	read(ctx context.Context)
-	disconnected(err error)
+	disconnected(err error) bool
 	createUUID() string
 	randomUUID() string
 	fireEvent(event string, data []byte, err error)
@@ -433,7 +435,12 @@ func NewWithConfig(callback func(kws *Websocket), eventCfg Config, wsConfig ...w
 			kws.mu.Lock()
 			kws.Conn = nil
 			kws.mu.Unlock()
-			kws.disconnected(ErrorCallbackPanic)
+			// A callback that closed the connection itself before panicking
+			// has already spent the one disconnect; the crash is still
+			// reported rather than folded into that clean close.
+			if !kws.disconnected(ErrorCallbackPanic) {
+				kws.fireEvent(EventError, nil, ErrorCallbackPanic)
+			}
 		}()
 
 		callback(kws)
@@ -1059,7 +1066,9 @@ func (fr *frameReader) retain(buf []byte) {
 	fr.buf = nil
 }
 
-func (kws *Websocket) disconnected(err error) {
+// disconnected tears the connection down once and reports whether this call
+// was the one that did it; later calls are no-ops that return false.
+func (kws *Websocket) disconnected(err error) bool {
 	disconnected := false
 	kws.once.Do(func() {
 		disconnected = true
@@ -1071,13 +1080,14 @@ func (kws *Websocket) disconnected(err error) {
 	})
 
 	if !disconnected {
-		return
+		return false
 	}
 
 	kws.fireEvent(EventDisconnect, nil, err)
 	if err != nil {
 		kws.fireEvent(EventError, nil, err)
 	}
+	return true
 }
 
 // unblockRead closes the underlying network connection so a read goroutine

--- a/v3/websocket/event/event.go
+++ b/v3/websocket/event/event.go
@@ -950,7 +950,6 @@ func (kws *Websocket) read(ctx context.Context) {
 	// the deadline is still at least three quarters of the timeout away.
 	refreshEvery := kws.settings.readIdleTimeout / 4
 	var nextRefresh time.Time
-	var frames frameReader
 
 	for {
 		select {
@@ -961,7 +960,7 @@ func (kws *Websocket) read(ctx context.Context) {
 		default:
 		}
 
-		mType, msg, err := frames.read(conn)
+		mType, msg, err := readFrame(conn)
 		if err != nil {
 			// Control frames (Ping, Pong, Close) are handled by the
 			// library's Set*Handler hooks above. An orderly client close
@@ -981,9 +980,9 @@ func (kws *Websocket) read(ctx context.Context) {
 
 		switch mType {
 		case TextMessage, BinaryMessage:
-			// read returns a copy made for this frame alone, so the fan-out
-			// owns it and skips the copy fireEvent makes for caller-provided
-			// data.
+			// readFrame returns a copy made for this frame alone, so the
+			// fan-out owns it and skips the copy fireEvent makes for
+			// caller-provided data.
 			kws.fireOwnedEvent(EventMessage, msg, nil)
 		default:
 			// Defensive: NextReader never delivers control frames.
@@ -991,13 +990,14 @@ func (kws *Websocket) read(ctx context.Context) {
 	}
 }
 
-// frameReader reads data messages into a buffer that persists across frames
-// and hands each one out as an exact-size copy. ReadMessage does the same job
-// through io.ReadAll, which starts at 512 bytes and doubles as it goes, so a
-// 64 KB frame costs it seventeen allocations and twice the frame in garbage.
-// Here the buffer only grows when a frame larger than any before it arrives,
-// the copy is the only allocation per frame, and the fan-out still owns what
-// it is given.
+// frameReader reads one data message into a growable buffer and hands it out
+// as an exact-size copy. ReadMessage does the same job through io.ReadAll,
+// which starts at 512 bytes and doubles as it goes, so a 64 KB frame costs it
+// seventeen allocations and twice the frame in garbage. Readers live in
+// framePool, so an idle connection holds no buffer at all: one is taken when
+// a frame starts arriving and returned once its copy is handed out, memory
+// follows the frames in flight rather than the number of connections, and the
+// GC trims what the pool keeps.
 type frameReader struct {
 	buf   []byte
 	probe [1]byte
@@ -1005,19 +1005,30 @@ type frameReader struct {
 
 const (
 	// frameBufferInitial is what a fresh buffer starts at, io.ReadAll's own
-	// figure, so a connection that only ever sees small frames never grows it.
+	// figure.
 	frameBufferInitial = 512
-	// frameBufferRetained caps what a connection keeps between frames. A
-	// buffer that grew past it is dropped after use, so one big frame does
-	// not pin its size for the life of the connection.
+	// frameBufferRetained caps what goes back into the pool. A buffer that
+	// grew past it is dropped after use, so one big frame does not leave its
+	// size behind for every later reader.
 	frameBufferRetained = 64 << 10
 )
 
-func (fr *frameReader) read(conn *websocket.Conn) (int, []byte, error) {
+var framePool = sync.Pool{New: func() interface{} { return new(frameReader) }}
+
+// readFrame reads the next data message from conn and returns a copy the
+// caller owns.
+func readFrame(conn *websocket.Conn) (int, []byte, error) {
 	mType, r, err := conn.NextReader()
 	if err != nil {
 		return mType, nil, err
 	}
+	fr := framePool.Get().(*frameReader)
+	msg, err := fr.readAll(r)
+	fr.release()
+	return mType, msg, err
+}
+
+func (fr *frameReader) readAll(r io.Reader) ([]byte, error) {
 	buf := fr.buf[:0]
 	if cap(buf) == 0 {
 		buf = make([]byte, 0, frameBufferInitial)
@@ -1037,8 +1048,8 @@ func (fr *frameReader) read(conn *websocket.Conn) (int, []byte, error) {
 				break
 			}
 			if err != nil {
-				fr.retain(buf)
-				return mType, nil, err
+				fr.buf = buf
+				return nil, err
 			}
 			continue
 		}
@@ -1048,22 +1059,29 @@ func (fr *frameReader) read(conn *websocket.Conn) (int, []byte, error) {
 			break
 		}
 		if err != nil {
-			fr.retain(buf)
-			return mType, nil, err
+			fr.buf = buf
+			return nil, err
 		}
 	}
 	msg := make([]byte, len(buf))
 	copy(msg, buf)
-	fr.retain(buf)
-	return mType, msg, nil
+	fr.buf = buf
+	return msg, nil
 }
 
-func (fr *frameReader) retain(buf []byte) {
-	if cap(buf) <= frameBufferRetained {
-		fr.buf = buf[:0]
+// release puts the reader back into the pool, minus a buffer that grew past
+// frameBufferRetained.
+func (fr *frameReader) release() {
+	fr.trim()
+	framePool.Put(fr)
+}
+
+func (fr *frameReader) trim() {
+	if cap(fr.buf) > frameBufferRetained {
+		fr.buf = nil
 		return
 	}
-	fr.buf = nil
+	fr.buf = fr.buf[:0]
 }
 
 // disconnected tears the connection down once and reports whether this call

--- a/v3/websocket/event/event.go
+++ b/v3/websocket/event/event.go
@@ -626,23 +626,42 @@ func (kws *Websocket) writeClose(code int, reason string) {
 	_ = conn.WriteControl(CloseMessage, payload, deadline)
 }
 
-// sanitizeCloseCode keeps a status code the protocol forbids off the wire. RFC
-// 6455 section 7.4.1 reserves 1006 and 1015 for failures an endpoint observes
-// locally and says they must never appear in a close frame, and section 7.4.2
-// leaves everything outside 1000-4999 undefined. CloseNoStatusReceived is left
-// alone because FormatCloseMessage already renders it as the empty payload that
-// expresses "no status" on the wire.
+// sanitizeCloseCode keeps a status code the peer would reject off the wire,
+// replacing it with a normal closure.
+//
+// RFC 6455 section 7.4.1 reserves 1005, 1006 and 1015 for conditions an
+// endpoint observes locally and says they must never appear in a close frame,
+// and lists 1004 as reserved with no meaning assigned. Endpoints are stricter
+// still: the receive side of this library accepts only 1000-1003, 1007-1013 and
+// the 3000-4999 application range, so 1004, 1014 and 1016-2999 make a
+// conformant peer fail the connection with a protocol error rather than read a
+// close. Only codes that survive that check are forwarded.
+//
+// CloseNoStatusReceived is the one exception: FormatCloseMessage renders it as
+// the empty payload, which is how "no status" is expressed on the wire.
 func sanitizeCloseCode(code int) int {
-	switch {
-	case code == websocket.CloseNoStatusReceived:
+	switch code {
+	case websocket.CloseNoStatusReceived:
 		return code
-	case code == websocket.CloseAbnormalClosure, code == websocket.CloseTLSHandshake:
-		return websocket.CloseNormalClosure
-	case code < 1000 || code > 4999:
-		return websocket.CloseNormalClosure
-	default:
+	case websocket.CloseNormalClosure,
+		websocket.CloseGoingAway,
+		websocket.CloseProtocolError,
+		websocket.CloseUnsupportedData,
+		websocket.CloseInvalidFramePayloadData,
+		websocket.ClosePolicyViolation,
+		websocket.CloseMessageTooBig,
+		websocket.CloseMandatoryExtension,
+		websocket.CloseInternalServerErr,
+		websocket.CloseServiceRestart,
+		websocket.CloseTryAgainLater:
 		return code
 	}
+	// 3000-3999 is registered for libraries and frameworks, 4000-4999 is
+	// private use; both are accepted by a conformant peer.
+	if code >= 3000 && code <= 4999 {
+		return code
+	}
+	return websocket.CloseNormalClosure
 }
 
 // closeReason makes reason safe to carry in a close frame. RFC 6455 section

--- a/v3/websocket/event/event.go
+++ b/v3/websocket/event/event.go
@@ -5,6 +5,7 @@ package event
 import (
 	"context"
 	"errors"
+	"io"
 	"maps"
 	"net"
 	"slices"
@@ -271,6 +272,9 @@ type Websocket struct {
 type safePool struct {
 	sync.RWMutex
 	conn map[string]ws
+	// snap is the last snapshot, kept until the next change to conn so a
+	// burst of broadcasts shares one slice instead of rebuilding it per call.
+	snap []ws
 }
 
 var pool = safePool{
@@ -280,20 +284,31 @@ var pool = safePool{
 func (p *safePool) set(ws ws) {
 	p.Lock()
 	p.conn[ws.GetUUID()] = ws
+	p.snap = nil
 	p.Unlock()
 }
 
-// snapshot copies the live connections into a slice. Every caller only ever
-// iterates the result, so a slice spares them the throwaway map a keyed copy
-// would build on each broadcast and each global event.
+// snapshot returns the live connections as a slice. Callers only ever iterate
+// the result and must not modify it: the same slice is handed out until a
+// connection joins or leaves.
 func (p *safePool) snapshot() []ws {
 	p.RLock()
-	ret := make([]ws, 0, len(p.conn))
-	for _, kws := range p.conn {
-		ret = append(ret, kws)
-	}
+	s := p.snap
 	p.RUnlock()
-	return ret
+	if s != nil {
+		return s
+	}
+	p.Lock()
+	if p.snap == nil {
+		s = make([]ws, 0, len(p.conn))
+		for _, kws := range p.conn {
+			s = append(s, kws)
+		}
+		p.snap = s
+	}
+	s = p.snap
+	p.Unlock()
+	return s
 }
 
 func (p *safePool) get(key string) (ws, error) {
@@ -309,44 +324,60 @@ func (p *safePool) get(key string) (ws, error) {
 func (p *safePool) delete(key string) {
 	p.Lock()
 	delete(p.conn, key)
+	p.snap = nil
 	p.Unlock()
 }
 
 type safeListeners struct {
-	sync.RWMutex
-	list map[string][]EventCallback
+	mu sync.Mutex
+	// list is replaced wholesale on every registration and removal, so a
+	// reader only loads a pointer. Every connection's read goroutine consults
+	// the global registry on every frame, and a read lock there is an atomic
+	// on one cache line that all of them would fight over.
+	list atomic.Pointer[map[string][]EventCallback]
 }
 
-// set registers callback for event. Clip forces append to allocate a fresh
-// backing array, so every stored slice is immutable once published and get can
-// hand it straight to the caller: registration is rare, firing is not.
+// set registers callback for event. The map and the slices in it are never
+// modified once published, so get can hand a slice straight to the caller:
+// registration is rare, firing is not.
 func (l *safeListeners) set(event string, callback EventCallback) {
-	l.Lock()
-	if l.list == nil {
-		l.list = make(map[string][]EventCallback)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	next := make(map[string][]EventCallback)
+	if cur := l.list.Load(); cur != nil {
+		maps.Copy(next, *cur)
 	}
-	l.list[event] = append(slices.Clip(l.list[event]), callback)
-	l.Unlock()
+	next[event] = append(slices.Clip(next[event]), callback)
+	l.list.Store(&next)
 }
 
 // get returns the callbacks registered for event, or nil when there are none.
 // The result is a snapshot that must only be read, never appended to.
 func (l *safeListeners) get(event string) []EventCallback {
-	l.RLock()
-	callbacks := l.list[event]
-	l.RUnlock()
-	return callbacks
+	cur := l.list.Load()
+	if cur == nil {
+		return nil
+	}
+	return (*cur)[event]
 }
 
 func (l *safeListeners) remove(event string) {
-	l.Lock()
-	delete(l.list, event)
-	l.Unlock()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	cur := l.list.Load()
+	if cur == nil {
+		return
+	}
+	if _, ok := (*cur)[event]; !ok {
+		return
+	}
+	next := make(map[string][]EventCallback, len(*cur))
+	maps.Copy(next, *cur)
+	delete(next, event)
+	l.list.Store(&next)
 }
 
-var listeners = safeListeners{
-	list: make(map[string][]EventCallback),
-}
+var listeners safeListeners
 
 // New returns a Fiber handler that upgrades the request to WebSocket and wraps
 // it with the event helper using default tuning. For per-instance tuning use
@@ -443,6 +474,9 @@ func (kws *Websocket) SetUUID(uuid string) error {
 		delete(pool.conn, prevUUID)
 	}
 	pool.conn[uuid] = kws
+	// The set of connections is unchanged, but every write to conn drops the
+	// cached snapshot so the rule stays simple.
+	pool.snap = nil
 	return nil
 }
 
@@ -909,6 +943,7 @@ func (kws *Websocket) read(ctx context.Context) {
 	// the deadline is still at least three quarters of the timeout away.
 	refreshEvery := kws.settings.readIdleTimeout / 4
 	var nextRefresh time.Time
+	var frames frameReader
 
 	for {
 		select {
@@ -919,7 +954,7 @@ func (kws *Websocket) read(ctx context.Context) {
 		default:
 		}
 
-		mType, msg, err := conn.ReadMessage()
+		mType, msg, err := frames.read(conn)
 		if err != nil {
 			// Control frames (Ping, Pong, Close) are handled by the
 			// library's Set*Handler hooks above. An orderly client close
@@ -939,14 +974,89 @@ func (kws *Websocket) read(ctx context.Context) {
 
 		switch mType {
 		case TextMessage, BinaryMessage:
-			// ReadMessage returns a slice it allocated for this frame alone,
-			// so the fan-out owns it and skips the copy fireEvent makes for
-			// caller-provided data.
+			// read returns a copy made for this frame alone, so the fan-out
+			// owns it and skips the copy fireEvent makes for caller-provided
+			// data.
 			kws.fireOwnedEvent(EventMessage, msg, nil)
 		default:
-			// Defensive: ReadMessage should not deliver control frames.
+			// Defensive: NextReader never delivers control frames.
 		}
 	}
+}
+
+// frameReader reads data messages into a buffer that persists across frames
+// and hands each one out as an exact-size copy. ReadMessage does the same job
+// through io.ReadAll, which starts at 512 bytes and doubles as it goes, so a
+// 64 KB frame costs it seventeen allocations and twice the frame in garbage.
+// Here the buffer only grows when a frame larger than any before it arrives,
+// the copy is the only allocation per frame, and the fan-out still owns what
+// it is given.
+type frameReader struct {
+	buf   []byte
+	probe [1]byte
+}
+
+const (
+	// frameBufferInitial is what a fresh buffer starts at, io.ReadAll's own
+	// figure, so a connection that only ever sees small frames never grows it.
+	frameBufferInitial = 512
+	// frameBufferRetained caps what a connection keeps between frames. A
+	// buffer that grew past it is dropped after use, so one big frame does
+	// not pin its size for the life of the connection.
+	frameBufferRetained = 64 << 10
+)
+
+func (fr *frameReader) read(conn *websocket.Conn) (int, []byte, error) {
+	mType, r, err := conn.NextReader()
+	if err != nil {
+		return mType, nil, err
+	}
+	buf := fr.buf[:0]
+	if cap(buf) == 0 {
+		buf = make([]byte, 0, frameBufferInitial)
+	}
+	for {
+		if len(buf) == cap(buf) {
+			// Full. A one-byte probe tells a message that exactly fills the
+			// buffer apart from one that continues, so the former does not
+			// double the buffer for nothing.
+			n, err := r.Read(fr.probe[:])
+			if n > 0 {
+				grown := make([]byte, len(buf), 2*cap(buf))
+				copy(grown, buf)
+				buf = append(grown, fr.probe[0])
+			}
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				fr.retain(buf)
+				return mType, nil, err
+			}
+			continue
+		}
+		n, err := r.Read(buf[len(buf):cap(buf)])
+		buf = buf[:len(buf)+n]
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			fr.retain(buf)
+			return mType, nil, err
+		}
+	}
+	msg := make([]byte, len(buf))
+	copy(msg, buf)
+	fr.retain(buf)
+	return mType, msg, nil
+}
+
+func (fr *frameReader) retain(buf []byte) {
+	if cap(buf) <= frameBufferRetained {
+		fr.buf = buf[:0]
+		return
+	}
+	fr.buf = nil
 }
 
 func (kws *Websocket) disconnected(err error) {

--- a/v3/websocket/event/event.go
+++ b/v3/websocket/event/event.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gofiber/contrib/v3/websocket"
 	"github.com/gofiber/fiber/v3"
@@ -94,7 +96,9 @@ type message struct {
 	retries int
 }
 
-// EventPayload stores information about an event and its connection.
+// EventPayload stores information about an event and its connection. One value
+// is shared by every listener of a fired event, so listeners must treat it as
+// read-only; the same already held for Data and SocketAttributes.
 type EventPayload struct {
 	// Kws is the connection object.
 	Kws *Websocket
@@ -274,11 +278,18 @@ func (p *safePool) set(ws ws) {
 	p.Unlock()
 }
 
-func (p *safePool) all() map[string]ws {
+// snapshot copies the live connections into a slice. Every caller only ever
+// iterates the result, so a slice spares them the throwaway map a keyed copy
+// would build on each broadcast and each global event.
+func (p *safePool) snapshot() []ws {
 	p.RLock()
-	ret := make(map[string]ws, len(p.conn))
-	for wsUUID, kws := range p.conn {
-		ret[wsUUID] = kws
+	if len(p.conn) == 0 {
+		p.RUnlock()
+		return nil
+	}
+	ret := make([]ws, 0, len(p.conn))
+	for _, kws := range p.conn {
+		ret = append(ret, kws)
 	}
 	p.RUnlock()
 	return ret
@@ -305,23 +316,30 @@ type safeListeners struct {
 	list map[string][]EventCallback
 }
 
+// set registers callback for event. The stored slice is replaced instead of
+// being appended to in place, which makes every stored slice immutable once
+// published and lets get hand its value straight to the caller: registration is
+// rare, firing is not.
 func (l *safeListeners) set(event string, callback EventCallback) {
 	l.Lock()
 	if l.list == nil {
 		l.list = make(map[string][]EventCallback)
 	}
-	l.list[event] = append(l.list[event], callback)
+	current := l.list[event]
+	next := make([]EventCallback, len(current)+1)
+	copy(next, current)
+	next[len(current)] = callback
+	l.list[event] = next
 	l.Unlock()
 }
 
+// get returns the callbacks registered for event, or nil when there are none.
+// The result is a snapshot that must only be read, never appended to.
 func (l *safeListeners) get(event string) []EventCallback {
 	l.RLock()
-	defer l.RUnlock()
-	if _, ok := l.list[event]; !ok {
-		return make([]EventCallback, 0)
-	}
-
-	return append([]EventCallback(nil), l.list[event]...)
+	callbacks := l.list[event]
+	l.RUnlock()
+	return callbacks
 }
 
 func (l *safeListeners) remove(event string) {
@@ -344,6 +362,9 @@ func New(callback func(kws *Websocket), config ...websocket.Config) fiber.Handle
 // NewWithConfig returns a Fiber handler that upgrades the request to WebSocket
 // and wraps it with the event helper, using the supplied per-instance tuning.
 func NewWithConfig(callback func(kws *Websocket), eventCfg Config, wsConfig ...websocket.Config) fiber.Handler {
+	if callback == nil {
+		panic("websocket/event: callback must not be nil")
+	}
 	s := resolveSettings(eventCfg)
 	return websocket.New(func(c *websocket.Conn) {
 		kws := &Websocket{
@@ -369,6 +390,13 @@ func NewWithConfig(callback func(kws *Websocket), eventCfg Config, wsConfig ...w
 
 		kws.UUID = kws.createUUID()
 		pool.set(kws)
+
+		// run leaves the pool and the socket clean on the normal path; this
+		// covers the abnormal one. Without it a panic in callback would strand a
+		// pool entry whose done channel is never closed, so the connection would
+		// keep accepting queued messages nobody reads and every later Broadcast
+		// would end up blocked on the full queue.
+		defer kws.shutdown()
 
 		callback(kws)
 		kws.fireEvent(EventConnect, nil, nil)
@@ -513,18 +541,24 @@ func EmitTo(uuid string, message []byte, mType ...int) error {
 // kws; the package-level Broadcast does not.
 func (kws *Websocket) Broadcast(message []byte, except bool, mType ...int) {
 	selfUUID := kws.GetUUID()
-	for wsUUID := range pool.all() {
-		if except && selfUUID == wsUUID {
+	for _, conn := range pool.snapshot() {
+		if except && selfUUID == conn.GetUUID() {
 			continue
 		}
-		// EmitTo already fires EventError on failure.
-		_ = kws.EmitTo(wsUUID, message, mType...)
+		// The snapshot already resolved every target, so unlike EmitTo this
+		// costs no second pool lookup per connection. A target that died in the
+		// meantime still reports EventError on the originating connection.
+		if !conn.IsAlive() {
+			kws.fireEvent(EventError, []byte(conn.GetUUID()), ErrorInvalidConnection)
+			continue
+		}
+		conn.Emit(message, mType...)
 	}
 }
 
 // Broadcast emits to all active connections.
 func Broadcast(message []byte, mType ...int) {
-	for _, kws := range pool.all() {
+	for _, kws := range pool.snapshot() {
 		kws.Emit(message, mType...)
 	}
 }
@@ -585,18 +619,51 @@ func (kws *Websocket) Close() {
 // WriteControl with a write deadline so shutdown cannot block on a slow
 // peer.
 func (kws *Websocket) writeClose(code int, reason string) {
-	if len(reason) > closeFrameMaxReason {
-		reason = reason[:closeFrameMaxReason]
-	}
-	kws.mu.RLock()
-	conn := kws.Conn
-	kws.mu.RUnlock()
+	conn := kws.conn()
 	if conn == nil {
 		return
 	}
-	payload := websocket.FormatCloseMessage(code, reason)
+	payload := websocket.FormatCloseMessage(sanitizeCloseCode(code), closeReason(reason))
 	deadline := time.Now().Add(kws.settings.writeTimeout)
 	_ = conn.WriteControl(CloseMessage, payload, deadline)
+}
+
+// sanitizeCloseCode keeps a status code the protocol forbids off the wire. RFC
+// 6455 section 7.4.1 reserves 1006 and 1015 for failures an endpoint observes
+// locally and says they must never appear in a close frame, and section 7.4.2
+// leaves everything outside 1000-4999 undefined. CloseNoStatusReceived is left
+// alone because FormatCloseMessage already renders it as the empty payload that
+// expresses "no status" on the wire.
+func sanitizeCloseCode(code int) int {
+	switch {
+	case code == websocket.CloseNoStatusReceived:
+		return code
+	case code == websocket.CloseAbnormalClosure, code == websocket.CloseTLSHandshake:
+		return websocket.CloseNormalClosure
+	case code < 1000 || code > 4999:
+		return websocket.CloseNormalClosure
+	default:
+		return code
+	}
+}
+
+// closeReason makes reason safe to carry in a close frame. RFC 6455 section
+// 5.5.1 requires the reason to be valid UTF-8 and section 5.5 leaves it
+// closeFrameMaxReason bytes once the status code is accounted for, so invalid
+// input is scrubbed and an over-long reason is cut back to a rune boundary
+// rather than through the middle of a multi-byte sequence.
+func closeReason(reason string) string {
+	if !utf8.ValidString(reason) {
+		reason = strings.ToValidUTF8(reason, "")
+	}
+	if len(reason) <= closeFrameMaxReason {
+		return reason
+	}
+	cut := closeFrameMaxReason
+	for cut > 0 && !utf8.RuneStart(reason[cut]) {
+		cut--
+	}
+	return reason[:cut]
 }
 
 // IsAlive reports whether the connection is active.
@@ -606,10 +673,16 @@ func (kws *Websocket) IsAlive() bool {
 	return kws.isAlive
 }
 
-func (kws *Websocket) hasConn() bool {
+// conn returns the underlying connection, or nil once it has been cleared by
+// closeConn or handed back to the middleware pool.
+func (kws *Websocket) conn() *websocket.Conn {
 	kws.mu.RLock()
-	defer kws.mu.RUnlock()
-	return kws.Conn != nil && kws.Conn.Conn != nil
+	conn := kws.Conn
+	kws.mu.RUnlock()
+	if conn == nil || conn.Conn == nil {
+		return nil
+	}
+	return conn
 }
 
 func (kws *Websocket) setAlive(alive bool) {
@@ -628,9 +701,7 @@ func (kws *Websocket) pong(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			kws.mu.RLock()
-			conn := kws.Conn
-			kws.mu.RUnlock()
+			conn := kws.conn()
 			if conn == nil {
 				return
 			}
@@ -664,7 +735,11 @@ func (kws *Websocket) send(ctx context.Context) {
 	for {
 		select {
 		case msg := <-kws.queue:
-			if !kws.hasConn() {
+			// One observation of the connection per message: the old pair of
+			// reads could disagree with each other and drop the message
+			// between them without retrying or reporting it.
+			conn := kws.conn()
+			if conn == nil {
 				if msg.retries <= kws.settings.maxSendRetry {
 					retryTimer := time.NewTimer(kws.settings.retrySendTimeout)
 					select {
@@ -695,12 +770,6 @@ func (kws *Websocket) send(ctx context.Context) {
 				continue
 			}
 
-			kws.mu.RLock()
-			conn := kws.Conn
-			kws.mu.RUnlock()
-			if conn == nil {
-				continue
-			}
 			_ = conn.SetWriteDeadline(time.Now().Add(kws.settings.writeTimeout))
 			err := conn.WriteMessage(msg.mType, msg.data)
 			if err != nil {
@@ -727,13 +796,20 @@ func (kws *Websocket) drainQueue() {
 }
 
 func (kws *Websocket) run() {
-	if kws.Conn != nil && kws.settings.maxMessageSize > 0 {
-		kws.Conn.SetReadLimit(kws.settings.maxMessageSize)
-	}
+	// Read the connection once and let the control frame handlers close over
+	// the value instead of the field: they run on the read goroutine while
+	// closeConn may be clearing kws.Conn, and the value itself never changes
+	// over the lifetime of the helper.
+	kws.mu.RLock()
+	conn := kws.Conn
+	kws.mu.RUnlock()
 
-	if kws.Conn != nil {
-		_ = kws.Conn.SetReadDeadline(time.Now().Add(kws.settings.readIdleTimeout))
-		kws.Conn.SetPongHandler(func(string) error {
+	if conn != nil {
+		if kws.settings.maxMessageSize > 0 {
+			conn.SetReadLimit(kws.settings.maxMessageSize)
+		}
+		_ = conn.SetReadDeadline(time.Now().Add(kws.settings.readIdleTimeout))
+		conn.SetPongHandler(func(string) error {
 			// Best-effort short circuit so a peer that keeps ponging does not
 			// keep firing events once shutdown started. Shutdown correctness
 			// does not depend on winning this race: run closes the underlying
@@ -743,14 +819,17 @@ func (kws *Websocket) run() {
 				return nil
 			default:
 			}
-			_ = kws.Conn.SetReadDeadline(time.Now().Add(kws.settings.readIdleTimeout))
+			_ = conn.SetReadDeadline(time.Now().Add(kws.settings.readIdleTimeout))
 			kws.fireEvent(EventPong, nil, nil)
 			return nil
 		})
-		kws.Conn.SetPingHandler(func(data string) error {
+		conn.SetPingHandler(func(data string) error {
+			// A ping proves the peer is alive just as a pong does, so the idle
+			// deadline restarts here too.
+			_ = conn.SetReadDeadline(time.Now().Add(kws.settings.readIdleTimeout))
 			kws.fireEvent(EventPing, []byte(data), nil)
 			deadline := time.Now().Add(kws.settings.writeTimeout)
-			err := kws.Conn.WriteControl(PongMessage, []byte(data), deadline)
+			err := conn.WriteControl(PongMessage, []byte(data), deadline)
 			if errors.Is(err, websocket.ErrCloseSent) {
 				return nil
 			}
@@ -789,6 +868,15 @@ func (kws *Websocket) run() {
 }
 
 func (kws *Websocket) read(ctx context.Context) {
+	// run installs the connection before this goroutine starts and closeConn
+	// only clears it once the goroutine has exited, so it is read once here
+	// instead of behind the mutex on every single frame. A close racing with
+	// this loop surfaces as a read error and is handled below.
+	conn := kws.conn()
+	if conn == nil {
+		return
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -796,13 +884,6 @@ func (kws *Websocket) read(ctx context.Context) {
 		case <-kws.done:
 			return
 		default:
-		}
-
-		kws.mu.RLock()
-		conn := kws.Conn
-		kws.mu.RUnlock()
-		if conn == nil {
-			return
 		}
 
 		mType, msg, err := conn.ReadMessage()
@@ -817,6 +898,11 @@ func (kws *Websocket) read(ctx context.Context) {
 			kws.disconnected(err)
 			return
 		}
+
+		// A complete frame is proof the peer is alive, so the idle deadline
+		// restarts on data as well. Leaving it to the pong handler alone would
+		// drop a peer that talks steadily but never answers a server ping.
+		_ = conn.SetReadDeadline(time.Now().Add(kws.settings.readIdleTimeout))
 
 		switch mType {
 		case TextMessage, BinaryMessage:
@@ -858,12 +944,18 @@ func (kws *Websocket) disconnected(err error) {
 // Conn field is deliberately left in place: closeConn performs the final
 // cleanup once the goroutines have exited, and closing twice is harmless.
 func (kws *Websocket) unblockRead() {
-	kws.mu.RLock()
-	conn := kws.Conn
-	kws.mu.RUnlock()
-	if conn != nil {
+	if conn := kws.conn(); conn != nil {
 		_ = conn.Close()
 	}
+}
+
+// shutdown makes sure a connection leaves the pool and its socket is closed
+// even when the user callback or the read loop panicked. Both steps are
+// idempotent, so on the normal path, where run already performed them, it costs
+// nothing.
+func (kws *Websocket) shutdown() {
+	kws.disconnected(nil)
+	kws.closeConn()
 }
 
 func (kws *Websocket) closeConn() {
@@ -871,7 +963,9 @@ func (kws *Websocket) closeConn() {
 	conn := kws.Conn
 	kws.Conn = nil
 	kws.mu.Unlock()
-	if conn != nil {
+	// Close is promoted from the embedded connection, so calling it on a Conn
+	// the middleware already handed back to its pool would dereference nil.
+	if conn != nil && conn.Conn != nil {
 		_ = conn.Close()
 	}
 }
@@ -894,45 +988,55 @@ func stopTimer(timer *time.Timer) {
 }
 
 func fireGlobalEvent(event string, data []byte, err error) {
-	for _, kws := range pool.all() {
+	for _, kws := range pool.snapshot() {
 		kws.fireEvent(event, data, err)
 	}
 }
 
 func (kws *Websocket) fireEvent(event string, data []byte, err error) {
-	// listeners.get returns a fresh slice, so appending the per-connection
-	// listeners to it does not mutate the global registry.
-	callbacks := append(listeners.get(event), kws.localListeners.get(event)...)
-	if len(callbacks) == 0 {
+	// Both registries hand back immutable snapshots, so the fan-out below runs
+	// without holding either lock and without copying the callback lists. An
+	// event nobody listens for costs two map lookups and nothing else, which
+	// matters because every inbound frame fires one.
+	globalCallbacks := listeners.get(event)
+	localCallbacks := kws.localListeners.get(event)
+	if len(globalCallbacks) == 0 && len(localCallbacks) == 0 {
 		return
 	}
 
 	kws.mu.RLock()
-	attrs := make(map[string]any, len(kws.attributes))
-	for key, value := range kws.attributes {
-		attrs[key] = value
+	var attrs map[string]any
+	if len(kws.attributes) > 0 {
+		attrs = make(map[string]any, len(kws.attributes))
+		for key, value := range kws.attributes {
+			attrs[key] = value
+		}
 	}
+	socketUUID := kws.UUID
 	kws.mu.RUnlock()
 
 	// Clone payload bytes once before fan-out so listeners that retain the
 	// slice are not exposed to the read buffer being reused by the next
 	// frame.
 	var payloadData []byte
-	if data != nil {
+	if len(data) > 0 {
 		payloadData = make([]byte, len(data))
 		copy(payloadData, data)
 	}
 
-	uuid := kws.GetUUID()
-	for _, callback := range callbacks {
-		kws.invokeCallback(event, callback, &EventPayload{
-			Kws:              kws,
-			Name:             event,
-			SocketUUID:       uuid,
-			SocketAttributes: attrs,
-			Data:             payloadData,
-			Error:            err,
-		})
+	payload := &EventPayload{
+		Kws:              kws,
+		Name:             event,
+		SocketUUID:       socketUUID,
+		SocketAttributes: attrs,
+		Data:             payloadData,
+		Error:            err,
+	}
+	for _, callback := range globalCallbacks {
+		kws.invokeCallback(event, callback, payload)
+	}
+	for _, callback := range localCallbacks {
+		kws.invokeCallback(event, callback, payload)
 	}
 }
 
@@ -999,13 +1103,13 @@ func Drain() {
 //
 // Reason is capped at 123 bytes per RFC 6455.
 func CloseAll(ctx context.Context, code int, reason string) error {
-	snapshot := pool.all()
-	if len(snapshot) == 0 {
+	conns := pool.snapshot()
+	if len(conns) == 0 {
 		return nil
 	}
 
 	var wg sync.WaitGroup
-	for _, c := range snapshot {
+	for _, c := range conns {
 		kws, ok := c.(*Websocket)
 		if !ok {
 			continue
@@ -1031,7 +1135,7 @@ func CloseAll(ctx context.Context, code int, reason string) error {
 	case <-done:
 		return nil
 	case <-ctx.Done():
-		for _, c := range pool.all() {
+		for _, c := range pool.snapshot() {
 			kws, ok := c.(*Websocket)
 			if !ok {
 				continue

--- a/v3/websocket/event/event.go
+++ b/v3/websocket/event/event.go
@@ -391,9 +391,9 @@ func NewWithConfig(callback func(kws *Websocket), eventCfg Config, wsConfig ...w
 		// before run starts nothing else would: the pool entry would keep its
 		// done channel open forever, so every later Broadcast would queue into
 		// a connection nobody reads until the queue filled and blocked. The
-		// wrapper is detached as well, because the middleware hands it back to
-		// its pool right after; the socket is left to the middleware, which
-		// closes it once RecoverHandler has written the error frame.
+		// connection is detached so conn() and IsAlive agree that it is gone;
+		// the socket is left to the middleware, which closes it once
+		// RecoverHandler has written the error frame.
 		completed := false
 		defer func() {
 			if completed {
@@ -699,16 +699,10 @@ func (kws *Websocket) IsAlive() bool {
 	return kws.isAlive
 }
 
-// conn returns the underlying connection, or nil once closeConn has cleared it
-// or the middleware has taken the wrapper back. Both checks happen under the
-// lock so a teardown racing with the caller cannot slip a recycled wrapper
-// through between them.
+// conn returns the underlying connection, or nil once closeConn has cleared it.
 func (kws *Websocket) conn() *websocket.Conn {
 	kws.mu.RLock()
 	defer kws.mu.RUnlock()
-	if kws.Conn == nil || kws.Conn.Conn == nil {
-		return nil
-	}
 	return kws.Conn
 }
 
@@ -996,8 +990,7 @@ func (kws *Websocket) closeConn() {
 	conn := kws.Conn
 	kws.Conn = nil
 	kws.mu.Unlock()
-	// Close is promoted from the embedded connection and is nil-receiver safe:
-	// on a wrapper the middleware already took back it just reports ErrNilConn.
+	// Close is nil-receiver safe and closing twice is harmless.
 	if conn != nil {
 		_ = conn.Close()
 	}

--- a/v3/websocket/event/event.go
+++ b/v3/websocket/event/event.go
@@ -5,7 +5,9 @@ package event
 import (
 	"context"
 	"errors"
+	"maps"
 	"net"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -64,6 +66,10 @@ var (
 	ErrorInvalidConnection = errors.New("message cannot be delivered invalid/gone connection")
 	// ErrorUUIDDuplication indicates that the UUID already exists in the pool.
 	ErrorUUIDDuplication = errors.New("UUID already exists in the available connections pool")
+	// ErrorCallbackPanic is carried by the EventDisconnect and EventError fired
+	// when the connection callback passed to New or NewWithConfig panics. The
+	// panic value itself goes to the middleware's RecoverHandler.
+	ErrorCallbackPanic = errors.New("connection callback panicked")
 )
 
 var (
@@ -224,6 +230,7 @@ type ws interface {
 	createUUID() string
 	randomUUID() string
 	fireEvent(event string, data []byte, err error)
+	fireOwnedEvent(event string, data []byte, err error)
 }
 
 // Websocket wraps a websocket.Conn with event-bus helpers.
@@ -281,10 +288,6 @@ func (p *safePool) set(ws ws) {
 // would build on each broadcast and each global event.
 func (p *safePool) snapshot() []ws {
 	p.RLock()
-	if len(p.conn) == 0 {
-		p.RUnlock()
-		return nil
-	}
 	ret := make([]ws, 0, len(p.conn))
 	for _, kws := range p.conn {
 		ret = append(ret, kws)
@@ -314,20 +317,15 @@ type safeListeners struct {
 	list map[string][]EventCallback
 }
 
-// set registers callback for event. The stored slice is replaced instead of
-// being appended to in place, which makes every stored slice immutable once
-// published and lets get hand its value straight to the caller: registration is
-// rare, firing is not.
+// set registers callback for event. Clip forces append to allocate a fresh
+// backing array, so every stored slice is immutable once published and get can
+// hand it straight to the caller: registration is rare, firing is not.
 func (l *safeListeners) set(event string, callback EventCallback) {
 	l.Lock()
 	if l.list == nil {
 		l.list = make(map[string][]EventCallback)
 	}
-	current := l.list[event]
-	next := make([]EventCallback, len(current)+1)
-	copy(next, current)
-	next[len(current)] = callback
-	l.list[event] = next
+	l.list[event] = append(slices.Clip(l.list[event]), callback)
 	l.Unlock()
 }
 
@@ -389,16 +387,28 @@ func NewWithConfig(callback func(kws *Websocket), eventCfg Config, wsConfig ...w
 		kws.UUID = kws.createUUID()
 		pool.set(kws)
 
-		// run leaves the pool clean on the normal path; this covers the abnormal
-		// one. Without it a panic in callback would strand a pool entry whose
-		// done channel is never closed, so the connection would keep accepting
-		// queued messages nobody reads and every later Broadcast would end up
-		// blocked on the full queue.
-		defer kws.shutdown()
+		// run tears the connection down on the normal path. If callback panics
+		// before run starts nothing else would: the pool entry would keep its
+		// done channel open forever, so every later Broadcast would queue into
+		// a connection nobody reads until the queue filled and blocked. The
+		// wrapper is detached as well, because the middleware hands it back to
+		// its pool right after; the socket is left to the middleware, which
+		// closes it once RecoverHandler has written the error frame.
+		completed := false
+		defer func() {
+			if completed {
+				return
+			}
+			kws.mu.Lock()
+			kws.Conn = nil
+			kws.mu.Unlock()
+			kws.disconnected(ErrorCallbackPanic)
+		}()
 
 		callback(kws)
 		kws.fireEvent(EventConnect, nil, nil)
 		kws.run()
+		completed = true
 	}, wsConfig...)
 }
 
@@ -506,11 +516,11 @@ func EmitToList(uuids []string, message []byte, mType ...int) {
 func (kws *Websocket) EmitTo(uuid string, message []byte, mType ...int) error {
 	conn, err := pool.get(uuid)
 	if err != nil {
-		kws.fireEvent(EventError, []byte(uuid), ErrorInvalidConnection)
+		kws.fireOwnedEvent(EventError, []byte(uuid), ErrorInvalidConnection)
 		return ErrorInvalidConnection
 	}
 	if !conn.IsAlive() {
-		kws.fireEvent(EventError, []byte(uuid), ErrorInvalidConnection)
+		kws.fireOwnedEvent(EventError, []byte(uuid), ErrorInvalidConnection)
 		return ErrorInvalidConnection
 	}
 
@@ -538,16 +548,17 @@ func EmitTo(uuid string, message []byte, mType ...int) error {
 // connection (kws) when except is true. Each failed target fires EventError on
 // kws; the package-level Broadcast does not.
 func (kws *Websocket) Broadcast(message []byte, except bool, mType ...int) {
-	selfUUID := kws.GetUUID()
 	for _, conn := range pool.snapshot() {
-		if except && selfUUID == conn.GetUUID() {
+		// Identity rather than UUID: it needs no lock, and it stays right when
+		// SetUUID runs concurrently.
+		if except && conn == ws(kws) {
 			continue
 		}
 		// The snapshot already resolved every target, so unlike EmitTo this
 		// costs no second pool lookup per connection. A target that died in the
 		// meantime still reports EventError on the originating connection.
 		if !conn.IsAlive() {
-			kws.fireEvent(EventError, []byte(conn.GetUUID()), ErrorInvalidConnection)
+			kws.fireOwnedEvent(EventError, []byte(conn.GetUUID()), ErrorInvalidConnection)
 			continue
 		}
 		conn.Emit(message, mType...)
@@ -670,9 +681,7 @@ func sanitizeCloseCode(code int) int {
 // input is scrubbed and an over-long reason is cut back to a rune boundary
 // rather than through the middle of a multi-byte sequence.
 func closeReason(reason string) string {
-	if !utf8.ValidString(reason) {
-		reason = strings.ToValidUTF8(reason, "")
-	}
+	reason = strings.ToValidUTF8(reason, "")
 	if len(reason) <= closeFrameMaxReason {
 		return reason
 	}
@@ -690,16 +699,17 @@ func (kws *Websocket) IsAlive() bool {
 	return kws.isAlive
 }
 
-// conn returns the underlying connection, or nil once it has been cleared by
-// closeConn or handed back to the middleware pool.
+// conn returns the underlying connection, or nil once closeConn has cleared it
+// or the middleware has taken the wrapper back. Both checks happen under the
+// lock so a teardown racing with the caller cannot slip a recycled wrapper
+// through between them.
 func (kws *Websocket) conn() *websocket.Conn {
 	kws.mu.RLock()
-	conn := kws.Conn
-	kws.mu.RUnlock()
-	if conn == nil || conn.Conn == nil {
+	defer kws.mu.RUnlock()
+	if kws.Conn == nil || kws.Conn.Conn == nil {
 		return nil
 	}
-	return conn
+	return kws.Conn
 }
 
 func (kws *Websocket) setAlive(alive bool) {
@@ -813,15 +823,10 @@ func (kws *Websocket) drainQueue() {
 }
 
 func (kws *Websocket) run() {
-	// Read the connection once and let the control frame handlers close over
-	// the value instead of the field: they run on the read goroutine while
-	// closeConn may be clearing kws.Conn, and the value itself never changes
-	// over the lifetime of the helper.
-	kws.mu.RLock()
-	conn := kws.Conn
-	kws.mu.RUnlock()
-
-	if conn != nil {
+	// The control frame handlers close over the connection value rather than
+	// the field: they run on the read goroutine while closeConn may be
+	// clearing kws.Conn.
+	if conn := kws.conn(); conn != nil {
 		if kws.settings.maxMessageSize > 0 {
 			conn.SetReadLimit(kws.settings.maxMessageSize)
 		}
@@ -841,10 +846,18 @@ func (kws *Websocket) run() {
 			return nil
 		})
 		conn.SetPingHandler(func(data string) error {
+			// Same short circuit as the pong handler: once shutdown has started
+			// no event is owed, and RFC 6455 section 5.5.2 lets an endpoint
+			// skip the pong reply once a close is under way.
+			select {
+			case <-kws.done:
+				return nil
+			default:
+			}
 			// A ping proves the peer is alive just as a pong does, so the idle
 			// deadline restarts here too.
 			_ = conn.SetReadDeadline(time.Now().Add(kws.settings.readIdleTimeout))
-			kws.fireEvent(EventPing, []byte(data), nil)
+			kws.fireOwnedEvent(EventPing, []byte(data), nil)
 			deadline := time.Now().Add(kws.settings.writeTimeout)
 			err := conn.WriteControl(PongMessage, []byte(data), deadline)
 			if errors.Is(err, websocket.ErrCloseSent) {
@@ -894,6 +907,15 @@ func (kws *Websocket) read(ctx context.Context) {
 		return
 	}
 
+	// A complete frame is proof the peer is alive, so the idle deadline is
+	// pushed out on data as well as on pongs; relying on pongs alone would drop
+	// a peer that talks steadily but never answers a server ping. Moving the
+	// deadline is a runtime timer update, so it is done at most once per
+	// quarter of the idle timeout rather than on every frame: after any frame
+	// the deadline is still at least three quarters of the timeout away.
+	refreshEvery := kws.settings.readIdleTimeout / 4
+	var nextRefresh time.Time
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -916,14 +938,17 @@ func (kws *Websocket) read(ctx context.Context) {
 			return
 		}
 
-		// A complete frame is proof the peer is alive, so the idle deadline
-		// restarts on data as well. Leaving it to the pong handler alone would
-		// drop a peer that talks steadily but never answers a server ping.
-		_ = conn.SetReadDeadline(time.Now().Add(kws.settings.readIdleTimeout))
+		if now := time.Now(); now.After(nextRefresh) {
+			_ = conn.SetReadDeadline(now.Add(kws.settings.readIdleTimeout))
+			nextRefresh = now.Add(refreshEvery)
+		}
 
 		switch mType {
 		case TextMessage, BinaryMessage:
-			kws.fireEvent(EventMessage, msg, nil)
+			// ReadMessage returns a slice it allocated for this frame alone,
+			// so the fan-out owns it and skips the copy fireEvent makes for
+			// caller-provided data.
+			kws.fireOwnedEvent(EventMessage, msg, nil)
 		default:
 			// Defensive: ReadMessage should not deliver control frames.
 		}
@@ -966,24 +991,14 @@ func (kws *Websocket) unblockRead() {
 	}
 }
 
-// shutdown makes sure a connection leaves the pool even when the user callback
-// or the read loop panicked, so no later Broadcast can queue into a connection
-// nobody reads. It is idempotent, so on the normal path, where run already did
-// it, it costs nothing. The socket itself is deliberately left alone: the
-// middleware closes a panicked handler's connection once its RecoverHandler has
-// written the error frame.
-func (kws *Websocket) shutdown() {
-	kws.disconnected(nil)
-}
-
 func (kws *Websocket) closeConn() {
 	kws.mu.Lock()
 	conn := kws.Conn
 	kws.Conn = nil
 	kws.mu.Unlock()
-	// Close is promoted from the embedded connection, so calling it on a Conn
-	// the middleware already handed back to its pool would dereference nil.
-	if conn != nil && conn.Conn != nil {
+	// Close is promoted from the embedded connection and is nil-receiver safe:
+	// on a wrapper the middleware already took back it just reports ErrNilConn.
+	if conn != nil {
 		_ = conn.Close()
 	}
 }
@@ -1006,12 +1021,28 @@ func stopTimer(timer *time.Timer) {
 }
 
 func fireGlobalEvent(event string, data []byte, err error) {
+	// One copy of the caller's bytes for the whole fan-out, not one per
+	// connection.
+	data = cloneBytes(data)
 	for _, kws := range pool.snapshot() {
-		kws.fireEvent(event, data, err)
+		kws.fireOwnedEvent(event, data, err)
 	}
 }
 
+// fireEvent delivers event to every listener with a copy of data, so a
+// listener that retains the slice is not exposed to the caller reusing it.
 func (kws *Websocket) fireEvent(event string, data []byte, err error) {
+	kws.fire(event, data, err, true)
+}
+
+// fireOwnedEvent is fireEvent for data the fan-out already owns: a slice
+// ReadMessage allocated for this frame alone, a fresh []byte(uuid), or one
+// fireGlobalEvent has just copied.
+func (kws *Websocket) fireOwnedEvent(event string, data []byte, err error) {
+	kws.fire(event, data, err, false)
+}
+
+func (kws *Websocket) fire(event string, data []byte, err error, clone bool) {
 	// Both registries hand back immutable snapshots, so the fan-out below runs
 	// without holding either lock and without copying the callback lists. An
 	// event nobody listens for costs two map lookups and nothing else, which
@@ -1021,32 +1052,24 @@ func (kws *Websocket) fireEvent(event string, data []byte, err error) {
 	if len(globalCallbacks) == 0 && len(localCallbacks) == 0 {
 		return
 	}
+	if clone {
+		data = cloneBytes(data)
+	}
 
 	kws.mu.RLock()
-	attrs := make(map[string]any, len(kws.attributes))
-	for key, value := range kws.attributes {
-		attrs[key] = value
-	}
+	attrs := maps.Clone(kws.attributes)
 	socketUUID := kws.UUID
 	kws.mu.RUnlock()
 
-	// Clone payload bytes once before fan-out so listeners that retain the
-	// slice are not exposed to the read buffer being reused by the next
-	// frame.
-	var payloadData []byte
-	if data != nil {
-		payloadData = make([]byte, len(data))
-		copy(payloadData, data)
-	}
-
-	// Each listener gets its own payload value: one listener mutating the
-	// struct must not be visible to the ones that run after it.
+	// Each listener gets its own EventPayload value, so a field one listener
+	// reassigns is not seen by the next. The map behind SocketAttributes and
+	// the bytes behind Data are shared across the fan-out, as they always were.
 	payload := EventPayload{
 		Kws:              kws,
 		Name:             event,
 		SocketUUID:       socketUUID,
 		SocketAttributes: attrs,
-		Data:             payloadData,
+		Data:             data,
 		Error:            err,
 	}
 	for _, callback := range globalCallbacks {
@@ -1057,6 +1080,15 @@ func (kws *Websocket) fireEvent(event string, data []byte, err error) {
 		p := payload
 		kws.invokeCallback(event, callback, &p)
 	}
+}
+
+func cloneBytes(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+	out := make([]byte, len(b))
+	copy(out, b)
+	return out
 }
 
 // invokeCallback runs a single listener callback with panic recovery so a
@@ -1106,10 +1138,12 @@ func Drain() {
 	draining.Store(true)
 }
 
-// CloseAll iterates every active connection in the in-process pool and
-// sends a close control frame with the supplied code and reason, then
-// waits for each helper's run() loop to exit. If ctx expires first,
-// remaining connections are force closed via Conn.Close.
+// CloseAll sends every active connection in the in-process pool a close
+// control frame with the supplied code and reason, fires EventClose on it and
+// marks it disconnected, and returns once those steps have finished for all of
+// them. Each connection's own goroutines then wind down on their own; CloseAll
+// does not wait for that. If ctx expires first, the connections still in the
+// pool are force closed via Conn.Close.
 //
 // The typical usage is from a Fiber shutdown hook:
 //

--- a/v3/websocket/event/event_test.go
+++ b/v3/websocket/event/event_test.go
@@ -1006,7 +1006,7 @@ func (s *WebsocketMock) read(_ context.Context) {
 	panic("implement me")
 }
 
-func (s *WebsocketMock) disconnected(_ error) {
+func (s *WebsocketMock) disconnected(_ error) bool {
 	panic("implement me")
 }
 
@@ -1200,6 +1200,69 @@ func TestCallbackPanicDoesNotStrandPoolEntry(t *testing.T) {
 	var netErr net.Error
 	require.False(t, errors.As(err, &netErr) && netErr.Timeout(),
 		"panicking callback left the connection open: %v", err)
+}
+
+func TestCallbackPanicAfterCloseStillReportsError(t *testing.T) {
+	resetState()
+
+	app := fiber.New()
+	ln := fasthttputil.NewInmemoryListener()
+	defer func() {
+		_ = app.Shutdown()
+		_ = ln.Close()
+	}()
+
+	disconnects := make(chan error, 2)
+	On(EventDisconnect, func(p *EventPayload) { disconnects <- p.Error })
+	errs := make(chan error, 2)
+	On(EventError, func(p *EventPayload) { errs <- p.Error })
+
+	app.Use(upgradeMiddleware)
+	app.Get("/", NewWithConfig(func(kws *Websocket) {
+		// The callback ends the connection cleanly and only then crashes.
+		kws.Close()
+		panic("callback boom after close")
+	}, Config{}, fws.Config{
+		RecoverHandler: func(*fws.Conn) { _ = recover() },
+	}))
+
+	go func() { _ = app.Listener(ln) }()
+
+	dialer := &websocket.Dialer{
+		NetDial:          func(_, _ string) (net.Conn, error) { return ln.Dial() },
+		HandshakeTimeout: 5 * time.Second,
+	}
+	conn, _, err := dialWithRetry(dialer, "ws://"+ln.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// The close the callback asked for is what the peer sees.
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	_, _, err = conn.ReadMessage()
+	require.True(t, websocket.IsCloseError(err, websocket.CloseNormalClosure), "expected the callback's close frame, got %v", err)
+
+	// The disconnect was clean and happened once; the crash is still reported
+	// on EventError instead of vanishing into the already-spent disconnect.
+	select {
+	case discErr := <-disconnects:
+		require.NoError(t, discErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("EventDisconnect was not fired for the close")
+	}
+	select {
+	case panicErr := <-errs:
+		require.ErrorIs(t, panicErr, ErrorCallbackPanic)
+	case <-time.After(2 * time.Second):
+		t.Fatal("EventError with ErrorCallbackPanic was not fired")
+	}
+	select {
+	case discErr := <-disconnects:
+		t.Fatalf("EventDisconnect fired twice, second with %v", discErr)
+	case <-time.After(100 * time.Millisecond):
+	}
+	require.Eventually(t, func() bool {
+		return len(pool.snapshot()) == 0
+	}, 2*time.Second, 10*time.Millisecond)
 }
 
 func TestCloseAllListenersStillSeeRequestData(t *testing.T) {

--- a/v3/websocket/event/event_test.go
+++ b/v3/websocket/event/event_test.go
@@ -6,10 +6,12 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/fasthttp/websocket"
 	fws "github.com/gofiber/contrib/v3/websocket"
@@ -203,7 +205,7 @@ func TestGlobalBroadcast(t *testing.T) {
 
 	Broadcast([]byte("test"), TextMessage)
 
-	for _, mws := range pool.all() {
+	for _, mws := range pool.snapshot() {
 		mws.(*WebsocketMock).wg.Wait()
 		mws.(*WebsocketMock).AssertNumberOfCalls(t, "Emit", 1)
 	}
@@ -260,7 +262,7 @@ func TestGlobalEmitToList(t *testing.T) {
 
 	EmitToList(uuids, []byte("test"), TextMessage)
 
-	for _, kws := range pool.all() {
+	for _, kws := range pool.snapshot() {
 		kws.(*WebsocketMock).wg.Wait()
 		kws.(*WebsocketMock).AssertNumberOfCalls(t, "Emit", 1)
 	}
@@ -437,7 +439,7 @@ func TestCloseAllSendsGoingAway(t *testing.T) {
 
 	// Give upgrades a moment to register in the pool.
 	require.Eventually(t, func() bool {
-		return len(pool.all()) == numConn
+		return len(pool.snapshot()) == numConn
 	}, 2*time.Second, 10*time.Millisecond, "expected %d pool entries", numConn)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -453,7 +455,7 @@ func TestCloseAllSendsGoingAway(t *testing.T) {
 		require.Equal(t, "bye", ce.Text)
 	}
 
-	require.Empty(t, pool.all())
+	require.Empty(t, pool.snapshot())
 }
 
 func TestCloseSendsFormatCloseMessage(t *testing.T) {
@@ -854,7 +856,7 @@ func TestSendDropFiresEventErrorAfterRetries(t *testing.T) {
 		}
 	})
 
-	// createWS leaves Conn nil, so hasConn() is false and zero settings give
+	// createWS leaves Conn nil, so conn() returns nil and zero settings give
 	// maxSendRetry 0: the message is requeued once and then dropped.
 	kws := createWS()
 	kws.queue <- message{mType: TextMessage, data: []byte("x")}
@@ -1016,4 +1018,210 @@ func (s *WebsocketMock) randomUUID() string {
 
 func (s *WebsocketMock) fireEvent(_ string, _ []byte, _ error) {
 	panic("implement me")
+}
+
+func TestCloseReasonStaysValidUTF8(t *testing.T) {
+	t.Run("short reason is untouched", func(t *testing.T) {
+		require.Equal(t, "bye", closeReason("bye"))
+	})
+
+	t.Run("truncation lands on a rune boundary", func(t *testing.T) {
+		// Each euro sign is three bytes, so a plain byte cut at 123 would slice
+		// the 41st one in half and put invalid UTF-8 in the close frame.
+		reason := closeReason(strings.Repeat("€", 50))
+		require.LessOrEqual(t, len(reason), closeFrameMaxReason)
+		require.True(t, utf8.ValidString(reason))
+		require.Equal(t, 41, utf8.RuneCountInString(reason))
+	})
+
+	t.Run("ascii reason fills the limit exactly", func(t *testing.T) {
+		reason := closeReason(strings.Repeat("a", 200))
+		require.Len(t, reason, closeFrameMaxReason)
+	})
+
+	t.Run("invalid input is scrubbed", func(t *testing.T) {
+		reason := closeReason("ok\xff\xfebye")
+		require.True(t, utf8.ValidString(reason))
+		require.Equal(t, "okbye", reason)
+	})
+}
+
+func TestSanitizeCloseCode(t *testing.T) {
+	// RFC 6455 section 7.4.1: 1006 and 1015 report locally observed failures and
+	// must never travel in a close frame; section 7.4.2 leaves anything outside
+	// 1000-4999 undefined.
+	require.Equal(t, websocket.CloseNormalClosure, sanitizeCloseCode(websocket.CloseAbnormalClosure))
+	require.Equal(t, websocket.CloseNormalClosure, sanitizeCloseCode(websocket.CloseTLSHandshake))
+	require.Equal(t, websocket.CloseNormalClosure, sanitizeCloseCode(0))
+	require.Equal(t, websocket.CloseNormalClosure, sanitizeCloseCode(999))
+	require.Equal(t, websocket.CloseNormalClosure, sanitizeCloseCode(5000))
+
+	// Everything the protocol allows travels unchanged, and 1005 keeps its
+	// meaning because FormatCloseMessage renders it as an empty payload.
+	require.Equal(t, websocket.CloseNormalClosure, sanitizeCloseCode(websocket.CloseNormalClosure))
+	require.Equal(t, websocket.CloseGoingAway, sanitizeCloseCode(websocket.CloseGoingAway))
+	require.Equal(t, websocket.CloseNoStatusReceived, sanitizeCloseCode(websocket.CloseNoStatusReceived))
+	require.Equal(t, 4000, sanitizeCloseCode(4000))
+	require.Empty(t, websocket.FormatCloseMessage(sanitizeCloseCode(websocket.CloseNoStatusReceived), "ignored"))
+}
+
+func TestCloseAllSanitizesReservedCode(t *testing.T) {
+	resetState()
+
+	app := fiber.New()
+	ln := fasthttputil.NewInmemoryListener()
+	defer func() {
+		_ = app.Shutdown()
+		_ = ln.Close()
+	}()
+
+	app.Use(upgradeMiddleware)
+	app.Get("/", New(func(_ *Websocket) {}))
+
+	go func() { _ = app.Listener(ln) }()
+
+	dialer := &websocket.Dialer{
+		NetDial:          func(_, _ string) (net.Conn, error) { return ln.Dial() },
+		HandshakeTimeout: 5 * time.Second,
+	}
+	conn, _, err := dialWithRetry(dialer, "ws://"+ln.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	require.Eventually(t, func() bool {
+		return len(pool.snapshot()) == 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	// 1006 must never reach the wire; it is replaced by a normal closure.
+	require.NoError(t, CloseAll(ctx, websocket.CloseAbnormalClosure, strings.Repeat("€", 50)))
+
+	_, _, err = conn.ReadMessage()
+	require.Error(t, err)
+	var ce *websocket.CloseError
+	require.ErrorAs(t, err, &ce)
+	require.Equal(t, websocket.CloseNormalClosure, ce.Code)
+	require.True(t, utf8.ValidString(ce.Text))
+	require.LessOrEqual(t, len(ce.Text), closeFrameMaxReason)
+}
+
+func TestCallbackPanicDoesNotStrandPoolEntry(t *testing.T) {
+	resetState()
+
+	app := fiber.New()
+	ln := fasthttputil.NewInmemoryListener()
+	defer func() {
+		_ = app.Shutdown()
+		_ = ln.Close()
+	}()
+
+	app.Use(upgradeMiddleware)
+	app.Get("/", NewWithConfig(func(_ *Websocket) {
+		panic("callback boom")
+	}, Config{}, fws.Config{
+		// Swallow the panic quietly; the cleanup is what is under test.
+		RecoverHandler: func(*fws.Conn) { _ = recover() },
+	}))
+
+	go func() { _ = app.Listener(ln) }()
+
+	dialer := &websocket.Dialer{
+		NetDial:          func(_, _ string) (net.Conn, error) { return ln.Dial() },
+		HandshakeTimeout: 5 * time.Second,
+	}
+	conn, _, err := dialWithRetry(dialer, "ws://"+ln.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// The upgrade succeeded, so the connection was registered. A panicking
+	// callback must still take it back out: a stranded entry has a done channel
+	// nobody closes, so every later Broadcast would fill its queue and block.
+	require.Eventually(t, func() bool {
+		return len(pool.snapshot()) == 0
+	}, 2*time.Second, 10*time.Millisecond, "panicking callback stranded a pool entry")
+
+	// The socket is closed rather than left dangling on a hijacked connection.
+	_, _, err = conn.ReadMessage()
+	require.Error(t, err)
+}
+
+func TestMethodBroadcastSkipsSelfAndReportsDead(t *testing.T) {
+	resetState()
+
+	var errs int32
+	On(EventError, func(p *EventPayload) {
+		if errors.Is(p.Error, ErrorInvalidConnection) {
+			atomic.AddInt32(&errs, 1)
+		}
+	})
+
+	sender := createWS()
+	pool.set(sender)
+
+	alive := new(WebsocketMock)
+	require.NoError(t, alive.SetUUID("alive"))
+	alive.On("IsAlive").Return(true)
+	alive.On("Emit", mock.Anything).Return(nil)
+	alive.wg.Add(1)
+	pool.set(alive)
+
+	dead := new(WebsocketMock)
+	require.NoError(t, dead.SetUUID("dead"))
+	dead.On("IsAlive").Return(false)
+	pool.set(dead)
+
+	sender.Broadcast([]byte("test"), true, TextMessage)
+
+	alive.wg.Wait()
+	alive.AssertNumberOfCalls(t, "Emit", 1)
+	dead.AssertNumberOfCalls(t, "Emit", 0)
+	require.Equal(t, int32(1), atomic.LoadInt32(&errs))
+	// The sender was skipped, so nothing was queued on it.
+	require.Empty(t, sender.queue)
+}
+
+func BenchmarkFireEventNoListeners(b *testing.B) {
+	resetState()
+	kws := createWS()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		kws.fireEvent(EventMessage, nil, nil)
+	}
+}
+
+func BenchmarkFireEventSingleListener(b *testing.B) {
+	resetState()
+	On(EventMessage, func(*EventPayload) {})
+	kws := createWS()
+	payload := []byte("hello websocket")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		kws.fireEvent(EventMessage, payload, nil)
+	}
+	b.StopTimer()
+	resetState()
+}
+
+func BenchmarkPoolSnapshot(b *testing.B) {
+	resetState()
+	for i := 0; i < 128; i++ {
+		kws := createWS()
+		kws.UUID = strconv.Itoa(i)
+		pool.set(kws)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if len(pool.snapshot()) != 128 {
+			b.Fatal("unexpected snapshot size")
+		}
+	}
+	b.StopTimer()
+	resetState()
 }

--- a/v3/websocket/event/event_test.go
+++ b/v3/websocket/event/event_test.go
@@ -1020,6 +1020,10 @@ func (s *WebsocketMock) fireEvent(_ string, _ []byte, _ error) {
 	panic("implement me")
 }
 
+func (s *WebsocketMock) fireOwnedEvent(_ string, _ []byte, _ error) {
+	panic("implement me")
+}
+
 func TestCloseReasonStaysValidUTF8(t *testing.T) {
 	t.Run("short reason is untouched", func(t *testing.T) {
 		require.Equal(t, "bye", closeReason("bye"))
@@ -1047,10 +1051,7 @@ func TestCloseReasonStaysValidUTF8(t *testing.T) {
 }
 
 func TestSanitizeCloseCode(t *testing.T) {
-	// A code a conformant peer rejects on receive is replaced with a normal
-	// closure: 1005/1006/1015 are reserved for locally observed conditions
-	// (RFC 6455 section 7.4.1), 1004 is reserved with no meaning assigned, and
-	// 1014 plus 1016-2999 are outside the set the library accepts.
+	// See sanitizeCloseCode for why each of these is rewritten.
 	for _, code := range []int{
 		0, 999, 1004, websocket.CloseAbnormalClosure, 1014,
 		websocket.CloseTLSHandshake, 1016, 2999, 5000,
@@ -1078,10 +1079,8 @@ func TestSanitizeCloseCode(t *testing.T) {
 
 func TestCloseAllSanitizesReservedCode(t *testing.T) {
 	// Each of these makes a conformant peer fail the connection with a protocol
-	// error instead of reading a close, so CloseAll must not put them on the
-	// wire. 1006 and 1015 are reserved for locally observed conditions, 1004 is
-	// reserved with no meaning assigned, and 1014 and 1016-2999 are outside the
-	// set the receive side accepts.
+	// error instead of reading a close (see sanitizeCloseCode), so CloseAll
+	// must not put them on the wire.
 	for _, code := range []int{1004, websocket.CloseAbnormalClosure, 1014, websocket.CloseTLSHandshake, 2999} {
 		t.Run(strconv.Itoa(code), func(t *testing.T) {
 			resetState()
@@ -1137,6 +1136,15 @@ func TestCallbackPanicDoesNotStrandPoolEntry(t *testing.T) {
 		_ = ln.Close()
 	}()
 
+	type disconnect struct {
+		err      error
+		detached bool
+	}
+	disconnects := make(chan disconnect, 1)
+	On(EventDisconnect, func(p *EventPayload) {
+		disconnects <- disconnect{err: p.Error, detached: p.Kws.conn() == nil}
+	})
+
 	app.Use(upgradeMiddleware)
 	app.Get("/", NewWithConfig(func(_ *Websocket) {
 		panic("callback boom")
@@ -1171,6 +1179,16 @@ func TestCallbackPanicDoesNotStrandPoolEntry(t *testing.T) {
 		return len(pool.snapshot()) == 0
 	}, 2*time.Second, 10*time.Millisecond, "panicking callback stranded a pool entry")
 
+	// Listeners learn it was a crash, not a clean close, and the helper no
+	// longer points at the wrapper the middleware is about to recycle.
+	select {
+	case d := <-disconnects:
+		require.ErrorIs(t, d.err, ErrorCallbackPanic)
+		require.True(t, d.detached, "kws.Conn still aliases the pooled wrapper")
+	case <-time.After(2 * time.Second):
+		t.Fatal("EventDisconnect was not fired for the panicking callback")
+	}
+
 	// The socket is closed rather than left dangling on a hijacked connection.
 	// The deadline only keeps a regression from blocking forever; a timeout
 	// means the socket stayed open, which is the failure being guarded against.
@@ -1180,6 +1198,67 @@ func TestCallbackPanicDoesNotStrandPoolEntry(t *testing.T) {
 	var netErr net.Error
 	require.False(t, errors.As(err, &netErr) && netErr.Timeout(),
 		"panicking callback left the connection open: %v", err)
+}
+
+func TestCloseAllListenersStillSeeRequestData(t *testing.T) {
+	// EventDisconnect listeners run on the goroutine that called CloseAll,
+	// while each connection's handler unwinds concurrently and hands its
+	// wrapper back to the middleware pool. The request data those listeners
+	// read through the wrapper must survive that: emptying the maps at
+	// release time raced with these reads and returned "" (or, under -race,
+	// a report against (*Conn).Query).
+	resetState()
+
+	const numConn = 25
+	var mu sync.Mutex
+	seen := make(map[string]int)
+	On(EventDisconnect, func(p *EventPayload) {
+		mu.Lock()
+		seen[p.Kws.Query("who")]++
+		mu.Unlock()
+	})
+
+	app := fiber.New()
+	ln := fasthttputil.NewInmemoryListener()
+	defer func() {
+		_ = app.Shutdown()
+		_ = ln.Close()
+	}()
+
+	app.Use(upgradeMiddleware)
+	app.Get("/", New(func(_ *Websocket) {}))
+
+	go func() { _ = app.Listener(ln) }()
+
+	dialer := &websocket.Dialer{
+		NetDial:          func(_, _ string) (net.Conn, error) { return ln.Dial() },
+		HandshakeTimeout: 5 * time.Second,
+	}
+	clients := make([]*websocket.Conn, 0, numConn)
+	defer func() {
+		for _, c := range clients {
+			_ = c.Close()
+		}
+	}()
+	for i := 0; i < numConn; i++ {
+		conn, _, err := dialWithRetry(dialer, "ws://"+ln.Addr().String()+"/?who=c"+strconv.Itoa(i))
+		require.NoError(t, err)
+		clients = append(clients, conn)
+	}
+	require.Eventually(t, func() bool {
+		return len(pool.snapshot()) == numConn
+	}, 2*time.Second, 10*time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	require.NoError(t, CloseAll(ctx, websocket.CloseGoingAway, "bye"))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, seen, numConn, "a listener saw an empty or duplicated query value: %v", seen)
+	for i := 0; i < numConn; i++ {
+		require.Equal(t, 1, seen["c"+strconv.Itoa(i)])
+	}
 }
 
 func TestMethodBroadcastSkipsSelfAndReportsDead(t *testing.T) {

--- a/v3/websocket/event/event_test.go
+++ b/v3/websocket/event/event_test.go
@@ -1120,8 +1120,11 @@ func TestCallbackPanicDoesNotStrandPoolEntry(t *testing.T) {
 	app.Get("/", NewWithConfig(func(_ *Websocket) {
 		panic("callback boom")
 	}, Config{}, fws.Config{
-		// Swallow the panic quietly; the cleanup is what is under test.
-		RecoverHandler: func(*fws.Conn) { _ = recover() },
+		RecoverHandler: func(c *fws.Conn) {
+			if r := recover(); r != nil {
+				_ = c.WriteJSON(fiber.Map{"error": r})
+			}
+		},
 	}))
 
 	go func() { _ = app.Listener(ln) }()
@@ -1134,6 +1137,12 @@ func TestCallbackPanicDoesNotStrandPoolEntry(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
+	// The cleanup must not run ahead of the middleware's recover handler: the
+	// client still receives the error frame the handler is documented to send.
+	var msg fiber.Map
+	require.NoError(t, conn.ReadJSON(&msg))
+	require.Equal(t, "callback boom", msg["error"])
+
 	// The upgrade succeeded, so the connection was registered. A panicking
 	// callback must still take it back out: a stranded entry has a done channel
 	// nobody closes, so every later Broadcast would fill its queue and block.
@@ -1142,8 +1151,14 @@ func TestCallbackPanicDoesNotStrandPoolEntry(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond, "panicking callback stranded a pool entry")
 
 	// The socket is closed rather than left dangling on a hijacked connection.
+	// The deadline only keeps a regression from blocking forever; a timeout
+	// means the socket stayed open, which is the failure being guarded against.
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
 	_, _, err = conn.ReadMessage()
 	require.Error(t, err)
+	var netErr net.Error
+	require.False(t, errors.As(err, &netErr) && netErr.Timeout(),
+		"panicking callback left the connection open: %v", err)
 }
 
 func TestMethodBroadcastSkipsSelfAndReportsDead(t *testing.T) {

--- a/v3/websocket/event/event_test.go
+++ b/v3/websocket/event/event_test.go
@@ -1047,63 +1047,84 @@ func TestCloseReasonStaysValidUTF8(t *testing.T) {
 }
 
 func TestSanitizeCloseCode(t *testing.T) {
-	// RFC 6455 section 7.4.1: 1006 and 1015 report locally observed failures and
-	// must never travel in a close frame; section 7.4.2 leaves anything outside
-	// 1000-4999 undefined.
-	require.Equal(t, websocket.CloseNormalClosure, sanitizeCloseCode(websocket.CloseAbnormalClosure))
-	require.Equal(t, websocket.CloseNormalClosure, sanitizeCloseCode(websocket.CloseTLSHandshake))
-	require.Equal(t, websocket.CloseNormalClosure, sanitizeCloseCode(0))
-	require.Equal(t, websocket.CloseNormalClosure, sanitizeCloseCode(999))
-	require.Equal(t, websocket.CloseNormalClosure, sanitizeCloseCode(5000))
+	// A code a conformant peer rejects on receive is replaced with a normal
+	// closure: 1005/1006/1015 are reserved for locally observed conditions
+	// (RFC 6455 section 7.4.1), 1004 is reserved with no meaning assigned, and
+	// 1014 plus 1016-2999 are outside the set the library accepts.
+	for _, code := range []int{
+		0, 999, 1004, websocket.CloseAbnormalClosure, 1014,
+		websocket.CloseTLSHandshake, 1016, 2999, 5000,
+	} {
+		require.Equal(t, websocket.CloseNormalClosure, sanitizeCloseCode(code),
+			"code %d must not reach the wire", code)
+	}
 
-	// Everything the protocol allows travels unchanged, and 1005 keeps its
-	// meaning because FormatCloseMessage renders it as an empty payload.
-	require.Equal(t, websocket.CloseNormalClosure, sanitizeCloseCode(websocket.CloseNormalClosure))
-	require.Equal(t, websocket.CloseGoingAway, sanitizeCloseCode(websocket.CloseGoingAway))
+	// Everything a peer accepts travels unchanged.
+	for _, code := range []int{
+		websocket.CloseNormalClosure, websocket.CloseGoingAway,
+		websocket.CloseProtocolError, websocket.CloseUnsupportedData,
+		websocket.CloseInvalidFramePayloadData, websocket.ClosePolicyViolation,
+		websocket.CloseMessageTooBig, websocket.CloseMandatoryExtension,
+		websocket.CloseInternalServerErr, websocket.CloseServiceRestart,
+		websocket.CloseTryAgainLater, 3000, 4000, 4999,
+	} {
+		require.Equal(t, code, sanitizeCloseCode(code), "code %d must survive", code)
+	}
+
+	// 1005 keeps its meaning: FormatCloseMessage renders it as an empty payload.
 	require.Equal(t, websocket.CloseNoStatusReceived, sanitizeCloseCode(websocket.CloseNoStatusReceived))
-	require.Equal(t, 4000, sanitizeCloseCode(4000))
 	require.Empty(t, websocket.FormatCloseMessage(sanitizeCloseCode(websocket.CloseNoStatusReceived), "ignored"))
 }
 
 func TestCloseAllSanitizesReservedCode(t *testing.T) {
-	resetState()
+	// Each of these makes a conformant peer fail the connection with a protocol
+	// error instead of reading a close, so CloseAll must not put them on the
+	// wire. 1006 and 1015 are reserved for locally observed conditions, 1004 is
+	// reserved with no meaning assigned, and 1014 and 1016-2999 are outside the
+	// set the receive side accepts.
+	for _, code := range []int{1004, websocket.CloseAbnormalClosure, 1014, websocket.CloseTLSHandshake, 2999} {
+		t.Run(strconv.Itoa(code), func(t *testing.T) {
+			resetState()
 
-	app := fiber.New()
-	ln := fasthttputil.NewInmemoryListener()
-	defer func() {
-		_ = app.Shutdown()
-		_ = ln.Close()
-	}()
+			app := fiber.New()
+			ln := fasthttputil.NewInmemoryListener()
+			defer func() {
+				_ = app.Shutdown()
+				_ = ln.Close()
+			}()
 
-	app.Use(upgradeMiddleware)
-	app.Get("/", New(func(_ *Websocket) {}))
+			app.Use(upgradeMiddleware)
+			app.Get("/", New(func(_ *Websocket) {}))
 
-	go func() { _ = app.Listener(ln) }()
+			go func() { _ = app.Listener(ln) }()
 
-	dialer := &websocket.Dialer{
-		NetDial:          func(_, _ string) (net.Conn, error) { return ln.Dial() },
-		HandshakeTimeout: 5 * time.Second,
+			dialer := &websocket.Dialer{
+				NetDial:          func(_, _ string) (net.Conn, error) { return ln.Dial() },
+				HandshakeTimeout: 5 * time.Second,
+			}
+			conn, _, err := dialWithRetry(dialer, "ws://"+ln.Addr().String())
+			require.NoError(t, err)
+			defer conn.Close()
+
+			require.Eventually(t, func() bool {
+				return len(pool.snapshot()) == 1
+			}, 2*time.Second, 10*time.Millisecond)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			require.NoError(t, CloseAll(ctx, code, strings.Repeat("€", 50)))
+
+			// The peer reads a well formed close rather than rejecting the
+			// frame, and the reason survives as valid UTF-8 within the limit.
+			_, _, err = conn.ReadMessage()
+			require.Error(t, err)
+			var ce *websocket.CloseError
+			require.ErrorAs(t, err, &ce)
+			require.Equal(t, websocket.CloseNormalClosure, ce.Code)
+			require.True(t, utf8.ValidString(ce.Text))
+			require.LessOrEqual(t, len(ce.Text), closeFrameMaxReason)
+		})
 	}
-	conn, _, err := dialWithRetry(dialer, "ws://"+ln.Addr().String())
-	require.NoError(t, err)
-	defer conn.Close()
-
-	require.Eventually(t, func() bool {
-		return len(pool.snapshot()) == 1
-	}, 2*time.Second, 10*time.Millisecond)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-	// 1006 must never reach the wire; it is replaced by a normal closure.
-	require.NoError(t, CloseAll(ctx, websocket.CloseAbnormalClosure, strings.Repeat("€", 50)))
-
-	_, _, err = conn.ReadMessage()
-	require.Error(t, err)
-	var ce *websocket.CloseError
-	require.ErrorAs(t, err, &ce)
-	require.Equal(t, websocket.CloseNormalClosure, ce.Code)
-	require.True(t, utf8.ValidString(ce.Text))
-	require.LessOrEqual(t, len(ce.Text), closeFrameMaxReason)
 }
 
 func TestCallbackPanicDoesNotStrandPoolEntry(t *testing.T) {

--- a/v3/websocket/event/event_test.go
+++ b/v3/websocket/event/event_test.go
@@ -1081,8 +1081,7 @@ func TestSanitizeCloseCode(t *testing.T) {
 
 func TestCloseAllSanitizesReservedCode(t *testing.T) {
 	// Each of these makes a conformant peer fail the connection with a protocol
-	// error instead of reading a close (see sanitizeCloseCode), so CloseAll
-	// must not put them on the wire.
+	// error (see sanitizeCloseCode), so CloseAll must not send them.
 	for _, code := range []int{1004, websocket.CloseAbnormalClosure, 1014, websocket.CloseTLSHandshake, 2999} {
 		t.Run(strconv.Itoa(code), func(t *testing.T) {
 			resetState()
@@ -1174,9 +1173,8 @@ func TestCallbackPanicDoesNotStrandPoolEntry(t *testing.T) {
 	require.NoError(t, conn.ReadJSON(&msg))
 	require.Equal(t, "callback boom", msg["error"])
 
-	// The upgrade succeeded, so the connection was registered. A panicking
-	// callback must still take it back out: a stranded entry has a done channel
-	// nobody closes, so every later Broadcast would fill its queue and block.
+	// A panicking callback must still leave the pool: a stranded entry has a
+	// done channel nobody closes, so every later Broadcast would block.
 	require.Eventually(t, func() bool {
 		return len(pool.snapshot()) == 0
 	}, 2*time.Second, 10*time.Millisecond, "panicking callback stranded a pool entry")
@@ -1191,9 +1189,8 @@ func TestCallbackPanicDoesNotStrandPoolEntry(t *testing.T) {
 		t.Fatal("EventDisconnect was not fired for the panicking callback")
 	}
 
-	// The socket is closed rather than left dangling on a hijacked connection.
-	// The deadline only keeps a regression from blocking forever; a timeout
-	// means the socket stayed open, which is the failure being guarded against.
+	// The socket must be closed rather than left dangling; a timeout here means
+	// it stayed open.
 	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
 	_, _, err = conn.ReadMessage()
 	require.Error(t, err)
@@ -1266,12 +1263,8 @@ func TestCallbackPanicAfterCloseStillReportsError(t *testing.T) {
 }
 
 func TestCloseAllListenersStillSeeRequestData(t *testing.T) {
-	// EventDisconnect listeners run on the goroutine that called CloseAll,
-	// while each connection's handler unwinds concurrently and hands its
-	// wrapper back to the middleware pool. The request data those listeners
-	// read through the wrapper must survive that: emptying the maps at
-	// release time raced with these reads and returned "" (or, under -race,
-	// a report against (*Conn).Query).
+	// EventDisconnect listeners run on CloseAll's goroutine while each handler
+	// returns concurrently; the request data they read must survive that.
 	resetState()
 
 	const numConn = 25
@@ -1327,11 +1320,9 @@ func TestCloseAllListenersStillSeeRequestData(t *testing.T) {
 }
 
 func TestCloseAllListenersSurviveConcurrentUpgrades(t *testing.T) {
-	// The scenario a reviewer raised against a pooled Conn: a disconnect
-	// listener runs on CloseAll's goroutine and reads the wrapper's request
-	// data while the handler returns, and a new upgrade lands on the same
-	// object and rewrites those maps underneath it. Nothing here may see
-	// another connection's value, an empty one, or a race report.
+	// A disconnect listener reads the wrapper's request data on CloseAll's
+	// goroutine while new upgrades keep landing; it must never see another
+	// connection's value, an empty one, or a race report.
 	resetState()
 
 	const numConn = 25
@@ -1414,10 +1405,8 @@ func TestCloseAllListenersSurviveConcurrentUpgrades(t *testing.T) {
 }
 
 func TestGlobalFireGivesEachConnectionItsOwnData(t *testing.T) {
-	// Package-level Fire fans one payload out to every connection. Each must
-	// get its own copy: a listener that mutates Data for one connection must
-	// not change what another connection's listener sees, nor the caller's
-	// slice.
+	// Package-level Fire must give each connection its own copy: a listener
+	// mutating Data for one connection must not affect another's or the caller's.
 	resetState()
 
 	var mu sync.Mutex
@@ -1483,8 +1472,7 @@ func BenchmarkFireEventNoListeners(b *testing.B) {
 	kws := createWS()
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		kws.fireEvent(EventMessage, nil, nil)
 	}
 }
@@ -1496,11 +1484,9 @@ func BenchmarkFireEventSingleListener(b *testing.B) {
 	payload := []byte("hello websocket")
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		kws.fireEvent(EventMessage, payload, nil)
 	}
-	b.StopTimer()
 	resetState()
 }
 
@@ -1513,13 +1499,11 @@ func BenchmarkPoolSnapshot(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if len(pool.snapshot()) != 128 {
 			b.Fatal("unexpected snapshot size")
 		}
 	}
-	b.StopTimer()
 	resetState()
 }
 
@@ -1673,9 +1657,8 @@ func TestFrameReaderTrimDropsOversizedBuffers(t *testing.T) {
 	require.Nil(t, fr.buf, "a buffer past the cap is dropped")
 }
 
-// frameBench is one upgraded loopback connection whose client side is a raw
-// TCP socket, so a benchmark can feed the server pre-built frames in large
-// batches without the client allocating or paying one syscall per frame.
+// frameBench is an upgraded loopback connection whose client side is a raw
+// TCP socket, so a benchmark can feed the server batches of pre-built frames.
 type frameBench struct {
 	server *fws.Conn
 	client net.Conn
@@ -1771,8 +1754,7 @@ func benchmarkFrameRead(b *testing.B, size int, exact bool) {
 
 	b.SetBytes(int64(size))
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var msg []byte
 		var err error
 		if exact {
@@ -1787,7 +1769,6 @@ func benchmarkFrameRead(b *testing.B, size int, exact bool) {
 			b.Fatalf("bad message of %d bytes", len(msg))
 		}
 	}
-	b.StopTimer()
 }
 
 var frameBenchSizes = []struct {
@@ -1807,9 +1788,8 @@ func BenchmarkFrameReader(b *testing.B) {
 	}
 }
 
-// Every connection's read goroutine fires EventMessage through the one global
-// registry, so this is the per-frame fan-out under the contention a busy
-// server sees.
+// The per-frame fan-out under the contention a busy server sees: every read
+// goroutine consults the one global registry.
 func BenchmarkFireOwnedEventParallel(b *testing.B) {
 	resetState()
 	On(EventMessage, func(*EventPayload) {})
@@ -1822,7 +1802,6 @@ func BenchmarkFireOwnedEventParallel(b *testing.B) {
 			kws.fireOwnedEvent(EventMessage, data, nil)
 		}
 	})
-	b.StopTimer()
 	resetState()
 }
 
@@ -1839,18 +1818,18 @@ func BenchmarkPoolSnapshotChurn(b *testing.B) {
 	extra.UUID = "extra"
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	i := 0
+	for b.Loop() {
 		switch i % 20 {
 		case 0:
 			pool.set(extra)
 		case 10:
 			pool.delete(extra.UUID)
 		}
+		i++
 		if len(pool.snapshot()) < 128 {
 			b.Fatal("unexpected snapshot size")
 		}
 	}
-	b.StopTimer()
 	resetState()
 }

--- a/v3/websocket/event/event_test.go
+++ b/v3/websocket/event/event_test.go
@@ -1348,6 +1348,36 @@ func TestCloseAllListenersSurviveConcurrentUpgrades(t *testing.T) {
 	}
 }
 
+func TestGlobalFireGivesEachConnectionItsOwnData(t *testing.T) {
+	// Package-level Fire fans one payload out to every connection. Each must
+	// get its own copy: a listener that mutates Data for one connection must
+	// not change what another connection's listener sees, nor the caller's
+	// slice.
+	resetState()
+
+	var mu sync.Mutex
+	seen := make(map[string]byte)
+	for i, kws := range []*Websocket{createWS(), createWS()} {
+		pool.set(kws)
+		name, marker := "c"+strconv.Itoa(i), byte('X'+i)
+		kws.On("custom", func(p *EventPayload) {
+			mu.Lock()
+			seen[name] = p.Data[0]
+			mu.Unlock()
+			p.Data[0] = marker
+		})
+	}
+
+	payload := []byte("abc")
+	Fire("custom", payload)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, byte('a'), seen["c0"])
+	require.Equal(t, byte('a'), seen["c1"])
+	require.Equal(t, "abc", string(payload))
+}
+
 func TestMethodBroadcastSkipsSelfAndReportsDead(t *testing.T) {
 	resetState()
 

--- a/v3/websocket/event/event_test.go
+++ b/v3/websocket/event/event_test.go
@@ -1261,6 +1261,93 @@ func TestCloseAllListenersStillSeeRequestData(t *testing.T) {
 	}
 }
 
+func TestCloseAllListenersSurviveConcurrentUpgrades(t *testing.T) {
+	// The scenario a reviewer raised against a pooled Conn: a disconnect
+	// listener runs on CloseAll's goroutine and reads the wrapper's request
+	// data while the handler returns, and a new upgrade lands on the same
+	// object and rewrites those maps underneath it. Nothing here may see
+	// another connection's value, an empty one, or a race report.
+	resetState()
+
+	const numConn = 25
+	var mu sync.Mutex
+	seen := make(map[string]int)
+	On(EventDisconnect, func(p *EventPayload) {
+		mu.Lock()
+		seen[p.Kws.Query("who")]++
+		mu.Unlock()
+	})
+
+	app := fiber.New()
+	ln := fasthttputil.NewInmemoryListener()
+	defer func() {
+		_ = app.Shutdown()
+		_ = ln.Close()
+	}()
+
+	app.Use(upgradeMiddleware)
+	app.Get("/", New(func(_ *Websocket) {}))
+
+	go func() { _ = app.Listener(ln) }()
+
+	dialer := &websocket.Dialer{
+		NetDial:          func(_, _ string) (net.Conn, error) { return ln.Dial() },
+		HandshakeTimeout: 5 * time.Second,
+	}
+	clients := make([]*websocket.Conn, 0, numConn)
+	defer func() {
+		for _, c := range clients {
+			_ = c.Close()
+		}
+	}()
+	for i := 0; i < numConn; i++ {
+		conn, _, err := dialWithRetry(dialer, "ws://"+ln.Addr().String()+"/?who=c"+strconv.Itoa(i))
+		require.NoError(t, err)
+		clients = append(clients, conn)
+	}
+	require.Eventually(t, func() bool {
+		return len(pool.snapshot()) == numConn
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Keep new upgrades arriving for the whole of CloseAll so a recycled
+	// wrapper would be re-acquired while listeners are still reading it.
+	stop := make(chan struct{})
+	churned := make(chan struct{})
+	go func() {
+		defer close(churned)
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			c, _, err := dialer.Dial("ws://"+ln.Addr().String()+"/?who=late"+strconv.Itoa(i), nil)
+			if err == nil {
+				_ = c.Close()
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := CloseAll(ctx, websocket.CloseGoingAway, "bye")
+	close(stop)
+	<-churned
+	require.NoError(t, err)
+
+	// Late connections may or may not have been caught by CloseAll; whatever
+	// was seen must be a real value that was seen exactly once.
+	mu.Lock()
+	defer mu.Unlock()
+	for i := 0; i < numConn; i++ {
+		require.Equal(t, 1, seen["c"+strconv.Itoa(i)], "connection c%d: %v", i, seen)
+	}
+	require.NotContains(t, seen, "", "a listener read an emptied wrapper")
+	for who, n := range seen {
+		require.Equal(t, 1, n, "%q seen %d times", who, n)
+	}
+}
+
 func TestMethodBroadcastSkipsSelfAndReportsDead(t *testing.T) {
 	resetState()
 

--- a/v3/websocket/event/event_test.go
+++ b/v3/websocket/event/event_test.go
@@ -1612,22 +1612,20 @@ func TestFrameReaderHandsOutExactSizeOwnedCopies(t *testing.T) {
 
 	type result struct {
 		msg      []byte
-		retained int
 		prevKept bool
 	}
 	results := make(chan result, 16)
 	app.Use(upgradeMiddleware)
 	app.Get("/", fws.New(func(c *fws.Conn) {
-		var fr frameReader
 		var prev, prevCopy []byte
 		for {
-			_, msg, err := fr.read(c)
+			_, msg, err := readFrame(c)
 			if err != nil {
 				return
 			}
 			// prev was handed out by the previous read; reading this frame
 			// must not have touched it.
-			results <- result{msg: msg, retained: cap(fr.buf), prevKept: bytes.Equal(prev, prevCopy)}
+			results <- result{msg: msg, prevKept: bytes.Equal(prev, prevCopy)}
 			prev = msg
 			prevCopy = bytes.Clone(msg)
 		}
@@ -1658,16 +1656,21 @@ func TestFrameReaderHandsOutExactSizeOwnedCopies(t *testing.T) {
 		case r := <-results:
 			require.Equal(t, want, r.msg, "size %d", size)
 			require.True(t, r.prevKept, "size %d: reading this frame changed the previous message", size)
-			if size > frameBufferRetained {
-				require.Zero(t, r.retained, "size %d: an oversized buffer must not be retained", size)
-			} else {
-				require.GreaterOrEqual(t, r.retained, size, "size %d", size)
-				require.LessOrEqual(t, r.retained, frameBufferRetained, "size %d", size)
-			}
 		case <-time.After(5 * time.Second):
 			t.Fatalf("no result for size %d", size)
 		}
 	}
+}
+
+func TestFrameReaderTrimDropsOversizedBuffers(t *testing.T) {
+	fr := &frameReader{buf: make([]byte, frameBufferRetained)}
+	fr.trim()
+	require.Equal(t, frameBufferRetained, cap(fr.buf), "a buffer within the cap goes back to the pool")
+	require.Empty(t, fr.buf)
+
+	fr = &frameReader{buf: make([]byte, frameBufferRetained+1)}
+	fr.trim()
+	require.Nil(t, fr.buf, "a buffer past the cap is dropped")
 }
 
 // frameBench is one upgraded loopback connection whose client side is a raw
@@ -1766,7 +1769,6 @@ func benchmarkFrameRead(b *testing.B, size int, exact bool) {
 		}
 	}()
 
-	var fr frameReader
 	b.SetBytes(int64(size))
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -1774,7 +1776,7 @@ func benchmarkFrameRead(b *testing.B, size int, exact bool) {
 		var msg []byte
 		var err error
 		if exact {
-			_, msg, err = fr.read(fb.server)
+			_, msg, err = readFrame(fb.server)
 		} else {
 			_, msg, err = fb.server.ReadMessage()
 		}

--- a/v3/websocket/event/event_test.go
+++ b/v3/websocket/event/event_test.go
@@ -1,8 +1,11 @@
 package event
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"strconv"
@@ -63,10 +66,9 @@ type WebsocketMock struct {
 func resetState() {
 	pool.Lock()
 	pool.conn = make(map[string]ws)
+	pool.snap = nil
 	pool.Unlock()
-	listeners.Lock()
-	listeners.list = make(map[string][]EventCallback)
-	listeners.Unlock()
+	listeners.list.Store(nil)
 	draining.Store(false)
 }
 
@@ -1451,6 +1453,336 @@ func BenchmarkPoolSnapshot(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if len(pool.snapshot()) != 128 {
+			b.Fatal("unexpected snapshot size")
+		}
+	}
+	b.StopTimer()
+	resetState()
+}
+
+func TestListenersRegistryIsCopyOnWrite(t *testing.T) {
+	var reg safeListeners
+	calls := 0
+	reg.set("e", func(*EventPayload) { calls++ })
+	reg.set("e", func(*EventPayload) { calls += 10 })
+	before := reg.get("e")
+	require.Len(t, before, 2)
+	require.Nil(t, reg.get("other"))
+
+	// A slice handed out earlier is not changed by a later registration.
+	reg.set("e", func(*EventPayload) { calls += 100 })
+	require.Len(t, before, 2)
+	require.Len(t, reg.get("e"), 3)
+	for _, cb := range reg.get("e") {
+		cb(nil)
+	}
+	require.Equal(t, 111, calls)
+
+	reg.remove("e")
+	require.Nil(t, reg.get("e"))
+	reg.remove("e")
+	require.Nil(t, reg.get("e"))
+
+	// Readers never block on writers; the race detector checks the rest.
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			reg.set("spin", func(*EventPayload) {})
+			if i%8 == 0 {
+				reg.remove("spin")
+			}
+		}
+	}()
+	for i := 0; i < 10000; i++ {
+		_ = reg.get("spin")
+	}
+	close(stop)
+	wg.Wait()
+}
+
+func TestPoolSnapshotIsCachedUntilMembershipChanges(t *testing.T) {
+	resetState()
+	defer resetState()
+
+	a, b := createWS(), createWS()
+	pool.set(a)
+	pool.set(b)
+
+	first := pool.snapshot()
+	require.Len(t, first, 2)
+	require.Same(t, &first[0], &pool.snapshot()[0], "unchanged pool must hand out the same slice")
+
+	c := createWS()
+	pool.set(c)
+	third := pool.snapshot()
+	require.Len(t, third, 3)
+	require.NotSame(t, &first[0], &third[0])
+	require.Len(t, first, 2, "an earlier snapshot is never modified")
+
+	pool.delete(c.GetUUID())
+	afterDelete := pool.snapshot()
+	require.Len(t, afterDelete, 2)
+	require.NotSame(t, &third[0], &afterDelete[0])
+
+	// A rename keeps the same set of connections but still refreshes the cache.
+	require.NoError(t, a.SetUUID("renamed"))
+	renamed := pool.snapshot()
+	require.NotSame(t, &afterDelete[0], &renamed[0])
+	require.ElementsMatch(t, afterDelete, renamed)
+}
+
+func TestFrameReaderHandsOutExactSizeOwnedCopies(t *testing.T) {
+	app := fiber.New()
+	ln := fasthttputil.NewInmemoryListener()
+	defer func() {
+		_ = app.Shutdown()
+		_ = ln.Close()
+	}()
+
+	type result struct {
+		msg      []byte
+		retained int
+		prevKept bool
+	}
+	results := make(chan result, 16)
+	app.Use(upgradeMiddleware)
+	app.Get("/", fws.New(func(c *fws.Conn) {
+		var fr frameReader
+		var prev, prevCopy []byte
+		for {
+			_, msg, err := fr.read(c)
+			if err != nil {
+				return
+			}
+			// prev was handed out by the previous read; reading this frame
+			// must not have touched it.
+			results <- result{msg: msg, retained: cap(fr.buf), prevKept: bytes.Equal(prev, prevCopy)}
+			prev = msg
+			prevCopy = bytes.Clone(msg)
+		}
+	}))
+	go func() { _ = app.Listener(ln) }()
+
+	// A small client write buffer splits the larger messages into
+	// continuation frames, so the reader is exercised across fragments too.
+	dialer := &websocket.Dialer{
+		NetDial: func(_, _ string) (net.Conn, error) {
+			return ln.Dial()
+		},
+		HandshakeTimeout: 5 * time.Second,
+		WriteBufferSize:  256,
+	}
+	conn, _, err := dialWithRetry(dialer, "ws://"+ln.Addr().String())
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	sizes := []int{0, 1, frameBufferInitial - 1, frameBufferInitial, frameBufferInitial + 1, 3000, frameBufferRetained, frameBufferRetained + 1, 16}
+	for _, size := range sizes {
+		want := make([]byte, size)
+		for i := range want {
+			want[i] = byte(i % 251)
+		}
+		require.NoError(t, conn.WriteMessage(websocket.BinaryMessage, want))
+		select {
+		case r := <-results:
+			require.Equal(t, want, r.msg, "size %d", size)
+			require.True(t, r.prevKept, "size %d: reading this frame changed the previous message", size)
+			if size > frameBufferRetained {
+				require.Zero(t, r.retained, "size %d: an oversized buffer must not be retained", size)
+			} else {
+				require.GreaterOrEqual(t, r.retained, size, "size %d", size)
+				require.LessOrEqual(t, r.retained, frameBufferRetained, "size %d", size)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("no result for size %d", size)
+		}
+	}
+}
+
+// frameBench is one upgraded loopback connection whose client side is a raw
+// TCP socket, so a benchmark can feed the server pre-built frames in large
+// batches without the client allocating or paying one syscall per frame.
+type frameBench struct {
+	server *fws.Conn
+	client net.Conn
+	app    *fiber.App
+	done   chan struct{}
+}
+
+func newFrameBench(tb testing.TB) *frameBench {
+	tb.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(tb, err)
+	done := make(chan struct{})
+	connCh := make(chan *fws.Conn, 1)
+	app := fiber.New()
+	app.Get("/", fws.New(func(c *fws.Conn) {
+		connCh <- c
+		<-done
+	}))
+	go func() { _ = app.Listener(ln, fiber.ListenConfig{DisableStartupMessage: true}) }()
+
+	client, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(tb, err)
+	_, err = fmt.Fprintf(client, "GET / HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n", ln.Addr())
+	require.NoError(tb, err)
+	br := bufio.NewReader(client)
+	status, err := br.ReadString('\n')
+	require.NoError(tb, err)
+	require.Contains(tb, status, "101")
+	for {
+		line, err := br.ReadString('\n')
+		require.NoError(tb, err)
+		if line == "\r\n" {
+			break
+		}
+	}
+	select {
+	case server := <-connCh:
+		return &frameBench{server: server, client: client, app: app, done: done}
+	case <-time.After(5 * time.Second):
+		tb.Fatal("server side never upgraded")
+		return nil
+	}
+}
+
+func (fb *frameBench) close() {
+	close(fb.done)
+	_ = fb.server.Close()
+	_ = fb.client.Close()
+	_ = fb.app.ShutdownWithTimeout(time.Second)
+}
+
+// maskedFrame builds one client-to-server binary frame carrying payload.
+func maskedFrame(payload []byte) []byte {
+	n := len(payload)
+	frame := make([]byte, 0, 14+n)
+	frame = append(frame, 0x80|byte(websocket.BinaryMessage))
+	switch {
+	case n < 126:
+		frame = append(frame, 0x80|byte(n))
+	case n < 1<<16:
+		frame = append(frame, 0x80|126, byte(n>>8), byte(n))
+	default:
+		frame = append(frame, 0x80|127, 0, 0, 0, 0, byte(n>>24), byte(n>>16), byte(n>>8), byte(n))
+	}
+	key := [4]byte{0x11, 0x22, 0x33, 0x44}
+	frame = append(frame, key[:]...)
+	for i, b := range payload {
+		frame = append(frame, b^key[i%4])
+	}
+	return frame
+}
+
+func benchmarkFrameRead(b *testing.B, size int, exact bool) {
+	fb := newFrameBench(b)
+	defer fb.close()
+
+	payload := make([]byte, size)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+	frame := maskedFrame(payload)
+	batch := frame
+	for len(batch) < 256<<10 {
+		batch = append(batch, frame...)
+	}
+	go func() {
+		for {
+			if _, err := fb.client.Write(batch); err != nil {
+				return
+			}
+		}
+	}()
+
+	var fr frameReader
+	b.SetBytes(int64(size))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var msg []byte
+		var err error
+		if exact {
+			_, msg, err = fr.read(fb.server)
+		} else {
+			_, msg, err = fb.server.ReadMessage()
+		}
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(msg) != size || msg[size/2] != payload[size/2] {
+			b.Fatalf("bad message of %d bytes", len(msg))
+		}
+	}
+	b.StopTimer()
+}
+
+var frameBenchSizes = []struct {
+	name string
+	size int
+}{{"128B", 128}, {"4KB", 4 << 10}, {"64KB", 64 << 10}}
+
+func BenchmarkReadMessage(b *testing.B) {
+	for _, s := range frameBenchSizes {
+		b.Run(s.name, func(b *testing.B) { benchmarkFrameRead(b, s.size, false) })
+	}
+}
+
+func BenchmarkFrameReader(b *testing.B) {
+	for _, s := range frameBenchSizes {
+		b.Run(s.name, func(b *testing.B) { benchmarkFrameRead(b, s.size, true) })
+	}
+}
+
+// Every connection's read goroutine fires EventMessage through the one global
+// registry, so this is the per-frame fan-out under the contention a busy
+// server sees.
+func BenchmarkFireOwnedEventParallel(b *testing.B) {
+	resetState()
+	On(EventMessage, func(*EventPayload) {})
+	data := []byte("hello websocket")
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		kws := createWS()
+		for pb.Next() {
+			kws.fireOwnedEvent(EventMessage, data, nil)
+		}
+	})
+	b.StopTimer()
+	resetState()
+}
+
+// One connection joins or leaves per ten snapshots: the amortised cost of a
+// broadcast on a pool whose membership keeps changing.
+func BenchmarkPoolSnapshotChurn(b *testing.B) {
+	resetState()
+	for i := 0; i < 128; i++ {
+		kws := createWS()
+		kws.UUID = strconv.Itoa(i)
+		pool.set(kws)
+	}
+	extra := createWS()
+	extra.UUID = "extra"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		switch i % 20 {
+		case 0:
+			pool.set(extra)
+		case 10:
+			pool.delete(extra.UUID)
+		}
+		if len(pool.snapshot()) < 128 {
 			b.Fatal("unexpected snapshot size")
 		}
 	}

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -434,9 +434,15 @@ func (conn *Conn) IP() string {
 
 // Close codes 1000-1011 and 1015 are defined in RFC 6455, section 11.7; 1012,
 // 1013 and 1014 were added to the IANA WebSocket Close Code Number Registry
-// afterwards. Note that 1005, 1006 and 1015 are reserved for use by
-// applications and must never be sent in a close frame (RFC 6455, section
-// 7.4.1).
+// afterwards.
+//
+// Not every code may travel in a close frame. RFC 6455, section 7.4.1 reserves
+// 1005, 1006 and 1015 for conditions an endpoint observes locally and forbids
+// sending them, and lists 1004 as reserved with no meaning assigned. Endpoints
+// are stricter still: the underlying library accepts only 1000-1003, 1007-1013
+// and 3000-4999 on receive, so sending 1004, 1014 or anything in 1016-2999
+// makes a conformant peer fail the connection with a protocol error. Prefer
+// 1000-1003, 1007-1013, or the 3000-4999 application range.
 const (
 	CloseNormalClosure           = 1000
 	CloseGoingAway               = 1001

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -203,10 +203,11 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 		if !IsWebSocketUpgrade(c) {
 			return fiber.ErrUpgradeRequired
 		}
-		ensureKeepHijackedConns(c.App().Server())
+		server := c.App().Server()
+		ensureKeepHijackedConns(server)
 
 		fctx := c.RequestCtx()
-		conn := acquireConn()
+		conn := &Conn{}
 
 		// Route params and the IP come from the Fiber context, which is
 		// recycled before the hijack callback runs, so they are captured now.
@@ -223,18 +224,16 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 			// Everything else is copied only once the handshake has been
 			// accepted, so a rejected one pays for none of it. fasthttp keeps
 			// the RequestCtx alive until this callback returns.
-			conn.capture(fctx)
+			conn.capture(fctx, !server.DisableHeaderNamesNormalizing)
 
 			returned := false
-			defer releaseConn(conn)
 			// Registered before the recover handler so it runs after it. A
 			// handler that panicked cannot be trusted to still own the socket,
 			// and KeepHijackedConns means nothing else will ever close it, so
 			// close it here -- but only once RecoverHandler has had its chance
 			// to write the error frame. A handler that returns normally leaves
-			// the socket open: the embedded fconn may be handed to another
-			// goroutine before returning. The wrapper itself may not be, since
-			// releaseConn takes it back the moment the handler returns.
+			// the socket open, so it may keep using the connection from another
+			// goroutine after returning.
 			defer func() {
 				if !returned {
 					_ = fconn.Close()
@@ -244,7 +243,6 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 			handler(conn)
 			returned = true
 		}); err != nil { // Handshake rejected
-			releaseConn(conn)
 			// The upgrader picked the status RFC 6455 asks for: 403 for an
 			// Origin the server does not accept (section 4.2.2), 400 for a
 			// malformed or unsupported handshake, 405 for a non-GET request.
@@ -273,67 +271,25 @@ type Conn struct {
 	ip      string
 }
 
-// Conn pool
-var poolConn = sync.Pool{
-	New: func() interface{} {
-		return new(Conn)
-	},
-}
-
-// maxPooledMapEntries bounds the maps carried by a pooled Conn. Reusing the
-// buckets of a modest map is the point of the pool, but a single request
-// carrying thousands of query arguments or headers would otherwise make every
-// later connection pay for that footprint, so oversized maps are dropped.
-const maxPooledMapEntries = 64
-
-// acquireConn takes a Conn from the pool and empties whatever the previous
-// connection left in it.
-func acquireConn() *Conn {
-	conn := poolConn.Get().(*Conn)
-	conn.reset()
-	return conn
-}
-
-// releaseConn detaches the socket and hands the Conn back to the pool. The maps
-// are deliberately left alone until the next acquireConn: the event helper's
-// Locals, Params, Query and Cookies closures keep reading them from listeners
-// that run on other goroutines while the handler is still unwinding, and
-// emptying them here raced with those reads.
-func releaseConn(conn *Conn) {
-	conn.Conn = nil
-	poolConn.Put(conn)
-}
-
-// reset empties the maps for the next connection. Emptying rather than
-// replacing them keeps their buckets, which is what saves the allocations;
-// a map that grew past maxPooledMapEntries is dropped instead.
-func (conn *Conn) reset() {
-	conn.ip = ""
-	conn.locals = resetMap(conn.locals)
-	conn.params = resetMap(conn.params)
-	conn.queries = resetMap(conn.queries)
-	conn.cookies = resetMap(conn.cookies)
-	conn.headers = resetMap(conn.headers)
-}
-
-func resetMap[V any](m map[string]V) map[string]V {
-	if len(m) > maxPooledMapEntries {
-		return nil
-	}
-	clear(m)
-	return m
-}
+// A Conn is allocated per upgrade and never reused. An earlier revision pooled
+// it and emptied the maps in place for the next connection, which is unsafe:
+// the event helper's Locals, Params, Query and Cookies closures read those maps
+// from listeners that run on other goroutines during Close and CloseAll, so a
+// new upgrade taking the wrapper could clear and refill them under a listener
+// still reading the previous client's data. The maps are only allocated when
+// the request carries that kind of data, so a typical handshake still allocates
+// less than unconditionally creating all five.
 
 // capture copies the locals, query arguments, cookies and headers of the
 // request into the Conn. It runs inside the hijack callback, where the
 // RequestCtx is still valid, and after the handshake has been accepted.
-func (conn *Conn) capture(fctx *fasthttp.RequestCtx) {
+// canonical says whether the server already normalizes header names.
+func (conn *Conn) capture(fctx *fasthttp.RequestCtx, canonical bool) {
 	fctx.VisitUserValues(func(key []byte, value interface{}) {
 		setEntry(&conn.locals, string(key), value)
 	})
 	// No size hint for the query map: Args.Len counts repeated keys that the
-	// assignments collapse into one entry, and a map sized for the repetitions
-	// with len stuck at 1 would slip past resetMap's entry cap and stay pooled.
+	// assignments collapse into one entry, so it would over-allocate.
 	for key, value := range fctx.QueryArgs().All() {
 		setEntry(&conn.queries, string(key), string(value))
 	}
@@ -341,10 +297,13 @@ func (conn *Conn) capture(fctx *fasthttp.RequestCtx) {
 		setEntry(&conn.cookies, string(key), string(value))
 	}
 	// Header names are stored in canonical form so Headers is a single probe.
-	// fasthttp already delivers them that way unless normalizing is disabled,
-	// in which case CanonicalHeaderKey rewrites them once per connection here.
+	// fasthttp delivers them that way already unless the server disabled
+	// normalizing, and only then is each name rewritten here.
 	for key, value := range fctx.Request.Header.All() {
-		setEntry(&conn.headers, string(utils.CanonicalHeaderKey(key)), string(value))
+		if !canonical {
+			key = utils.CanonicalHeaderKey(key)
+		}
+		setEntry(&conn.headers, string(key), string(value))
 	}
 }
 

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -28,11 +28,17 @@ type Config struct {
 	// HandshakeTimeout specifies the duration for the handshake to complete.
 	HandshakeTimeout time.Duration
 
-	// Subprotocols specifies the client's requested subprotocols.
+	// Subprotocols lists the subprotocols this server supports, in order of
+	// preference. The handshake negotiates the first entry that also appears in
+	// the client's Sec-WebSocket-Protocol header; when nothing matches, no
+	// subprotocol is negotiated and the response header is omitted, as required
+	// by RFC 6455 section 4.2.2.
 	Subprotocols []string
 
 	// Allowed Origin's based on the Origin header, this validate the request origin to
 	// prevent cross-site request forgery. Everything is allowed if left empty.
+	// Comparison is case-insensitive, matching the case-insensitive scheme and
+	// host of a serialized origin (RFC 6454, section 4).
 	Origins []string
 
 	// AllowEmptyOrigin allows WebSocket connections when the Origin header is absent.
@@ -70,48 +76,68 @@ type Config struct {
 	RecoverHandler func(*Conn)
 }
 
+// supportedVersion is the only WebSocket protocol version defined by RFC 6455.
+const supportedVersion = "13"
+
+// defaultRecoverWriteTimeout bounds the courtesy error frame defaultRecover
+// sends after a panic. The handler is already unwinding, so a peer that stopped
+// reading must not be able to park the hijacked goroutine and its file
+// descriptor forever.
+const defaultRecoverWriteTimeout = 5 * time.Second
+
 func defaultRecover(c *Conn) {
 	if err := recover(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "panic: %v\n%s\n", err, debug.Stack()) //nolint:errcheck // This will never fail
-		if err := c.WriteJSON(fiber.Map{"error": err}); err != nil {
+		if c.Conn == nil {
+			return
+		}
+		_ = c.SetWriteDeadline(time.Now().Add(defaultRecoverWriteTimeout))
+		// The panic value is rendered before encoding: panic(err) is by far the
+		// most common shape and an error marshals to "{}", so the client would
+		// otherwise be told an error occurred without being told which.
+		if err := c.WriteJSON(fiber.Map{"error": fmt.Sprint(err)}); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "could not write error response: %v\n", err)
 		}
 	}
 }
 
+// keepHijackedConnsServers records the fasthttp servers whose KeepHijackedConns
+// flag this package has already set. Every upgrade goes through the lookup, so
+// it uses a sync.Map to stay lock free once a server has been seen; the entry is
+// only published after the flag is written, which is what lets a later reader
+// take the fast path and still observe the flag.
 var (
 	keepHijackedConnsMu      sync.Mutex
-	keepHijackedConnsServers = make(map[*fasthttp.Server]struct{})
+	keepHijackedConnsServers sync.Map // map[*fasthttp.Server]struct{}
 )
 
 func ensureKeepHijackedConns(server *fasthttp.Server) {
+	if server == nil {
+		return
+	}
+	if _, ok := keepHijackedConnsServers.Load(server); ok {
+		return
+	}
 	keepHijackedConnsMu.Lock()
 	defer keepHijackedConnsMu.Unlock()
-	if _, ok := keepHijackedConnsServers[server]; ok {
+	if _, ok := keepHijackedConnsServers.Load(server); ok {
 		return
 	}
 	server.KeepHijackedConns = true
-	keepHijackedConnsServers[server] = struct{}{}
+	keepHijackedConnsServers.Store(server, struct{}{})
 }
 
 // New returns a new `handler func(*Conn)` that upgrades a client to the
 // websocket protocol, you can pass an optional config.
 func New(handler func(*Conn), config ...Config) fiber.Handler {
+	if handler == nil {
+		panic("websocket: handler must not be nil")
+	}
+
 	// Init config
 	var cfg Config
 	if len(config) > 0 {
 		cfg = config[0]
-	}
-	if len(cfg.Origins) == 0 {
-		cfg.Origins = []string{"*"}
-	}
-	// Check if wildcard is present in the Origins list during initialization
-	hasWildcard := false
-	for _, origin := range cfg.Origins {
-		if origin == "*" {
-			hasWildcard = true
-			break
-		}
 	}
 	if cfg.ReadBufferSize == 0 {
 		cfg.ReadBufferSize = 1024
@@ -122,6 +148,22 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 	if cfg.RecoverHandler == nil {
 		cfg.RecoverHandler = defaultRecover
 	}
+
+	// Resolve the origin policy once so the upgrade path only walks the
+	// explicit entries instead of searching for the wildcard per request. An
+	// empty list keeps the historical "allow everything" default. The list is
+	// copied so mutating the caller's slice afterwards cannot change the policy
+	// of an already mounted handler.
+	allowAllOrigins := len(cfg.Origins) == 0
+	allowedOrigins := make([]string, 0, len(cfg.Origins))
+	for _, origin := range cfg.Origins {
+		if origin == "*" {
+			allowAllOrigins = true
+			continue
+		}
+		allowedOrigins = append(allowedOrigins, origin)
+	}
+
 	var upgrader = websocket.FastHTTPUpgrader{
 		HandshakeTimeout:  cfg.HandshakeTimeout,
 		Subprotocols:      cfg.Subprotocols,
@@ -130,22 +172,19 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 		EnableCompression: cfg.EnableCompression,
 		WriteBufferPool:   cfg.WriteBufferPool,
 		CheckOrigin: func(fctx *fasthttp.RequestCtx) bool {
-			// Fast path: if Origins is just wildcard (the default), allow all without checking header
-			if len(cfg.Origins) == 1 && cfg.Origins[0] == "*" {
+			if allowAllOrigins {
 				return true
 			}
-			origin := utils.UnsafeString(fctx.Request.Header.Peek("Origin"))
+			origin := utils.UnsafeString(fctx.Request.Header.Peek(fiber.HeaderOrigin))
 			if origin == "" {
-				// Allow empty Origin if wildcard is in list or explicitly configured
-				return hasWildcard || cfg.AllowEmptyOrigin
+				return cfg.AllowEmptyOrigin
 			}
-			// If wildcard is present, allow any non-empty origin
-			if hasWildcard {
-				return true
-			}
-			// No wildcard present, check if origin matches any specific origin in the list
-			for i := range cfg.Origins {
-				if cfg.Origins[i] == origin {
+			// RFC 6454 section 4 serializes an origin as scheme "://" host
+			// [":" port] and both the scheme and the host are case-insensitive,
+			// so a client may legitimately send an origin whose case differs
+			// from the configured one.
+			for i := range allowedOrigins {
+				if utils.EqualFold(allowedOrigins[i], origin) {
 					return true
 				}
 			}
@@ -156,49 +195,87 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 		if cfg.Next != nil && cfg.Next(c) {
 			return c.Next()
 		}
+		// A request that never asked to switch protocols cannot become a
+		// WebSocket connection. Answering here keeps the whole request copy
+		// below off the path taken by plain GETs and crawlers.
+		if !IsWebSocketUpgrade(c) {
+			return fiber.ErrUpgradeRequired
+		}
 		ensureKeepHijackedConns(c.App().Server())
 
+		fctx := c.RequestCtx()
 		conn := acquireConn()
+
 		// locals
-		c.RequestCtx().VisitUserValues(func(key []byte, value interface{}) {
+		fctx.VisitUserValues(func(key []byte, value interface{}) {
+			if conn.locals == nil {
+				conn.locals = make(map[string]interface{})
+			}
 			conn.locals[string(key)] = value
 		})
 
-		// params
-		params := c.Route().Params
-		for i := 0; i < len(params); i++ {
-			conn.params[utils.CopyString(params[i])] = utils.CopyString(c.Params(params[i]))
+		// params: the names belong to the parsed route and stay valid for the
+		// lifetime of the app, so only the values are copied out of the request
+		// buffer that fasthttp recycles.
+		if params := c.Route().Params; len(params) > 0 {
+			if conn.params == nil {
+				conn.params = make(map[string]string, len(params))
+			}
+			for i := range params {
+				conn.params[params[i]] = utils.CopyString(c.Params(params[i]))
+			}
 		}
 
 		// queries
-		queries := c.RequestCtx().QueryArgs().All()
-		for key, value := range queries {
-			conn.queries[string(key)] = string(value)
+		if args := fctx.QueryArgs(); args.Len() > 0 {
+			if conn.queries == nil {
+				conn.queries = make(map[string]string, args.Len())
+			}
+			for key, value := range args.All() {
+				conn.queries[string(key)] = string(value)
+			}
 		}
 
 		// cookies
-		cookies := c.RequestCtx().Request.Header.Cookies()
-		for key, value := range cookies {
+		for key, value := range fctx.Request.Header.Cookies() {
+			if conn.cookies == nil {
+				conn.cookies = make(map[string]string)
+			}
 			conn.cookies[string(key)] = string(value)
 		}
 
 		// headers
-		headers := c.RequestCtx().Request.Header.All()
-		for key, value := range headers {
-			conn.headers[string(key)] = string(value)
+		if n := fctx.Request.Header.Len(); n > 0 {
+			if conn.headers == nil {
+				conn.headers = make(map[string]string, n)
+			}
+			for key, value := range fctx.Request.Header.All() {
+				conn.headers[string(key)] = string(value)
+			}
 		}
 
 		// ip address
 		conn.ip = utils.CopyString(c.IP())
 
-		if err := upgrader.Upgrade(c.RequestCtx(), func(fconn *websocket.Conn) {
+		if err := upgrader.Upgrade(fctx, func(fconn *websocket.Conn) {
 			conn.Conn = fconn
 			defer releaseConn(conn)
 			defer cfg.RecoverHandler(conn)
 			handler(conn)
-		}); err != nil { // Upgrading required
+		}); err != nil { // Handshake rejected
 			releaseConn(conn)
-			return fiber.ErrUpgradeRequired
+			// The upgrader already wrote the status RFC 6455 asks for: 403 for
+			// an Origin the server does not accept (section 4.2.2), 400 for a
+			// malformed or unsupported handshake, 405 for a non-GET request.
+			// Keeping it beats flattening every rejection to 426, which only
+			// describes a client that has not tried to upgrade at all.
+			//
+			// fasthttp's ctx.Error resets the response on its way out and drops
+			// the Sec-WebSocket-Version header the upgrader had just set, so it
+			// is restored here: section 4.4 requires a server that turns a
+			// handshake down to advertise the versions it does understand.
+			c.Set(fiber.HeaderSecWebSocketVersion, supportedVersion)
+			return nil
 		}
 
 		return nil
@@ -223,21 +300,40 @@ var poolConn = sync.Pool{
 	},
 }
 
+// maxPooledMapEntries bounds the maps carried by a pooled Conn. Reusing the
+// buckets of a modest map is the point of the pool, but a single request
+// carrying thousands of query arguments or headers would otherwise make every
+// later connection pay for that footprint, so oversized maps are dropped.
+const maxPooledMapEntries = 64
+
 // Acquire Conn from pool
 func acquireConn() *Conn {
-	conn := poolConn.Get().(*Conn)
-	conn.locals = make(map[string]interface{})
-	conn.params = make(map[string]string)
-	conn.queries = make(map[string]string)
-	conn.cookies = make(map[string]string)
-	conn.headers = make(map[string]string)
-	return conn
+	return poolConn.Get().(*Conn)
 }
 
 // Return Conn to pool
 func releaseConn(conn *Conn) {
 	conn.Conn = nil
+	conn.ip = ""
+	// Emptying the maps rather than replacing them keeps their buckets for the
+	// next connection, and it stops a pooled Conn from pinning the finished
+	// connection's locals, headers and cookies until it is picked up again.
+	conn.locals = resetMap(conn.locals)
+	conn.params = resetMap(conn.params)
+	conn.queries = resetMap(conn.queries)
+	conn.cookies = resetMap(conn.cookies)
+	conn.headers = resetMap(conn.headers)
 	poolConn.Put(conn)
+}
+
+// resetMap empties m so the next connection can reuse it, or discards it once
+// it has grown past maxPooledMapEntries.
+func resetMap[V any](m map[string]V) map[string]V {
+	if len(m) > maxPooledMapEntries {
+		return nil
+	}
+	clear(m)
+	return m
 }
 
 // Locals makes it possible to pass interface{} values under string keys scoped to the request
@@ -245,6 +341,9 @@ func releaseConn(conn *Conn) {
 func (conn *Conn) Locals(key string, value ...interface{}) interface{} {
 	if len(value) == 0 {
 		return conn.locals[key]
+	}
+	if conn.locals == nil {
+		conn.locals = make(map[string]interface{}, 1)
 	}
 	conn.locals[key] = value[0]
 	return value[0]
@@ -288,6 +387,15 @@ func (conn *Conn) Cookies(key string, defaultValue ...string) string {
 // If a default value is given, it will return that value if the header doesn't exist.
 // Header lookups are case-insensitive.
 func (conn *Conn) Headers(key string, defaultValue ...string) string {
+	// fasthttp stores inbound header names in canonical form, so canonicalizing
+	// the requested key turns the lookup into a single map probe instead of a
+	// case-insensitive walk over every header of the request.
+	if v, ok := conn.headers[utils.CanonicalHeaderKey(key)]; ok {
+		return v
+	}
+	// Fall back to the scan for servers that disabled header name normalizing,
+	// and for keys outside the RFC 9110 token alphabet, which
+	// CanonicalHeaderKey deliberately leaves untouched.
 	for k, v := range conn.headers {
 		if utils.EqualFold(k, key) {
 			return v
@@ -306,7 +414,11 @@ func (conn *Conn) IP() string {
 
 // Constants are taken from https://github.com/fasthttp/websocket/blob/master/conn.go#L43
 
-// Close codes defined in RFC 6455, section 11.7.
+// Close codes 1000-1011 and 1015 are defined in RFC 6455, section 11.7; 1012,
+// 1013 and 1014 were added to the IANA WebSocket Close Code Number Registry
+// afterwards. Note that 1005, 1006 and 1015 are reserved for use by
+// applications and must never be sent in a close frame (RFC 6455, section
+// 7.4.1).
 const (
 	CloseNormalClosure           = 1000
 	CloseGoingAway               = 1001
@@ -321,6 +433,7 @@ const (
 	CloseInternalServerErr       = 1011
 	CloseServiceRestart          = 1012
 	CloseTryAgainLater           = 1013
+	CloseBadGateway              = 1014
 	CloseTLSHandshake            = 1015
 )
 

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -89,6 +89,9 @@ const defaultRecoverWriteTimeout = 5 * time.Second
 // deliberately constant and carries nothing derived from the panic.
 const defaultRecoverMessage = "internal error"
 
+// defaultRecover is the RecoverHandler used when Config leaves one unset. It
+// recovers the panic, writes the value and stack to stderr, and tells the peer
+// only that something failed.
 func defaultRecover(c *Conn) {
 	if err := recover(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "panic: %v\n%s\n", err, debug.Stack()) //nolint:errcheck // This will never fail
@@ -118,6 +121,9 @@ var (
 	keepHijackedConnsServers sync.Map // map[*fasthttp.Server]struct{}
 )
 
+// ensureKeepHijackedConns sets KeepHijackedConns on the server the first time it
+// is seen, so fasthttp leaves the upgraded connection open for this package to
+// own once the request handler returns.
 func ensureKeepHijackedConns(server *fasthttp.Server) {
 	if server == nil {
 		return

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -92,10 +92,14 @@ func defaultRecover(c *Conn) {
 			return
 		}
 		_ = c.SetWriteDeadline(time.Now().Add(defaultRecoverWriteTimeout))
-		// The panic value is rendered before encoding: panic(err) is by far the
-		// most common shape and an error marshals to "{}", so the client would
-		// otherwise be told an error occurred without being told which.
-		if err := c.WriteJSON(fiber.Map{"error": fmt.Sprint(err)}); err != nil {
+		// The recovered value is handed to the encoder as-is, deliberately: the
+		// stderr line above already gives the operator the full detail, so
+		// rendering it here would only widen what a remote peer can read out of
+		// a panic. An error value has no exported fields and encodes as {},
+		// which keeps a wrapped internal error (paths, DSNs, schema names) off
+		// the wire. Applications that want to say more, or nothing at all,
+		// should supply their own RecoverHandler.
+		if err := c.WriteJSON(fiber.Map{"error": err}); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "could not write error response: %v\n", err)
 		}
 	}

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -29,17 +29,14 @@ type Config struct {
 	// HandshakeTimeout specifies the duration for the handshake to complete.
 	HandshakeTimeout time.Duration
 
-	// Subprotocols lists the subprotocols this server supports, in order of
-	// preference. The handshake negotiates the first entry that also appears in
-	// the client's Sec-WebSocket-Protocol header; when nothing matches, no
-	// subprotocol is negotiated and the response header is omitted, as required
-	// by RFC 6455 section 4.2.2.
+	// Subprotocols lists the subprotocols the server supports in order of
+	// preference. The first one the client also offers is negotiated; with no
+	// match none is (RFC 6455 section 4.2.2).
 	Subprotocols []string
 
 	// Allowed Origin's based on the Origin header, this validate the request origin to
 	// prevent cross-site request forgery. Everything is allowed if left empty.
-	// Comparison is case-insensitive, matching the case-insensitive scheme and
-	// host of a serialized origin (RFC 6454, section 4).
+	// Matching is case-insensitive (RFC 6454 section 4).
 	Origins []string
 
 	// AllowEmptyOrigin allows WebSocket connections when the Origin header is absent.
@@ -80,44 +77,34 @@ type Config struct {
 // supportedVersion is the only WebSocket protocol version defined by RFC 6455.
 const supportedVersion = "13"
 
-// defaultRecoverWriteTimeout bounds the courtesy error frame defaultRecover
-// sends after a panic. The handler is already unwinding, so a peer that stopped
-// reading must not be able to park the hijacked goroutine and its file
-// descriptor forever.
+// defaultRecoverWriteTimeout bounds the error frame defaultRecover sends after
+// a panic, so a peer that stopped reading cannot park the goroutine.
 const defaultRecoverWriteTimeout = 5 * time.Second
 
 // defaultRecoverMessage is what defaultRecover tells the peer. It is
 // deliberately constant and carries nothing derived from the panic.
 const defaultRecoverMessage = "internal error"
 
-// defaultRecover is the RecoverHandler used when Config leaves one unset. It
-// recovers the panic, writes the value and stack to stderr, and tells the peer
-// only that something failed.
+// defaultRecover is the default RecoverHandler: it logs the panic and stack to
+// stderr and sends the peer a fixed error.
 func defaultRecover(c *Conn) {
 	if err := recover(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "panic: %v\n%s\n", err, debug.Stack()) //nolint:errcheck // This will never fail
 		_ = c.SetWriteDeadline(time.Now().Add(defaultRecoverWriteTimeout))
-		// A fixed payload: the stderr line above already gives the operator the
-		// full value and stack, so anything derived from the panic here would
-		// only widen what a remote peer can read out of it. panic("...") sent
-		// its string verbatim and a custom error type could expose exported
-		// fields or its own MarshalJSON. Applications that want to tell the peer
-		// more should supply their own RecoverHandler.
+		// Fixed payload: the panic value may carry internal detail and is already on
+		// stderr.
 		if err := c.WriteJSON(fiber.Map{"error": defaultRecoverMessage}); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "could not write error response: %v\n", err)
 		}
 	}
 }
 
-// keepHijackedConnsServers holds one sync.Once per fasthttp server this package
-// has upgraded on. Every upgrade goes through the lookup, so the steady state is
-// a lock free Load and a Once that has already run; Once.Do is also what makes
-// the flag write visible to every request that takes that fast path.
+// keepHijackedConnsServers holds one sync.Once per fasthttp server, so the
+// steady state per upgrade is a lock-free Load.
 var keepHijackedConnsServers sync.Map // map[*fasthttp.Server]*sync.Once
 
-// ensureKeepHijackedConns sets KeepHijackedConns on the server the first time it
-// is seen, so fasthttp leaves the upgraded connection open for this package to
-// own once the request handler returns.
+// ensureKeepHijackedConns makes fasthttp leave upgraded connections open after
+// the handler returns. It runs once per server.
 func ensureKeepHijackedConns(server *fasthttp.Server) {
 	once, ok := keepHijackedConnsServers.Load(server)
 	if !ok {
@@ -150,10 +137,8 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 		cfg.RecoverHandler = defaultRecover
 	}
 
-	// Resolve the origin policy once so the upgrade path never searches for the
-	// wildcard per request. An empty list keeps the historical "allow everything"
-	// default; the clone keeps a later mutation of the caller's slice from
-	// changing the policy of an already mounted handler.
+	// Resolved once: no wildcard search per request, and the clone keeps a later
+	// mutation of cfg.Origins from changing a mounted handler.
 	allowAllOrigins := len(cfg.Origins) == 0 || slices.Contains(cfg.Origins, "*")
 	allowedOrigins := slices.Clone(cfg.Origins)
 
@@ -164,12 +149,9 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 		WriteBufferSize:   cfg.WriteBufferSize,
 		EnableCompression: cfg.EnableCompression,
 		WriteBufferPool:   cfg.WriteBufferPool,
-		// Only the status is recorded here. Left to itself the upgrader would
-		// call ctx.Error, whose Response.Reset wipes every header earlier
-		// middleware set (request IDs, CORS) together with the
-		// Sec-WebSocket-Version header the upgrader adds just before. The
-		// handler below turns the status into a *fiber.Error so the rejection
-		// reaches the app's ErrorHandler like any other error.
+		// Record the status only. ctx.Error would Response.Reset, wiping headers
+		// earlier middleware set and the Sec-WebSocket-Version header; the handler
+		// returns a *fiber.Error instead.
 		Error: func(fctx *fasthttp.RequestCtx, status int, _ error) {
 			fctx.SetStatusCode(status)
 		},
@@ -181,10 +163,7 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 			if origin == "" {
 				return cfg.AllowEmptyOrigin
 			}
-			// RFC 6454 section 4 serializes an origin as scheme "://" host
-			// [":" port] and both the scheme and the host are case-insensitive,
-			// so a client may legitimately send an origin whose case differs
-			// from the configured one.
+			// Scheme and host of an origin are case-insensitive (RFC 6454 section 4).
 			for i := range allowedOrigins {
 				if utils.EqualFold(allowedOrigins[i], origin) {
 					return true
@@ -198,11 +177,8 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 			return c.Next()
 		}
 		fctx := c.RequestCtx()
-		// A request that never asked to switch protocols cannot become a
-		// WebSocket connection. Answering here keeps the whole request copy
-		// below off the path taken by plain GETs and crawlers. One that asked
-		// but got the handshake wrong goes on to the upgrader, whose 400 is
-		// the right answer for a malformed attempt.
+		// No upgrade signal at all: answer 426 before copying the request. A partial
+		// handshake goes on to the upgrader for its 400.
 		if !asksToUpgrade(fctx) {
 			return fiber.ErrUpgradeRequired
 		}
@@ -210,32 +186,24 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 
 		conn := &Conn{}
 
-		// Route params and the IP come from the Fiber context, which is
-		// recycled before the hijack callback runs, so they are captured now.
-		// The param names belong to the parsed route and stay valid for the
-		// lifetime of the app; only the values are copied out of the request
-		// buffer.
+		// Route params and the IP come from the Fiber context, which is recycled
+		// before the hijack callback runs. Param names outlive the request; only the
+		// values are copied.
 		for _, name := range c.Route().Params {
 			setEntry(&conn.params, name, utils.CopyString(c.Params(name)))
 		}
 		conn.ip = utils.CopyString(c.IP())
-		// The rest is copied now, while the middleware chain is still on the
-		// stack, so a local or header an outer middleware sets for the request
-		// and clears after c.Next is what the handler sees. The hijack callback
-		// only runs after the whole chain has unwound.
+		// Copied while the middleware chain is still on the stack: the hijack
+		// callback runs only after it has unwound.
 		conn.capture(fctx)
 
 		if err := upgrader.Upgrade(fctx, func(fconn *websocket.Conn) {
 			conn.Conn = fconn
 
 			returned := false
-			// Registered before the recover handler so it runs after it. A
-			// handler that panicked cannot be trusted to still own the socket,
-			// and KeepHijackedConns means nothing else will ever close it, so
-			// close it here -- but only once RecoverHandler has had its chance
-			// to write the error frame. A handler that returns normally leaves
-			// the socket open, so it may keep using the connection from another
-			// goroutine after returning.
+			// Runs after RecoverHandler. A handler that panicked cannot be trusted with
+			// the socket and nothing else closes a hijacked connection; a normal return
+			// leaves it open.
 			defer func() {
 				if !returned {
 					_ = fconn.Close()
@@ -245,14 +213,9 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 			handler(conn)
 			returned = true
 		}); err != nil { // Handshake rejected
-			// The upgrader picked the status RFC 6455 asks for: 403 for an
-			// Origin the server does not accept (section 4.2.2), 400 for a
-			// malformed or unsupported handshake, 405 for a non-GET request.
-			// Section 4.4 also has a server that turns a handshake down
-			// advertise the versions it understands. Returning a *fiber.Error
-			// with that status keeps the rejection on the same path as every
-			// other error: a custom ErrorHandler formats it, error logging and
-			// metrics see it.
+			// The upgrader chose the RFC 6455 status: 403 for a bad Origin, 400 for a
+			// malformed handshake, 405 for a non-GET; section 4.4 asks for the supported
+			// version on rejection. A *fiber.Error keeps it on the ErrorHandler path.
 			status := fctx.Response.StatusCode()
 			c.Set(fiber.HeaderSecWebSocketVersion, supportedVersion)
 			return fiber.NewError(status, utils.StatusMessage(status))
@@ -273,36 +236,28 @@ type Conn struct {
 	ip      string
 }
 
-// A Conn is allocated per upgrade and never reused. An earlier revision pooled
-// it and emptied the maps in place for the next connection, which is unsafe:
-// the event helper's Locals, Params, Query and Cookies closures read those maps
-// from listeners that run on other goroutines during Close and CloseAll, so a
-// new upgrade taking the wrapper could clear and refill them under a listener
-// still reading the previous client's data. The maps are only allocated when
-// the request carries that kind of data, so a typical handshake still allocates
-// less than unconditionally creating all five.
+// A Conn is allocated per upgrade and never reused: the event helper reads
+// these maps from listeners on other goroutines after the handler returns, so
+// pooling them is unsafe. Each map is allocated only when the request carries
+// that kind of data.
 
-// capture copies the locals, query arguments, cookies and headers of the
-// request into the Conn before the handshake, out of a RequestCtx fasthttp
-// will recycle. canonical says whether the server already normalizes header
-// names.
+// capture copies the request's locals, query arguments, cookies and headers
+// into the Conn before fasthttp recycles the RequestCtx.
 func (conn *Conn) capture(fctx *fasthttp.RequestCtx) {
 	fctx.VisitUserValues(func(key []byte, value interface{}) {
 		setEntry(&conn.locals, string(key), value)
 	})
-	// No size hint for the query map: Args.Len counts repeated keys that the
-	// assignments collapse into one entry, so it would over-allocate.
+	// No size hint: Args.Len counts repeated keys that collapse into one entry.
 	for key, value := range fctx.QueryArgs().All() {
 		setEntry(&conn.queries, string(key), string(value))
 	}
 	for key, value := range fctx.Request.Header.Cookies() {
 		setEntry(&conn.cookies, string(key), string(value))
 	}
-	// Header names are stored in canonical form so Headers is a single probe.
-	// fasthttp delivers them that way unless normalizing was switched off,
-	// server-wide or by earlier middleware on this one request, and the
-	// request does not say which, so every name is checked. A name that is
-	// already canonical comes back as it is without allocating.
+	// Names are stored canonical so Headers is one probe. fasthttp delivers them
+	// that way unless normalizing was disabled, server-wide or per request, which
+	// is not observable here, so every name is checked; a canonical name comes
+	// back without allocating.
 	for key, value := range fctx.Request.Header.All() {
 		setEntry(&conn.headers, string(utils.CanonicalHeaderKey(key)), string(value))
 	}
@@ -365,10 +320,8 @@ func (conn *Conn) Cookies(key string, defaultValue ...string) string {
 // If a default value is given, it will return that value if the header doesn't exist.
 // Header lookups are case-insensitive.
 func (conn *Conn) Headers(key string, defaultValue ...string) string {
-	// capture stores names in canonical form, so the canonical form of key is
-	// one map probe. CanonicalHeaderKey returns key itself when it is already
-	// canonical, which is the usual spelling, and allocates a small copy
-	// otherwise.
+	// Names are canonical in the map; CanonicalHeaderKey returns key unchanged
+	// when it already is.
 	if v, ok := conn.headers[utils.CanonicalHeaderKey(key)]; ok {
 		return v
 	}
@@ -385,16 +338,12 @@ func (conn *Conn) IP() string {
 
 // Constants are taken from https://github.com/fasthttp/websocket/blob/master/conn.go#L43
 
-// Close codes 1000-1011 and 1015 are defined in RFC 6455, section 11.7; 1012
-// and 1013 were added to the IANA WebSocket Close Code Number Registry
-// afterwards. 1014 is registered too but is deliberately not exported: the
-// underlying library rejects it in both directions, so it can neither be sent
-// nor received through this stack.
-//
-// Not every code may travel in a close frame: RFC 6455, section 7.4.1 forbids
-// sending 1005, 1006 and 1015, and the underlying library rejects anything but
-// 1000-1003, 1007-1013 and 3000-4999 on receive. The event package's
-// sanitizeCloseCode is the one place that rule is applied.
+// Close codes 1000-1011 and 1015 are defined in RFC 6455 section 11.7; 1012
+// and 1013 come from the IANA registry. 1014 is not exported because the
+// underlying library rejects it in both directions. Not every code may be
+// sent: section 7.4.1 forbids 1005, 1006 and 1015, and the library accepts
+// only 1000-1003, 1007-1013 and 3000-4999 on receive; the event package's
+// sanitizeCloseCode applies that rule.
 const (
 	CloseNormalClosure           = 1000
 	CloseGoingAway               = 1001
@@ -465,11 +414,9 @@ func IsUnexpectedCloseError(err error, expectedCodes ...int) bool {
 	return websocket.IsUnexpectedCloseError(err, expectedCodes...)
 }
 
-// asksToUpgrade reports whether the request attempts a protocol switch at
-// all: an Upgrade header, or an upgrade token in Connection. It is the
-// looser question next to IsWebSocketUpgrade, which wants a well-formed
-// WebSocket handshake; a partial one still reaches the upgrader so the
-// rejection carries the status a malformed handshake deserves.
+// asksToUpgrade reports whether the request carries any upgrade signal: an
+// Upgrade header or an upgrade token in Connection. Unlike IsWebSocketUpgrade
+// it accepts a partial handshake, so the upgrader can answer it with 400.
 func asksToUpgrade(fctx *fasthttp.RequestCtx) bool {
 	h := &fctx.Request.Header
 	return h.ConnectionUpgrade() || len(h.Peek(fiber.HeaderUpgrade)) > 0

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -244,14 +244,14 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 			conn.cookies[string(key)] = string(value)
 		}
 
-		// headers
-		if n := fctx.Request.Header.Len(); n > 0 {
+		// headers: allocated inside the loop because fasthttp's Header.Len is
+		// itself a full iteration, so asking for a size hint would walk every
+		// header a second time.
+		for key, value := range fctx.Request.Header.All() {
 			if conn.headers == nil {
-				conn.headers = make(map[string]string, n)
+				conn.headers = make(map[string]string)
 			}
-			for key, value := range fctx.Request.Header.All() {
-				conn.headers[string(key)] = string(value)
-			}
+			conn.headers[string(key)] = string(value)
 		}
 
 		// ip address
@@ -259,9 +259,23 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 
 		if err := upgrader.Upgrade(fctx, func(fconn *websocket.Conn) {
 			conn.Conn = fconn
+			returned := false
 			defer releaseConn(conn)
+			// Registered before the recover handler so it runs after it. A
+			// handler that panicked cannot be trusted to still own the socket,
+			// and KeepHijackedConns means nothing else will ever close it, so
+			// close it here -- but only once RecoverHandler has had its chance
+			// to write the error frame. A handler that returns normally keeps
+			// the connection, which is what lets a handler hand it to another
+			// goroutine.
+			defer func() {
+				if !returned {
+					_ = fconn.Close()
+				}
+			}()
 			defer cfg.RecoverHandler(conn)
 			handler(conn)
+			returned = true
 		}); err != nil { // Handshake rejected
 			releaseConn(conn)
 			// The upgrader already wrote the status RFC 6455 asks for: 403 for

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -197,16 +197,17 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 		if cfg.Next != nil && cfg.Next(c) {
 			return c.Next()
 		}
+		fctx := c.RequestCtx()
 		// A request that never asked to switch protocols cannot become a
 		// WebSocket connection. Answering here keeps the whole request copy
-		// below off the path taken by plain GETs and crawlers.
-		if !IsWebSocketUpgrade(c) {
+		// below off the path taken by plain GETs and crawlers. One that asked
+		// but got the handshake wrong goes on to the upgrader, whose 400 is
+		// the right answer for a malformed attempt.
+		if !asksToUpgrade(fctx) {
 			return fiber.ErrUpgradeRequired
 		}
-		server := c.App().Server()
-		ensureKeepHijackedConns(server)
+		ensureKeepHijackedConns(c.App().Server())
 
-		fctx := c.RequestCtx()
 		conn := &Conn{}
 
 		// Route params and the IP come from the Fiber context, which is
@@ -222,7 +223,7 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 		// stack, so a local or header an outer middleware sets for the request
 		// and clears after c.Next is what the handler sees. The hijack callback
 		// only runs after the whole chain has unwound.
-		conn.capture(fctx, !server.DisableHeaderNamesNormalizing)
+		conn.capture(fctx)
 
 		if err := upgrader.Upgrade(fctx, func(fconn *websocket.Conn) {
 			conn.Conn = fconn
@@ -285,7 +286,7 @@ type Conn struct {
 // request into the Conn before the handshake, out of a RequestCtx fasthttp
 // will recycle. canonical says whether the server already normalizes header
 // names.
-func (conn *Conn) capture(fctx *fasthttp.RequestCtx, canonical bool) {
+func (conn *Conn) capture(fctx *fasthttp.RequestCtx) {
 	fctx.VisitUserValues(func(key []byte, value interface{}) {
 		setEntry(&conn.locals, string(key), value)
 	})
@@ -298,13 +299,12 @@ func (conn *Conn) capture(fctx *fasthttp.RequestCtx, canonical bool) {
 		setEntry(&conn.cookies, string(key), string(value))
 	}
 	// Header names are stored in canonical form so Headers is a single probe.
-	// fasthttp delivers them that way already unless the server disabled
-	// normalizing, and only then is each name rewritten here.
+	// fasthttp delivers them that way unless normalizing was switched off,
+	// server-wide or by earlier middleware on this one request, and the
+	// request does not say which, so every name is checked. A name that is
+	// already canonical comes back as it is without allocating.
 	for key, value := range fctx.Request.Header.All() {
-		if !canonical {
-			key = utils.CanonicalHeaderKey(key)
-		}
-		setEntry(&conn.headers, string(key), string(value))
+		setEntry(&conn.headers, string(utils.CanonicalHeaderKey(key)), string(value))
 	}
 }
 
@@ -463,6 +463,16 @@ func IsCloseError(err error, codes ...int) bool {
 // *CloseError with a code not in the list of expected codes.
 func IsUnexpectedCloseError(err error, expectedCodes ...int) bool {
 	return websocket.IsUnexpectedCloseError(err, expectedCodes...)
+}
+
+// asksToUpgrade reports whether the request attempts a protocol switch at
+// all: an Upgrade header, or an upgrade token in Connection. It is the
+// looser question next to IsWebSocketUpgrade, which wants a well-formed
+// WebSocket handshake; a partial one still reaches the upgrader so the
+// rejection carries the status a malformed handshake deserves.
+func asksToUpgrade(fctx *fasthttp.RequestCtx) bool {
+	h := &fctx.Request.Header
+	return h.ConnectionUpgrade() || len(h.Peek(fiber.HeaderUpgrade)) > 0
 }
 
 // IsWebSocketUpgrade returns true if the client requested upgrade to the

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"runtime/debug"
+	"slices"
 	"sync"
 	"time"
 
@@ -95,9 +96,6 @@ const defaultRecoverMessage = "internal error"
 func defaultRecover(c *Conn) {
 	if err := recover(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "panic: %v\n%s\n", err, debug.Stack()) //nolint:errcheck // This will never fail
-		if c.Conn == nil {
-			return
-		}
 		_ = c.SetWriteDeadline(time.Now().Add(defaultRecoverWriteTimeout))
 		// A fixed payload: the stderr line above already gives the operator the
 		// full value and stack, so anything derived from the panic here would
@@ -111,33 +109,23 @@ func defaultRecover(c *Conn) {
 	}
 }
 
-// keepHijackedConnsServers records the fasthttp servers whose KeepHijackedConns
-// flag this package has already set. Every upgrade goes through the lookup, so
-// it uses a sync.Map to stay lock free once a server has been seen; the entry is
-// only published after the flag is written, which is what lets a later reader
-// take the fast path and still observe the flag.
-var (
-	keepHijackedConnsMu      sync.Mutex
-	keepHijackedConnsServers sync.Map // map[*fasthttp.Server]struct{}
-)
+// keepHijackedConnsServers holds one sync.Once per fasthttp server this package
+// has upgraded on. Every upgrade goes through the lookup, so the steady state is
+// a lock free Load and a Once that has already run; Once.Do is also what makes
+// the flag write visible to every request that takes that fast path.
+var keepHijackedConnsServers sync.Map // map[*fasthttp.Server]*sync.Once
 
 // ensureKeepHijackedConns sets KeepHijackedConns on the server the first time it
 // is seen, so fasthttp leaves the upgraded connection open for this package to
 // own once the request handler returns.
 func ensureKeepHijackedConns(server *fasthttp.Server) {
-	if server == nil {
-		return
+	once, ok := keepHijackedConnsServers.Load(server)
+	if !ok {
+		once, _ = keepHijackedConnsServers.LoadOrStore(server, new(sync.Once))
 	}
-	if _, ok := keepHijackedConnsServers.Load(server); ok {
-		return
-	}
-	keepHijackedConnsMu.Lock()
-	defer keepHijackedConnsMu.Unlock()
-	if _, ok := keepHijackedConnsServers.Load(server); ok {
-		return
-	}
-	server.KeepHijackedConns = true
-	keepHijackedConnsServers.Store(server, struct{}{})
+	once.(*sync.Once).Do(func() {
+		server.KeepHijackedConns = true
+	})
 }
 
 // New returns a new `handler func(*Conn)` that upgrades a client to the
@@ -162,20 +150,12 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 		cfg.RecoverHandler = defaultRecover
 	}
 
-	// Resolve the origin policy once so the upgrade path only walks the
-	// explicit entries instead of searching for the wildcard per request. An
-	// empty list keeps the historical "allow everything" default. The list is
-	// copied so mutating the caller's slice afterwards cannot change the policy
-	// of an already mounted handler.
-	allowAllOrigins := len(cfg.Origins) == 0
-	allowedOrigins := make([]string, 0, len(cfg.Origins))
-	for _, origin := range cfg.Origins {
-		if origin == "*" {
-			allowAllOrigins = true
-			continue
-		}
-		allowedOrigins = append(allowedOrigins, origin)
-	}
+	// Resolve the origin policy once so the upgrade path never searches for the
+	// wildcard per request. An empty list keeps the historical "allow everything"
+	// default; the clone keeps a later mutation of the caller's slice from
+	// changing the policy of an already mounted handler.
+	allowAllOrigins := len(cfg.Origins) == 0 || slices.Contains(cfg.Origins, "*")
+	allowedOrigins := slices.Clone(cfg.Origins)
 
 	var upgrader = websocket.FastHTTPUpgrader{
 		HandshakeTimeout:  cfg.HandshakeTimeout,
@@ -184,6 +164,15 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 		WriteBufferSize:   cfg.WriteBufferSize,
 		EnableCompression: cfg.EnableCompression,
 		WriteBufferPool:   cfg.WriteBufferPool,
+		// Only the status is recorded here. Left to itself the upgrader would
+		// call ctx.Error, whose Response.Reset wipes every header earlier
+		// middleware set (request IDs, CORS) together with the
+		// Sec-WebSocket-Version header the upgrader adds just before. The
+		// handler below turns the status into a *fiber.Error so the rejection
+		// reaches the app's ErrorHandler like any other error.
+		Error: func(fctx *fasthttp.RequestCtx, status int, _ error) {
+			fctx.SetStatusCode(status)
+		},
 		CheckOrigin: func(fctx *fasthttp.RequestCtx) bool {
 			if allowAllOrigins {
 				return true
@@ -219,70 +208,33 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 		fctx := c.RequestCtx()
 		conn := acquireConn()
 
-		// locals
-		fctx.VisitUserValues(func(key []byte, value interface{}) {
-			if conn.locals == nil {
-				conn.locals = make(map[string]interface{})
-			}
-			conn.locals[string(key)] = value
-		})
-
-		// params: the names belong to the parsed route and stay valid for the
-		// lifetime of the app, so only the values are copied out of the request
-		// buffer that fasthttp recycles.
-		if params := c.Route().Params; len(params) > 0 {
-			if conn.params == nil {
-				conn.params = make(map[string]string, len(params))
-			}
-			for i := range params {
-				conn.params[params[i]] = utils.CopyString(c.Params(params[i]))
-			}
+		// Route params and the IP come from the Fiber context, which is
+		// recycled before the hijack callback runs, so they are captured now.
+		// The param names belong to the parsed route and stay valid for the
+		// lifetime of the app; only the values are copied out of the request
+		// buffer.
+		for _, name := range c.Route().Params {
+			setEntry(&conn.params, name, utils.CopyString(c.Params(name)))
 		}
-
-		// queries: no size hint. Args.Len counts every key/value pair, including
-		// repetitions of the same key, but the assignments below collapse those
-		// to one entry -- so a hint taken from it would size the map for the
-		// repetitions while len stays at 1, and resetMap's entry cap would keep
-		// the oversized buckets pooled instead of dropping them.
-		for key, value := range fctx.QueryArgs().All() {
-			if conn.queries == nil {
-				conn.queries = make(map[string]string)
-			}
-			conn.queries[string(key)] = string(value)
-		}
-
-		// cookies
-		for key, value := range fctx.Request.Header.Cookies() {
-			if conn.cookies == nil {
-				conn.cookies = make(map[string]string)
-			}
-			conn.cookies[string(key)] = string(value)
-		}
-
-		// headers: allocated inside the loop because fasthttp's Header.Len is
-		// itself a full iteration, so asking for a size hint would walk every
-		// header a second time.
-		for key, value := range fctx.Request.Header.All() {
-			if conn.headers == nil {
-				conn.headers = make(map[string]string)
-			}
-			conn.headers[string(key)] = string(value)
-		}
-
-		// ip address
 		conn.ip = utils.CopyString(c.IP())
 
 		if err := upgrader.Upgrade(fctx, func(fconn *websocket.Conn) {
 			conn.Conn = fconn
+			// Everything else is copied only once the handshake has been
+			// accepted, so a rejected one pays for none of it. fasthttp keeps
+			// the RequestCtx alive until this callback returns.
+			conn.capture(fctx)
+
 			returned := false
 			defer releaseConn(conn)
 			// Registered before the recover handler so it runs after it. A
 			// handler that panicked cannot be trusted to still own the socket,
 			// and KeepHijackedConns means nothing else will ever close it, so
 			// close it here -- but only once RecoverHandler has had its chance
-			// to write the error frame. A handler that returns normally keeps
-			// the connection, which is what lets a handler hand it to another
-			// goroutine.
+			// to write the error frame. A handler that returns normally leaves
+			// the socket open: the embedded fconn may be handed to another
+			// goroutine before returning. The wrapper itself may not be, since
+			// releaseConn takes it back the moment the handler returns.
 			defer func() {
 				if !returned {
 					_ = fconn.Close()
@@ -293,18 +245,17 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 			returned = true
 		}); err != nil { // Handshake rejected
 			releaseConn(conn)
-			// The upgrader already wrote the status RFC 6455 asks for: 403 for
-			// an Origin the server does not accept (section 4.2.2), 400 for a
+			// The upgrader picked the status RFC 6455 asks for: 403 for an
+			// Origin the server does not accept (section 4.2.2), 400 for a
 			// malformed or unsupported handshake, 405 for a non-GET request.
-			// Keeping it beats flattening every rejection to 426, which only
-			// describes a client that has not tried to upgrade at all.
-			//
-			// fasthttp's ctx.Error resets the response on its way out and drops
-			// the Sec-WebSocket-Version header the upgrader had just set, so it
-			// is restored here: section 4.4 requires a server that turns a
-			// handshake down to advertise the versions it does understand.
+			// Section 4.4 also has a server that turns a handshake down
+			// advertise the versions it understands. Returning a *fiber.Error
+			// with that status keeps the rejection on the same path as every
+			// other error: a custom ErrorHandler formats it, error logging and
+			// metrics see it.
+			status := fctx.Response.StatusCode()
 			c.Set(fiber.HeaderSecWebSocketVersion, supportedVersion)
-			return nil
+			return fiber.NewError(status, utils.StatusMessage(status))
 		}
 
 		return nil
@@ -335,28 +286,36 @@ var poolConn = sync.Pool{
 // later connection pay for that footprint, so oversized maps are dropped.
 const maxPooledMapEntries = 64
 
-// Acquire Conn from pool
+// acquireConn takes a Conn from the pool and empties whatever the previous
+// connection left in it.
 func acquireConn() *Conn {
-	return poolConn.Get().(*Conn)
+	conn := poolConn.Get().(*Conn)
+	conn.reset()
+	return conn
 }
 
-// Return Conn to pool
+// releaseConn detaches the socket and hands the Conn back to the pool. The maps
+// are deliberately left alone until the next acquireConn: the event helper's
+// Locals, Params, Query and Cookies closures keep reading them from listeners
+// that run on other goroutines while the handler is still unwinding, and
+// emptying them here raced with those reads.
 func releaseConn(conn *Conn) {
 	conn.Conn = nil
+	poolConn.Put(conn)
+}
+
+// reset empties the maps for the next connection. Emptying rather than
+// replacing them keeps their buckets, which is what saves the allocations;
+// a map that grew past maxPooledMapEntries is dropped instead.
+func (conn *Conn) reset() {
 	conn.ip = ""
-	// Emptying the maps rather than replacing them keeps their buckets for the
-	// next connection, and it stops a pooled Conn from pinning the finished
-	// connection's locals, headers and cookies until it is picked up again.
 	conn.locals = resetMap(conn.locals)
 	conn.params = resetMap(conn.params)
 	conn.queries = resetMap(conn.queries)
 	conn.cookies = resetMap(conn.cookies)
 	conn.headers = resetMap(conn.headers)
-	poolConn.Put(conn)
 }
 
-// resetMap empties m so the next connection can reuse it, or discards it once
-// it has grown past maxPooledMapEntries.
 func resetMap[V any](m map[string]V) map[string]V {
 	if len(m) > maxPooledMapEntries {
 		return nil
@@ -365,16 +324,46 @@ func resetMap[V any](m map[string]V) map[string]V {
 	return m
 }
 
+// capture copies the locals, query arguments, cookies and headers of the
+// request into the Conn. It runs inside the hijack callback, where the
+// RequestCtx is still valid, and after the handshake has been accepted.
+func (conn *Conn) capture(fctx *fasthttp.RequestCtx) {
+	fctx.VisitUserValues(func(key []byte, value interface{}) {
+		setEntry(&conn.locals, string(key), value)
+	})
+	// No size hint for the query map: Args.Len counts repeated keys that the
+	// assignments collapse into one entry, and a map sized for the repetitions
+	// with len stuck at 1 would slip past resetMap's entry cap and stay pooled.
+	for key, value := range fctx.QueryArgs().All() {
+		setEntry(&conn.queries, string(key), string(value))
+	}
+	for key, value := range fctx.Request.Header.Cookies() {
+		setEntry(&conn.cookies, string(key), string(value))
+	}
+	// Header names are stored in canonical form so Headers is a single probe.
+	// fasthttp already delivers them that way unless normalizing is disabled,
+	// in which case CanonicalHeaderKey rewrites them once per connection here.
+	for key, value := range fctx.Request.Header.All() {
+		setEntry(&conn.headers, string(utils.CanonicalHeaderKey(key)), string(value))
+	}
+}
+
+// setEntry stores value under key in *m, allocating the map on first use so a
+// connection that carries no entries of a kind never allocates one.
+func setEntry[V any](m *map[string]V, key string, value V) {
+	if *m == nil {
+		*m = make(map[string]V)
+	}
+	(*m)[key] = value
+}
+
 // Locals makes it possible to pass interface{} values under string keys scoped to the request
 // and therefore available to all following routes that match the request.
 func (conn *Conn) Locals(key string, value ...interface{}) interface{} {
 	if len(value) == 0 {
 		return conn.locals[key]
 	}
-	if conn.locals == nil {
-		conn.locals = make(map[string]interface{}, 1)
-	}
-	conn.locals[key] = value[0]
+	setEntry(&conn.locals, key, value[0])
 	return value[0]
 }
 
@@ -416,19 +405,12 @@ func (conn *Conn) Cookies(key string, defaultValue ...string) string {
 // If a default value is given, it will return that value if the header doesn't exist.
 // Header lookups are case-insensitive.
 func (conn *Conn) Headers(key string, defaultValue ...string) string {
-	// fasthttp stores inbound header names in canonical form, so canonicalizing
-	// the requested key turns the lookup into a single map probe instead of a
-	// case-insensitive walk over every header of the request.
+	// capture stores names in canonical form, so the canonical form of key is
+	// one map probe. CanonicalHeaderKey returns key itself when it is already
+	// canonical, which is the usual spelling, and allocates a small copy
+	// otherwise.
 	if v, ok := conn.headers[utils.CanonicalHeaderKey(key)]; ok {
 		return v
-	}
-	// Fall back to the scan for servers that disabled header name normalizing,
-	// and for keys outside the RFC 9110 token alphabet, which
-	// CanonicalHeaderKey deliberately leaves untouched.
-	for k, v := range conn.headers {
-		if utils.EqualFold(k, key) {
-			return v
-		}
 	}
 	if len(defaultValue) > 0 {
 		return defaultValue[0]
@@ -449,13 +431,10 @@ func (conn *Conn) IP() string {
 // underlying library rejects it in both directions, so it can neither be sent
 // nor received through this stack.
 //
-// Not every code may travel in a close frame. RFC 6455, section 7.4.1 reserves
-// 1005, 1006 and 1015 for conditions an endpoint observes locally and forbids
-// sending them, and lists 1004 as reserved with no meaning assigned. Endpoints
-// are stricter still: the underlying library accepts only 1000-1003, 1007-1013
-// and 3000-4999 on receive, so sending 1004, 1014 or anything in 1016-2999
-// makes a conformant peer fail the connection with a protocol error. Prefer
-// 1000-1003, 1007-1013, or the 3000-4999 application range.
+// Not every code may travel in a close frame: RFC 6455, section 7.4.1 forbids
+// sending 1005, 1006 and 1015, and the underlying library rejects anything but
+// 1000-1003, 1007-1013 and 3000-4999 on receive. The event package's
+// sanitizeCloseCode is the one place that rule is applied.
 const (
 	CloseNormalClosure           = 1000
 	CloseGoingAway               = 1001

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -85,6 +85,10 @@ const supportedVersion = "13"
 // descriptor forever.
 const defaultRecoverWriteTimeout = 5 * time.Second
 
+// defaultRecoverMessage is what defaultRecover tells the peer. It is
+// deliberately constant and carries nothing derived from the panic.
+const defaultRecoverMessage = "internal error"
+
 func defaultRecover(c *Conn) {
 	if err := recover(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "panic: %v\n%s\n", err, debug.Stack()) //nolint:errcheck // This will never fail
@@ -92,14 +96,13 @@ func defaultRecover(c *Conn) {
 			return
 		}
 		_ = c.SetWriteDeadline(time.Now().Add(defaultRecoverWriteTimeout))
-		// The recovered value is handed to the encoder as-is, deliberately: the
-		// stderr line above already gives the operator the full detail, so
-		// rendering it here would only widen what a remote peer can read out of
-		// a panic. An error value has no exported fields and encodes as {},
-		// which keeps a wrapped internal error (paths, DSNs, schema names) off
-		// the wire. Applications that want to say more, or nothing at all,
-		// should supply their own RecoverHandler.
-		if err := c.WriteJSON(fiber.Map{"error": err}); err != nil {
+		// A fixed payload: the stderr line above already gives the operator the
+		// full value and stack, so anything derived from the panic here would
+		// only widen what a remote peer can read out of it. panic("...") sent
+		// its string verbatim and a custom error type could expose exported
+		// fields or its own MarshalJSON. Applications that want to tell the peer
+		// more should supply their own RecoverHandler.
+		if err := c.WriteJSON(fiber.Map{"error": defaultRecoverMessage}); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "could not write error response: %v\n", err)
 		}
 	}
@@ -230,14 +233,16 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 			}
 		}
 
-		// queries
-		if args := fctx.QueryArgs(); args.Len() > 0 {
+		// queries: no size hint. Args.Len counts every key/value pair, including
+		// repetitions of the same key, but the assignments below collapse those
+		// to one entry -- so a hint taken from it would size the map for the
+		// repetitions while len stays at 1, and resetMap's entry cap would keep
+		// the oversized buckets pooled instead of dropping them.
+		for key, value := range fctx.QueryArgs().All() {
 			if conn.queries == nil {
-				conn.queries = make(map[string]string, args.Len())
+				conn.queries = make(map[string]string)
 			}
-			for key, value := range args.All() {
-				conn.queries[string(key)] = string(value)
-			}
+			conn.queries[string(key)] = string(value)
 		}
 
 		// cookies
@@ -432,9 +437,11 @@ func (conn *Conn) IP() string {
 
 // Constants are taken from https://github.com/fasthttp/websocket/blob/master/conn.go#L43
 
-// Close codes 1000-1011 and 1015 are defined in RFC 6455, section 11.7; 1012,
-// 1013 and 1014 were added to the IANA WebSocket Close Code Number Registry
-// afterwards.
+// Close codes 1000-1011 and 1015 are defined in RFC 6455, section 11.7; 1012
+// and 1013 were added to the IANA WebSocket Close Code Number Registry
+// afterwards. 1014 is registered too but is deliberately not exported: the
+// underlying library rejects it in both directions, so it can neither be sent
+// nor received through this stack.
 //
 // Not every code may travel in a close frame. RFC 6455, section 7.4.1 reserves
 // 1005, 1006 and 1015 for conditions an endpoint observes locally and forbids
@@ -457,7 +464,6 @@ const (
 	CloseInternalServerErr       = 1011
 	CloseServiceRestart          = 1012
 	CloseTryAgainLater           = 1013
-	CloseBadGateway              = 1014
 	CloseTLSHandshake            = 1015
 )
 

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -218,13 +218,14 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 			setEntry(&conn.params, name, utils.CopyString(c.Params(name)))
 		}
 		conn.ip = utils.CopyString(c.IP())
+		// The rest is copied now, while the middleware chain is still on the
+		// stack, so a local or header an outer middleware sets for the request
+		// and clears after c.Next is what the handler sees. The hijack callback
+		// only runs after the whole chain has unwound.
+		conn.capture(fctx, !server.DisableHeaderNamesNormalizing)
 
 		if err := upgrader.Upgrade(fctx, func(fconn *websocket.Conn) {
 			conn.Conn = fconn
-			// Everything else is copied only once the handshake has been
-			// accepted, so a rejected one pays for none of it. fasthttp keeps
-			// the RequestCtx alive until this callback returns.
-			conn.capture(fctx, !server.DisableHeaderNamesNormalizing)
 
 			returned := false
 			// Registered before the recover handler so it runs after it. A
@@ -281,9 +282,9 @@ type Conn struct {
 // less than unconditionally creating all five.
 
 // capture copies the locals, query arguments, cookies and headers of the
-// request into the Conn. It runs inside the hijack callback, where the
-// RequestCtx is still valid, and after the handshake has been accepted.
-// canonical says whether the server already normalizes header names.
+// request into the Conn before the handshake, out of a RequestCtx fasthttp
+// will recycle. canonical says whether the server already normalizes header
+// names.
 func (conn *Conn) capture(fctx *fasthttp.RequestCtx, canonical bool) {
 	fctx.VisitUserValues(func(key []byte, value interface{}) {
 		setEntry(&conn.locals, string(key), value)

--- a/v3/websocket/websocket_test.go
+++ b/v3/websocket/websocket_test.go
@@ -3,6 +3,8 @@ package websocket
 import (
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -79,7 +81,11 @@ func TestWebSocketMiddlewareConfigOrigin(t *testing.T) {
 		}
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "bad handshake")
-		assert.Equal(t, fiber.StatusUpgradeRequired, resp.StatusCode)
+		// RFC 6455 section 4.2.2: an origin the server does not accept is
+		// answered with 403, and section 4.4 asks a rejecting server to
+		// advertise the versions it understands.
+		assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+		assert.Equal(t, "13", resp.Header.Get(fiber.HeaderSecWebSocketVersion))
 		assert.Equal(t, "", resp.Header.Get("Upgrade"))
 
 		assert.Nil(t, conn)
@@ -154,7 +160,8 @@ func TestWebSocketMiddlewareConfigOrigin(t *testing.T) {
 		})
 		defer conn.Close()
 		assert.Equal(t, err.Error(), "websocket: bad handshake")
-		assert.Equal(t, fiber.StatusUpgradeRequired, resp.StatusCode)
+		assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+		assert.Equal(t, "13", resp.Header.Get(fiber.HeaderSecWebSocketVersion))
 		assert.Equal(t, "", resp.Header.Get("Upgrade"))
 
 		assert.Nil(t, conn)
@@ -536,4 +543,177 @@ func TestWebsocketRecoverCustomHandlerShouldNotPanic(t *testing.T) {
 	err = conn.ReadJSON(&msg)
 	assert.NoError(t, err)
 	assert.Equal(t, "error occurred", msg["customError"])
+}
+
+func TestWebSocketMiddlewareOriginCaseInsensitive(t *testing.T) {
+	// RFC 6454 section 4 serializes an origin with a case-insensitive scheme
+	// and host, so a configured origin must match regardless of its case.
+	app := setupTestApp(Config{
+		Origins: []string{"HTTP://LocalHost:3000"},
+	}, nil)
+	defer app.Shutdown()
+
+	conn, resp, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", http.Header{
+		"Origin": []string{"http://localhost:3000"},
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+	assert.Equal(t, fiber.StatusSwitchingProtocols, resp.StatusCode)
+
+	var msg fiber.Map
+	require.NoError(t, conn.ReadJSON(&msg))
+	assert.Equal(t, "hello websocket", msg["message"])
+}
+
+func TestNewPanicsOnNilHandler(t *testing.T) {
+	assert.Panics(t, func() {
+		New(nil)
+	})
+}
+
+func TestWebSocketNonUpgradeRequestIsUpgradeRequired(t *testing.T) {
+	app := fiber.New()
+	app.Get("/ws", New(func(*Conn) {}))
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/ws", nil))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusUpgradeRequired, resp.StatusCode)
+}
+
+func TestWebSocketRejectedHandshakeKeepsUpgraderResponse(t *testing.T) {
+	app := fiber.New()
+	app.Get("/ws", New(func(*Conn) {}))
+
+	// A handshake that asks for a version the server does not speak must be
+	// answered with the versions it does speak (RFC 6455 section 4.4), not
+	// flattened into a bare 426.
+	req := httptest.NewRequest(fiber.MethodGet, "/ws", nil)
+	req.Header.Set(fiber.HeaderConnection, "Upgrade")
+	req.Header.Set(fiber.HeaderUpgrade, "websocket")
+	req.Header.Set(fiber.HeaderSecWebSocketVersion, "12")
+	req.Header.Set(fiber.HeaderSecWebSocketKey, "dGhlIHNhbXBsZSBub25jZQ==")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "13", resp.Header.Get(fiber.HeaderSecWebSocketVersion))
+}
+
+func TestConnPoolReleaseClearsState(t *testing.T) {
+	conn := acquireConn()
+	conn.Locals("session", "secret")
+	conn.params = map[string]string{"id": "1"}
+	conn.queries = map[string]string{"q": "1"}
+	conn.cookies = map[string]string{"c": "1"}
+	conn.headers = map[string]string{"Authorization": "Bearer token"}
+	conn.ip = "127.0.0.1"
+
+	locals := conn.locals
+	releaseConn(conn)
+
+	// A pooled Conn must not keep the finished connection's data reachable.
+	assert.Nil(t, conn.Conn)
+	assert.Empty(t, conn.ip)
+	assert.Empty(t, locals)
+	assert.Empty(t, conn.params)
+	assert.Empty(t, conn.queries)
+	assert.Empty(t, conn.cookies)
+	assert.Empty(t, conn.headers)
+
+	// The maps themselves survive so the next connection reuses their buckets.
+	assert.NotNil(t, conn.locals)
+	assert.NotNil(t, conn.headers)
+}
+
+func TestConnPoolDropsOversizedMaps(t *testing.T) {
+	conn := &Conn{queries: make(map[string]string)}
+	for i := 0; i <= maxPooledMapEntries; i++ {
+		conn.queries[strconv.Itoa(i)] = "value"
+	}
+
+	releaseConn(conn)
+
+	assert.Nil(t, conn.queries, "an oversized map must be dropped instead of pooled")
+}
+
+func TestConnHeadersLookup(t *testing.T) {
+	conn := &Conn{headers: map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": "Bearer token",
+	}}
+
+	assert.Equal(t, "application/json", conn.Headers("Content-Type"))
+	assert.Equal(t, "application/json", conn.Headers("content-type"))
+	assert.Equal(t, "application/json", conn.Headers("CONTENT-TYPE"))
+	assert.Equal(t, "Bearer token", conn.Headers("authorization"))
+	assert.Equal(t, "", conn.Headers("X-Missing"))
+	assert.Equal(t, "fallback", conn.Headers("X-Missing", "fallback"))
+
+	// A server with header name normalizing turned off stores the key as it
+	// arrived, which the case-insensitive fallback still resolves.
+	raw := &Conn{headers: map[string]string{"x-custom": "value"}}
+	assert.Equal(t, "value", raw.Headers("X-Custom"))
+}
+
+func TestConnAccessorsOnEmptyConn(t *testing.T) {
+	conn := &Conn{}
+
+	assert.Nil(t, conn.Locals("missing"))
+	assert.Equal(t, "", conn.Params("missing"))
+	assert.Equal(t, "fallback", conn.Params("missing", "fallback"))
+	assert.Equal(t, "", conn.Query("missing"))
+	assert.Equal(t, "fallback", conn.Query("missing", "fallback"))
+	assert.Equal(t, "", conn.Cookies("missing"))
+	assert.Equal(t, "fallback", conn.Cookies("missing", "fallback"))
+	assert.Equal(t, "", conn.Headers("missing"))
+
+	// Setting a local on a connection that carried none allocates on demand.
+	assert.Equal(t, "value", conn.Locals("key", "value"))
+	assert.Equal(t, "value", conn.Locals("key"))
+}
+
+func TestCloseCodeValues(t *testing.T) {
+	// RFC 6455 section 11.7 plus the later IANA registrations.
+	assert.Equal(t, 1000, CloseNormalClosure)
+	assert.Equal(t, 1011, CloseInternalServerErr)
+	assert.Equal(t, 1012, CloseServiceRestart)
+	assert.Equal(t, 1013, CloseTryAgainLater)
+	assert.Equal(t, 1014, CloseBadGateway)
+	assert.Equal(t, 1015, CloseTLSHandshake)
+}
+
+func BenchmarkConnHeaders(b *testing.B) {
+	conn := &Conn{headers: map[string]string{
+		"Host":                  "localhost:3000",
+		"Connection":            "Upgrade",
+		"Upgrade":               "websocket",
+		"Sec-Websocket-Version": "13",
+		"Sec-Websocket-Key":     "dGhlIHNhbXBsZSBub25jZQ==",
+		"User-Agent":            "Go-http-client/1.1",
+		"Accept-Encoding":       "gzip",
+		"Authorization":         "Bearer token",
+	}}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if conn.Headers("Authorization") == "" {
+			b.Fatal("missing header")
+		}
+	}
+}
+
+func BenchmarkAcquireReleaseConn(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		conn := acquireConn()
+		conn.Locals("local", "value")
+		conn.ip = "127.0.0.1"
+		releaseConn(conn)
+	}
 }

--- a/v3/websocket/websocket_test.go
+++ b/v3/websocket/websocket_test.go
@@ -83,9 +83,8 @@ func TestWebSocketMiddlewareConfigOrigin(t *testing.T) {
 		}
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "bad handshake")
-		// RFC 6455 section 4.2.2: an origin the server does not accept is
-		// answered with 403, and section 4.4 asks a rejecting server to
-		// advertise the versions it understands.
+		// RFC 6455: a rejected origin is answered with 403 (section 4.2.2) and the
+		// supported version is advertised (section 4.4).
 		assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
 		assert.Equal(t, "13", resp.Header.Get(fiber.HeaderSecWebSocketVersion))
 		assert.Equal(t, "", resp.Header.Get("Upgrade"))
@@ -338,10 +337,8 @@ func TestWebSocketConnLocals(t *testing.T) {
 }
 
 func TestWebSocketConnLocalsSeeMiddlewareStateAtUpgradeTime(t *testing.T) {
-	// A middleware that sets a local for the duration of the request and
-	// clears it once c.Next returns is common for auth claims. The handler
-	// must see the value that was present while the chain was on the stack,
-	// not the state left behind after the chain unwound.
+	// Middleware often sets a local for the request and clears it after c.Next;
+	// the handler must see the value present while the chain was on the stack.
 	app := fiber.New()
 	app.Use(func(c fiber.Ctx) error {
 		c.Locals("claims", "admin")
@@ -559,11 +556,8 @@ func TestWebsocketRecoverDefaultHandlerShouldNotPanic(t *testing.T) {
 }
 
 func TestWebsocketRecoverDoesNotLeakErrorDetail(t *testing.T) {
-	// Nothing derived from the panic may reach the peer: the operator already
-	// gets the full value and stack on stderr, so putting any of it in the frame
-	// would only hand a remote client an oracle for internal paths, DSNs and
-	// schema names. This holds for a string panic as much as for an error one,
-	// since a string is sent verbatim by any encoder.
+	// Nothing derived from the panic may reach the peer, whether it is a string
+	// or an error: the operator already has the full value on stderr.
 	for _, tc := range []struct {
 		name  string
 		value any
@@ -604,10 +598,8 @@ func TestWebsocketPanicClosesConnection(t *testing.T) {
 	require.NoError(t, conn.ReadJSON(&msg))
 	assert.Equal(t, defaultRecoverMessage, msg["error"])
 
-	// ...and only then is the socket closed. Nothing else would ever close it:
-	// KeepHijackedConns leaves that to this package. The deadline is only so a
-	// regression fails instead of blocking forever; a timeout means the socket
-	// was left open, which is the failure being guarded against.
+	// ...and only then is the socket closed; nothing else closes a hijacked
+	// connection. A timeout here means the socket was left open.
 	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
 	_, _, err = conn.ReadMessage()
 	require.Error(t, err)
@@ -681,9 +673,8 @@ func TestWebSocketPartialHandshakeIsBadRequest(t *testing.T) {
 	app := fiber.New()
 	app.Get("/ws", New(func(*Conn) {}))
 
-	// Either upgrade signal on its own is an attempted but malformed
-	// handshake. The upgrader answers it with 400; 426 is reserved for a
-	// request that never asked to switch protocols.
+	// Either signal on its own is a malformed handshake: 400 from the upgrader,
+	// not the 426 reserved for requests that never asked to switch protocols.
 	cases := map[string][][2]string{
 		"upgrade without connection": {{fiber.HeaderUpgrade, "websocket"}},
 		"connection without upgrade": {{fiber.HeaderConnection, "Upgrade"}},
@@ -709,9 +700,8 @@ func TestWebSocketRejectedHandshakeKeepsUpgraderResponse(t *testing.T) {
 	app := fiber.New()
 	app.Get("/ws", New(func(*Conn) {}))
 
-	// A handshake that asks for a version the server does not speak must be
-	// answered with the versions it does speak (RFC 6455 section 4.4), not
-	// flattened into a bare 426.
+	// An unsupported version must be answered with the supported one (RFC 6455
+	// section 4.4), not flattened into a bare 426.
 	req := httptest.NewRequest(fiber.MethodGet, "/ws", nil)
 	req.Header.Set(fiber.HeaderConnection, "Upgrade")
 	req.Header.Set(fiber.HeaderUpgrade, "websocket")
@@ -798,10 +788,8 @@ func TestConnHeadersLookup(t *testing.T) {
 }
 
 func TestConnCaptureCanonicalizesHeaderNames(t *testing.T) {
-	// With normalizing disabled on the request, as earlier middleware can do
-	// for one request without the server flag being set, fasthttp hands names
-	// over as they arrived; capture canonicalizes them so lookups stay
-	// case-insensitive without a fallback scan.
+	// Middleware can disable normalizing for one request without the server flag;
+	// capture canonicalizes the names so lookups stay case-insensitive.
 	fctx := &fasthttp.RequestCtx{}
 	fctx.Request.Header.DisableNormalizing()
 	fctx.Request.Header.Set("x-custom", "value")
@@ -855,7 +843,7 @@ func BenchmarkConnHeaders(b *testing.B) {
 	for _, key := range []string{"Authorization", "authorization", "X-Missing"} {
 		b.Run(key, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				_ = conn.Headers(key, "fallback")
 			}
 		})
@@ -888,8 +876,7 @@ func handshakeRequest() *fasthttp.RequestCtx {
 func BenchmarkNewConn(b *testing.B) {
 	fctx := handshakeRequest()
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		conn := &Conn{ip: "127.0.0.1"}
 		conn.capture(fctx)
 	}

--- a/v3/websocket/websocket_test.go
+++ b/v3/websocket/websocket_test.go
@@ -337,6 +337,41 @@ func TestWebSocketConnLocals(t *testing.T) {
 	assert.Equal(t, "hello websocket", msg["message"])
 }
 
+func TestWebSocketConnLocalsSeeMiddlewareStateAtUpgradeTime(t *testing.T) {
+	// A middleware that sets a local for the duration of the request and
+	// clears it once c.Next returns is common for auth claims. The handler
+	// must see the value that was present while the chain was on the stack,
+	// not the state left behind after the chain unwound.
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.Locals("claims", "admin")
+		err := c.Next()
+		c.Locals("claims", nil)
+		return err
+	})
+	app.Get("/ws", New(func(c *Conn) {
+		_ = c.WriteJSON(fiber.Map{"claims": c.Locals("claims")})
+	}))
+	go app.Listen(":3000", fiber.ListenConfig{DisableStartupMessage: true})
+	defer app.Shutdown()
+	require.Eventually(t, func() bool {
+		conn, err := net.Dial("tcp", "localhost:3000")
+		if err != nil {
+			return false
+		}
+		conn.Close()
+		return true
+	}, 5*time.Second, 10*time.Millisecond)
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws", nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	var msg fiber.Map
+	require.NoError(t, conn.ReadJSON(&msg))
+	assert.Equal(t, "admin", msg["claims"])
+}
+
 func TestWebSocketConnIP(t *testing.T) {
 	app := setupTestApp(Config{}, func(c *Conn) {
 		ip := c.IP()

--- a/v3/websocket/websocket_test.go
+++ b/v3/websocket/websocket_test.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -702,54 +701,22 @@ func TestWebSocketRejectedHandshakeReachesErrorHandler(t *testing.T) {
 	assert.Equal(t, "13", resp.Header.Get(fiber.HeaderSecWebSocketVersion))
 }
 
-func TestConnResetEmptiesPooledState(t *testing.T) {
-	conn := &Conn{ip: "127.0.0.1"}
-	conn.Locals("session", "secret")
-	setEntry(&conn.params, "id", "1")
-	setEntry(&conn.queries, "q", "1")
-	setEntry(&conn.cookies, "c", "1")
-	setEntry(&conn.headers, "Authorization", "Bearer token")
-	locals, headers := conn.locals, conn.headers
+func TestConnCaptureAllocatesOnlyWhatTheRequestCarries(t *testing.T) {
+	// A bare handshake has headers and nothing else, so only the header map
+	// exists afterwards; the accessors for the rest answer without one.
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.Set(fiber.HeaderHost, "localhost")
 
-	conn.reset()
-
-	// Nothing of the previous connection survives into the next one...
-	assert.Empty(t, conn.ip)
-	assert.Empty(t, conn.locals)
-	assert.Empty(t, conn.params)
-	assert.Empty(t, conn.queries)
-	assert.Empty(t, conn.cookies)
-	assert.Empty(t, conn.headers)
-
-	// ...but the maps are the same ones, emptied in place, so their buckets
-	// are reused instead of reallocated.
-	assert.NotNil(t, conn.locals)
-	assert.Equal(t, 0, len(locals))
-	assert.Equal(t, 0, len(headers))
-}
-
-func TestConnResetDropsOversizedMaps(t *testing.T) {
 	conn := &Conn{}
-	for i := 0; i <= maxPooledMapEntries; i++ {
-		setEntry(&conn.queries, strconv.Itoa(i), "value")
-	}
+	conn.capture(fctx, true)
 
-	conn.reset()
-
-	assert.Nil(t, conn.queries, "an oversized map must be dropped instead of pooled")
-}
-
-func TestReleaseConnLeavesMapsForLateReaders(t *testing.T) {
-	// A listener fired by Close or CloseAll from another goroutine may still be
-	// reading the wrapper while the handler unwinds, so release must not write
-	// into the maps; that happens on the next acquire instead.
-	conn := &Conn{}
-	conn.Locals("user", "alice")
-
-	releaseConn(conn)
-
-	assert.Nil(t, conn.Conn)
-	assert.Equal(t, "alice", conn.Locals("user"))
+	assert.NotNil(t, conn.headers)
+	assert.Nil(t, conn.locals)
+	assert.Nil(t, conn.queries)
+	assert.Nil(t, conn.cookies)
+	assert.Equal(t, "", conn.Query("missing"))
+	assert.Equal(t, "", conn.Cookies("missing"))
+	assert.Nil(t, conn.Locals("missing"))
 }
 
 func TestConnHeadersLookup(t *testing.T) {
@@ -776,7 +743,7 @@ func TestConnCaptureCanonicalizesHeaderNames(t *testing.T) {
 	fctx.Request.Header.Set("x-custom", "value")
 
 	conn := &Conn{}
-	conn.capture(fctx)
+	conn.capture(fctx, false)
 
 	assert.Equal(t, "value", conn.Headers("x-custom"))
 	assert.Equal(t, "value", conn.Headers("X-Custom"))
@@ -831,13 +798,35 @@ func BenchmarkConnHeaders(b *testing.B) {
 	}
 }
 
-func BenchmarkAcquireReleaseConn(b *testing.B) {
+// handshakeRequest is a typical browser upgrade: nine headers, two cookies,
+// two query arguments and one local set by earlier middleware.
+func handshakeRequest() *fasthttp.RequestCtx {
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.SetRequestURI("/ws?v=1&room=lobby")
+	h := &fctx.Request.Header
+	h.Set(fiber.HeaderHost, "localhost:3000")
+	h.Set(fiber.HeaderConnection, "Upgrade")
+	h.Set(fiber.HeaderUpgrade, "websocket")
+	h.Set(fiber.HeaderSecWebSocketVersion, "13")
+	h.Set(fiber.HeaderSecWebSocketKey, "dGhlIHNhbXBsZSBub25jZQ==")
+	h.Set(fiber.HeaderUserAgent, "Mozilla/5.0")
+	h.Set(fiber.HeaderAcceptEncoding, "gzip, deflate, br")
+	h.Set(fiber.HeaderOrigin, "http://localhost:3000")
+	h.Set(fiber.HeaderAuthorization, "Bearer token")
+	h.SetCookie("session", "abc123")
+	h.SetCookie("theme", "dark")
+	fctx.SetUserValue("user", "alice")
+	return fctx
+}
+
+// BenchmarkNewConn is the per-upgrade cost of building a Conn: the struct plus
+// only the maps the request carries.
+func BenchmarkNewConn(b *testing.B) {
+	fctx := handshakeRequest()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		conn := acquireConn()
-		conn.Locals("local", "value")
-		conn.ip = "127.0.0.1"
-		releaseConn(conn)
+		conn := &Conn{ip: "127.0.0.1"}
+		conn.capture(fctx, true)
 	}
 }

--- a/v3/websocket/websocket_test.go
+++ b/v3/websocket/websocket_test.go
@@ -522,6 +522,27 @@ func TestWebsocketRecoverDefaultHandlerShouldNotPanic(t *testing.T) {
 	assert.Equal(t, "test panic", msg["error"])
 }
 
+func TestWebsocketRecoverDoesNotLeakErrorDetail(t *testing.T) {
+	// A panic carrying an error must not put that error's text on the wire. The
+	// operator already gets the full detail on stderr, so rendering it into the
+	// frame would only hand a remote peer an oracle for internal paths, DSNs
+	// and schema names. *errors.errorString has no exported fields, so handing
+	// the value to the encoder unrendered keeps it at {}.
+	app := setupTestApp(Config{}, func(*Conn) {
+		panic(errors.New("dial tcp 10.0.3.14:5432: connection refused"))
+	})
+	defer app.Shutdown()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, raw, err := conn.ReadMessage()
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "10.0.3.14")
+	assert.JSONEq(t, `{"error":{}}`, string(raw))
+}
+
 func TestWebsocketPanicClosesConnection(t *testing.T) {
 	app := setupTestApp(Config{}, func(*Conn) {
 		panic("test panic")

--- a/v3/websocket/websocket_test.go
+++ b/v3/websocket/websocket_test.go
@@ -677,6 +677,34 @@ func TestWebSocketNonUpgradeRequestIsUpgradeRequired(t *testing.T) {
 	assert.Equal(t, fiber.StatusUpgradeRequired, resp.StatusCode)
 }
 
+func TestWebSocketPartialHandshakeIsBadRequest(t *testing.T) {
+	app := fiber.New()
+	app.Get("/ws", New(func(*Conn) {}))
+
+	// Either upgrade signal on its own is an attempted but malformed
+	// handshake. The upgrader answers it with 400; 426 is reserved for a
+	// request that never asked to switch protocols.
+	cases := map[string][][2]string{
+		"upgrade without connection": {{fiber.HeaderUpgrade, "websocket"}},
+		"connection without upgrade": {{fiber.HeaderConnection, "Upgrade"}},
+		"wrong protocol":             {{fiber.HeaderConnection, "Upgrade"}, {fiber.HeaderUpgrade, "h2c"}},
+	}
+	for name, headers := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(fiber.MethodGet, "/ws", nil)
+			for _, h := range headers {
+				req.Header.Set(h[0], h[1])
+			}
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+			assert.Equal(t, "13", resp.Header.Get(fiber.HeaderSecWebSocketVersion))
+		})
+	}
+}
+
 func TestWebSocketRejectedHandshakeKeepsUpgraderResponse(t *testing.T) {
 	app := fiber.New()
 	app.Get("/ws", New(func(*Conn) {}))
@@ -743,7 +771,7 @@ func TestConnCaptureAllocatesOnlyWhatTheRequestCarries(t *testing.T) {
 	fctx.Request.Header.Set(fiber.HeaderHost, "localhost")
 
 	conn := &Conn{}
-	conn.capture(fctx, true)
+	conn.capture(fctx)
 
 	assert.NotNil(t, conn.headers)
 	assert.Nil(t, conn.locals)
@@ -770,15 +798,16 @@ func TestConnHeadersLookup(t *testing.T) {
 }
 
 func TestConnCaptureCanonicalizesHeaderNames(t *testing.T) {
-	// With header name normalizing disabled fasthttp hands names over as they
-	// arrived; capture canonicalizes them so lookups stay case-insensitive
-	// without a fallback scan.
+	// With normalizing disabled on the request, as earlier middleware can do
+	// for one request without the server flag being set, fasthttp hands names
+	// over as they arrived; capture canonicalizes them so lookups stay
+	// case-insensitive without a fallback scan.
 	fctx := &fasthttp.RequestCtx{}
 	fctx.Request.Header.DisableNormalizing()
 	fctx.Request.Header.Set("x-custom", "value")
 
 	conn := &Conn{}
-	conn.capture(fctx, false)
+	conn.capture(fctx)
 
 	assert.Equal(t, "value", conn.Headers("x-custom"))
 	assert.Equal(t, "value", conn.Headers("X-Custom"))
@@ -862,6 +891,6 @@ func BenchmarkNewConn(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		conn := &Conn{ip: "127.0.0.1"}
-		conn.capture(fctx, true)
+		conn.capture(fctx)
 	}
 }

--- a/v3/websocket/websocket_test.go
+++ b/v3/websocket/websocket_test.go
@@ -519,28 +519,36 @@ func TestWebsocketRecoverDefaultHandlerShouldNotPanic(t *testing.T) {
 	var msg fiber.Map
 	err = conn.ReadJSON(&msg)
 	assert.NoError(t, err)
-	assert.Equal(t, "test panic", msg["error"])
+	assert.Equal(t, defaultRecoverMessage, msg["error"])
 }
 
 func TestWebsocketRecoverDoesNotLeakErrorDetail(t *testing.T) {
-	// A panic carrying an error must not put that error's text on the wire. The
-	// operator already gets the full detail on stderr, so rendering it into the
-	// frame would only hand a remote peer an oracle for internal paths, DSNs
-	// and schema names. *errors.errorString has no exported fields, so handing
-	// the value to the encoder unrendered keeps it at {}.
-	app := setupTestApp(Config{}, func(*Conn) {
-		panic(errors.New("dial tcp 10.0.3.14:5432: connection refused"))
-	})
-	defer app.Shutdown()
+	// Nothing derived from the panic may reach the peer: the operator already
+	// gets the full value and stack on stderr, so putting any of it in the frame
+	// would only hand a remote client an oracle for internal paths, DSNs and
+	// schema names. This holds for a string panic as much as for an error one,
+	// since a string is sent verbatim by any encoder.
+	for name, value := range map[string]any{
+		"error":  errors.New("dial tcp 10.0.3.14:5432: connection refused"),
+		"string": "loading /srv/app/conf/tenants.yaml failed",
+	} {
+		t.Run(name, func(t *testing.T) {
+			app := setupTestApp(Config{}, func(*Conn) {
+				panic(value)
+			})
+			defer app.Shutdown()
 
-	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
-	require.NoError(t, err)
-	defer conn.Close()
+			conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
+			require.NoError(t, err)
+			defer conn.Close()
 
-	_, raw, err := conn.ReadMessage()
-	require.NoError(t, err)
-	assert.NotContains(t, string(raw), "10.0.3.14")
-	assert.JSONEq(t, `{"error":{}}`, string(raw))
+			_, raw, err := conn.ReadMessage()
+			require.NoError(t, err)
+			assert.NotContains(t, string(raw), "10.0.3.14")
+			assert.NotContains(t, string(raw), "/srv/app/conf")
+			assert.JSONEq(t, `{"error":"internal error"}`, string(raw))
+		})
+	}
 }
 
 func TestWebsocketPanicClosesConnection(t *testing.T) {
@@ -557,7 +565,7 @@ func TestWebsocketPanicClosesConnection(t *testing.T) {
 	// The recover handler still gets to write its error frame...
 	var msg fiber.Map
 	require.NoError(t, conn.ReadJSON(&msg))
-	assert.Equal(t, "test panic", msg["error"])
+	assert.Equal(t, defaultRecoverMessage, msg["error"])
 
 	// ...and only then is the socket closed. Nothing else would ever close it:
 	// KeepHijackedConns leaves that to this package. The deadline is only so a
@@ -732,7 +740,6 @@ func TestCloseCodeValues(t *testing.T) {
 	assert.Equal(t, 1011, CloseInternalServerErr)
 	assert.Equal(t, 1012, CloseServiceRestart)
 	assert.Equal(t, 1013, CloseTryAgainLater)
-	assert.Equal(t, 1014, CloseBadGateway)
 	assert.Equal(t, 1015, CloseTLSHandshake)
 }
 

--- a/v3/websocket/websocket_test.go
+++ b/v3/websocket/websocket_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
 )
 
 func TestWebSocketMiddlewareDefaultConfig(t *testing.T) {
@@ -528,13 +530,16 @@ func TestWebsocketRecoverDoesNotLeakErrorDetail(t *testing.T) {
 	// would only hand a remote client an oracle for internal paths, DSNs and
 	// schema names. This holds for a string panic as much as for an error one,
 	// since a string is sent verbatim by any encoder.
-	for name, value := range map[string]any{
-		"error":  errors.New("dial tcp 10.0.3.14:5432: connection refused"),
-		"string": "loading /srv/app/conf/tenants.yaml failed",
+	for _, tc := range []struct {
+		name  string
+		value any
+	}{
+		{"error", errors.New("dial tcp 10.0.3.14:5432: connection refused")},
+		{"string", "loading /srv/app/conf/tenants.yaml failed"},
 	} {
-		t.Run(name, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			app := setupTestApp(Config{}, func(*Conn) {
-				panic(value)
+				panic(tc.value)
 			})
 			defer app.Shutdown()
 
@@ -544,8 +549,6 @@ func TestWebsocketRecoverDoesNotLeakErrorDetail(t *testing.T) {
 
 			_, raw, err := conn.ReadMessage()
 			require.NoError(t, err)
-			assert.NotContains(t, string(raw), "10.0.3.14")
-			assert.NotContains(t, string(raw), "/srv/app/conf")
 			assert.JSONEq(t, `{"error":"internal error"}`, string(raw))
 		})
 	}
@@ -661,41 +664,92 @@ func TestWebSocketRejectedHandshakeKeepsUpgraderResponse(t *testing.T) {
 	assert.Equal(t, "13", resp.Header.Get(fiber.HeaderSecWebSocketVersion))
 }
 
-func TestConnPoolReleaseClearsState(t *testing.T) {
-	conn := acquireConn()
+func TestWebSocketRejectedHandshakeReachesErrorHandler(t *testing.T) {
+	var handled atomic.Int32
+	app := fiber.New(fiber.Config{
+		ErrorHandler: func(c fiber.Ctx, err error) error {
+			handled.Add(1)
+			var fe *fiber.Error
+			require.ErrorAs(t, err, &fe)
+			return c.Status(fe.Code).JSON(fiber.Map{"reason": fe.Message})
+		},
+	})
+	// A header set by earlier middleware, as a request-id or CORS middleware
+	// would. fasthttp's ctx.Error would have reset it away.
+	app.Use(func(c fiber.Ctx) error {
+		c.Set("X-Request-ID", "req-1")
+		return c.Next()
+	})
+	app.Get("/ws", New(func(*Conn) {}, Config{Origins: []string{"http://allowed"}}))
+
+	req := httptest.NewRequest(fiber.MethodGet, "/ws", nil)
+	req.Header.Set(fiber.HeaderConnection, "Upgrade")
+	req.Header.Set(fiber.HeaderUpgrade, "websocket")
+	req.Header.Set(fiber.HeaderSecWebSocketVersion, "13")
+	req.Header.Set(fiber.HeaderSecWebSocketKey, "dGhlIHNhbXBsZSBub25jZQ==")
+	req.Header.Set(fiber.HeaderOrigin, "http://evil")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// The rejection is a *fiber.Error with the upgrader's status, so the
+	// app's own error formatting, logging and metrics all see it.
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+	assert.Equal(t, int32(1), handled.Load())
+	assert.Equal(t, fiber.MIMEApplicationJSONCharsetUTF8, resp.Header.Get(fiber.HeaderContentType))
+	assert.Equal(t, "req-1", resp.Header.Get("X-Request-ID"))
+	assert.Equal(t, "13", resp.Header.Get(fiber.HeaderSecWebSocketVersion))
+}
+
+func TestConnResetEmptiesPooledState(t *testing.T) {
+	conn := &Conn{ip: "127.0.0.1"}
 	conn.Locals("session", "secret")
-	conn.params = map[string]string{"id": "1"}
-	conn.queries = map[string]string{"q": "1"}
-	conn.cookies = map[string]string{"c": "1"}
-	conn.headers = map[string]string{"Authorization": "Bearer token"}
-	conn.ip = "127.0.0.1"
+	setEntry(&conn.params, "id", "1")
+	setEntry(&conn.queries, "q", "1")
+	setEntry(&conn.cookies, "c", "1")
+	setEntry(&conn.headers, "Authorization", "Bearer token")
+	locals, headers := conn.locals, conn.headers
 
-	locals := conn.locals
-	releaseConn(conn)
+	conn.reset()
 
-	// A pooled Conn must not keep the finished connection's data reachable.
-	assert.Nil(t, conn.Conn)
+	// Nothing of the previous connection survives into the next one...
 	assert.Empty(t, conn.ip)
-	assert.Empty(t, locals)
+	assert.Empty(t, conn.locals)
 	assert.Empty(t, conn.params)
 	assert.Empty(t, conn.queries)
 	assert.Empty(t, conn.cookies)
 	assert.Empty(t, conn.headers)
 
-	// The maps themselves survive so the next connection reuses their buckets.
+	// ...but the maps are the same ones, emptied in place, so their buckets
+	// are reused instead of reallocated.
 	assert.NotNil(t, conn.locals)
-	assert.NotNil(t, conn.headers)
+	assert.Equal(t, 0, len(locals))
+	assert.Equal(t, 0, len(headers))
 }
 
-func TestConnPoolDropsOversizedMaps(t *testing.T) {
-	conn := &Conn{queries: make(map[string]string)}
+func TestConnResetDropsOversizedMaps(t *testing.T) {
+	conn := &Conn{}
 	for i := 0; i <= maxPooledMapEntries; i++ {
-		conn.queries[strconv.Itoa(i)] = "value"
+		setEntry(&conn.queries, strconv.Itoa(i), "value")
 	}
+
+	conn.reset()
+
+	assert.Nil(t, conn.queries, "an oversized map must be dropped instead of pooled")
+}
+
+func TestReleaseConnLeavesMapsForLateReaders(t *testing.T) {
+	// A listener fired by Close or CloseAll from another goroutine may still be
+	// reading the wrapper while the handler unwinds, so release must not write
+	// into the maps; that happens on the next acquire instead.
+	conn := &Conn{}
+	conn.Locals("user", "alice")
 
 	releaseConn(conn)
 
-	assert.Nil(t, conn.queries, "an oversized map must be dropped instead of pooled")
+	assert.Nil(t, conn.Conn)
+	assert.Equal(t, "alice", conn.Locals("user"))
 }
 
 func TestConnHeadersLookup(t *testing.T) {
@@ -711,10 +765,22 @@ func TestConnHeadersLookup(t *testing.T) {
 	assert.Equal(t, "", conn.Headers("X-Missing"))
 	assert.Equal(t, "fallback", conn.Headers("X-Missing", "fallback"))
 
-	// A server with header name normalizing turned off stores the key as it
-	// arrived, which the case-insensitive fallback still resolves.
-	raw := &Conn{headers: map[string]string{"x-custom": "value"}}
-	assert.Equal(t, "value", raw.Headers("X-Custom"))
+}
+
+func TestConnCaptureCanonicalizesHeaderNames(t *testing.T) {
+	// With header name normalizing disabled fasthttp hands names over as they
+	// arrived; capture canonicalizes them so lookups stay case-insensitive
+	// without a fallback scan.
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.DisableNormalizing()
+	fctx.Request.Header.Set("x-custom", "value")
+
+	conn := &Conn{}
+	conn.capture(fctx)
+
+	assert.Equal(t, "value", conn.Headers("x-custom"))
+	assert.Equal(t, "value", conn.Headers("X-Custom"))
+	assert.Equal(t, "value", conn.Headers("X-CUSTOM"))
 }
 
 func TestConnAccessorsOnEmptyConn(t *testing.T) {
@@ -755,12 +821,13 @@ func BenchmarkConnHeaders(b *testing.B) {
 		"Authorization":         "Bearer token",
 	}}
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if conn.Headers("Authorization") == "" {
-			b.Fatal("missing header")
-		}
+	for _, key := range []string{"Authorization", "authorization", "X-Missing"} {
+		b.Run(key, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = conn.Headers(key, "fallback")
+			}
+		})
 	}
 }
 

--- a/v3/websocket/websocket_test.go
+++ b/v3/websocket/websocket_test.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -519,6 +520,34 @@ func TestWebsocketRecoverDefaultHandlerShouldNotPanic(t *testing.T) {
 	err = conn.ReadJSON(&msg)
 	assert.NoError(t, err)
 	assert.Equal(t, "test panic", msg["error"])
+}
+
+func TestWebsocketPanicClosesConnection(t *testing.T) {
+	app := setupTestApp(Config{}, func(*Conn) {
+		panic("test panic")
+	})
+	defer app.Shutdown()
+
+	conn, resp, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
+	require.NoError(t, err)
+	defer conn.Close()
+	assert.Equal(t, fiber.StatusSwitchingProtocols, resp.StatusCode)
+
+	// The recover handler still gets to write its error frame...
+	var msg fiber.Map
+	require.NoError(t, conn.ReadJSON(&msg))
+	assert.Equal(t, "test panic", msg["error"])
+
+	// ...and only then is the socket closed. Nothing else would ever close it:
+	// KeepHijackedConns leaves that to this package. The deadline is only so a
+	// regression fails instead of blocking forever; a timeout means the socket
+	// was left open, which is the failure being guarded against.
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	_, _, err = conn.ReadMessage()
+	require.Error(t, err)
+	var netErr net.Error
+	assert.False(t, errors.As(err, &netErr) && netErr.Timeout(),
+		"panicking handler left the connection open: %v", err)
 }
 
 func TestWebsocketRecoverCustomHandlerShouldNotPanic(t *testing.T) {


### PR DESCRIPTION
## Summary

Three things in `v3/websocket` and `v3/websocket/event`:

1. **Performance** — the event fan-out allocated on every inbound frame, `Broadcast` copied the whole pool and re-looked-up every target, header lookups scanned with case folding, and the `sync.Pool` for `Conn` recycled the struct while re-allocating every map anyway. A second round then removed the per-frame registry lock, the per-broadcast snapshot rebuild and `io.ReadAll`'s growth on the read path. Details and measurements below.
2. **RFC 6455 / 6454 compliance** — rejected handshakes returned the wrong status and bypassed the app's `ErrorHandler`, close frames could carry invalid UTF-8 and status codes a peer rejects, and origins were compared case-sensitively.
3. **Bug fixes** — a panicking event callback stranded a connection in the global pool and leaked its socket; the `Conn` pool let a wrapper retained past the handler's return reach the *next* client's socket and request data, so the pool is removed; and review of this branch caught optimisations of its own that changed semantics, all reverted (see *Bug fixes*).

No new dependencies. **One public API addition**: `event.ErrorCallbackPanic`, the error carried by the events fired when a connection callback panics — previously reported to listeners as a clean disconnect.

The branch has been through two nine-angle `/code-review` passes, a `/security-review`, and reviews by Copilot, CodeRabbit and Codex; every finding is either fixed or explicitly declined below.

---

## Performance

### Methodology

Every "before" number comes from a **verbatim replica of the `main` implementation**, benchmarked side by side with the new one in an isolated copy of the module — same binary, same machine, same run. `-benchmem -count=6`, medians. `linux/amd64`, Intel Xeon @ 2.80 GHz, Go 1.26. These are microbenchmarks of the functions changed, not end-to-end throughput. The second-round table further down compares the two heads of this branch back to back the same way.

**Per frame** (paid on every inbound message on every connection):

| Benchmark | Before | After | Δ |
|:---|:---|:---|:---|
| event fan-out, read path, 1 listener (`FireOwnedEvent`) | 223 ns · 168 B · 4 allocs | **153 ns · 144 B · 2 allocs** | −31% time, −50% allocs |
| event fan-out, caller data, 1 listener (`FireEvent`) | 223 ns · 168 B · 4 allocs | **167 ns · 160 B · 3 allocs** | −25% |
| event fan-out, no listeners | 42 ns | **37 ns** | −12% (−90% after round 2, below) |
| read-deadline refresh | every frame (~220 ns) | at most once per ¼ idle timeout | — |

**Per broadcast / global event**:

| Benchmark | Before | After | Δ |
|:---|:---|:---|:---|
| pool snapshot, 128 conns (`PoolSnapshot`) | 6.1 µs · 9560 B · 4 allocs | **2.0 µs · 2304 B · 1 alloc** | −68% time, −76% bytes (0 B after round 2, below) |

**Per connection** (paid once per handshake):

| Benchmark | Before | After | Δ |
|:---|:---|:---|:---|
| `Headers("Authorization")` — canonical spelling | 61 ns · 0 allocs | **36 ns · 0 allocs** | −41% |
| `Headers("X-Missing", fallback)` — miss | 72 ns · 0 allocs | **28 ns · 0 allocs** | −61% |
| `Headers("authorization")` — non-canonical spelling | 61 ns · 0 allocs | 68 ns · 16 B · **1 alloc** | ⚠️ +11%, allocates |
| request copy per upgrade, browser handshake (pooled `Conn` + 5 `make`s + copy loops + release on `main`; allocate + `capture` here) | 1893 ns · 2368 B · 40 allocs | 2011 ns · 2304 B · 38 allocs | ⚠️ +6% time, −2 allocs |

**Second round**, back to back against the first-round head (c8da20e), same method; the frame-read rows compare `ReadMessage`, which round 1 still used, with the pooled reader on the same run:

| Benchmark | Round 1 head | Now | Δ |
|:---|:---|:---|:---|
| event nobody listens for | 35 ns | **4 ns** | −88% |
| one listener, 4 goroutines firing concurrently (`FireOwnedEventParallel`) | 148 ns/op | **121 ns/op** | −18% |
| pool snapshot, 128 conns (`PoolSnapshot`) | 2.4 µs · 2304 B · 1 alloc | **16 ns · 0 B · 0 allocs** | −99% |
| pool snapshot, one join or leave per ten calls (`PoolSnapshotChurn`) | 2.5 µs · 2304 B | **337 ns · 230 B** | −87% |
| frame read, 128 B (`ReadMessage` → `FrameReader`) | 498 ns · 520 B · 2 allocs | **438 ns · 136 B · 2 allocs** | −12% |
| frame read, 4 KB | 9.4 µs · 10.4 KB · 10 allocs | **6.2 µs · 4.1 KB · 2 allocs** | −34% time, −80% allocs |
| frame read, 64 KB | 123 µs · 138 KB · 17 allocs | **67 µs · 66 KB · 2 allocs** | −45% time, −88% allocs |

The benchmarks are committed (`BenchmarkConnHeaders` with all three spellings, `BenchmarkNewConn`, `BenchmarkFireEventNoListeners`, `BenchmarkFireEventSingleListener`, `BenchmarkFireOwnedEventParallel`, `BenchmarkPoolSnapshot`, `BenchmarkPoolSnapshotChurn`, `BenchmarkReadMessage`, `BenchmarkFrameReader`) so the numbers can be re-derived.

### 1. Event fan-out allocated on every frame

`fireEvent` runs for **every inbound message**. It called `safeListeners.get` twice — each taking an `RLock`, doing two map lookups and copying the callback slice — then `append`ed the two together, all *before* checking whether anyone was listening. It then deep-copied the attribute map with a range loop, and cloned the message bytes — even though `ReadMessage` goes through `io.ReadAll` and already returns a slice allocated for that frame alone, so the clone re-allocated and memcpy'd an owned buffer (64 KiB extra per 64 KiB frame).

Now: the registry stores immutable slices, so `get` hands the stored slice out with no copy and the two lists are iterated in place. An event nobody listens for costs two map lookups. Attributes use `maps.Clone`. The read path calls `fireOwnedEvent`, which skips the clone; `fireEvent` still clones for caller-provided data (`Fire`, the send-drop path), and a global `Fire` still gives every connection its own copy, as on `main` — an intermediate revision shared one clone across the fan-out, which Codex caught (see *Bug fixes*).

### 2. `Broadcast` copied the pool and re-looked-up every target

`pool.all()` built a throwaway `map[string]ws` of the whole pool, then `Broadcast` called `EmitTo(uuid)` per entry — another pool `RLock` and lookup per target — and took each target's own mutex just to compare UUID strings. `pool.snapshot()` returns a `[]ws`; `Broadcast` emits to the connections it already holds and skips itself by **identity**, which needs no lock and stays correct under a concurrent `SetUUID`.

### 3. Read-deadline refresh was a per-frame timer update

The idle deadline now refreshes on data as well as on pong (a peer that talks steadily but never answers a server ping was being dropped). `SetReadDeadline` is a runtime timer modification (~180 ns) plus `time.Now`, so it is done at most once per **quarter** of the idle timeout: after any frame the deadline is still at least ¾ of the timeout away, and the common case is one `time.Now` and a compare.

### 4. Header lookup scanned with case folding

`Conn.Headers` walked every header calling `utils.EqualFold`. Names are now stored in canonical form at the single store site — every name goes through `CanonicalHeaderKey` at capture, because fasthttp delivers them canonical unless normalising was disabled server-wide *or by earlier middleware on that one request*, which is not observable from the handler (a Codex finding; an earlier revision only checked the server flag). An already-canonical name comes back unchanged without allocating, so the pass costs about 120 ns per handshake and a lookup is **one map probe with no fallback scan**. `CanonicalHeaderKey` returns the key itself for the usual `"Authorization"` spelling and allocates a 16-byte copy for `"authorization"` — the one lookup regression in the table. I chose not to reimplement the canonicaliser into a stack buffer to remove it: `Headers` is per-connection setup, not per-frame, and duplicating the token-table rules is a drift risk.

### 5. The `Conn` pool is removed

On `main`, `acquireConn` called `poolConn.Get()` and then immediately replaced all five maps with fresh `make(...)` calls, so every upgrade paid the allocations anyway — the pool recycled the struct and nothing else. An earlier revision of this branch tried to make it a real pool by `clear()`ing the maps in place so their buckets survived. Review showed that cannot be made safe: the event helper's `Locals/Params/Query/Cookies` closures (and `v3/socketio`'s) read the wrapper from `EventDisconnect` listeners that run on whichever goroutine called `Close()` or `CloseAll()` — the graceful-shutdown pattern the event README recommends — after the handler has returned and released it, and the middleware has no way to know when they are done. Whether the maps are emptied at release or at the next acquire only moves the window; four reviewers reproduced the race either way (a listener reading `""` or another client's value; worst case a fatal `concurrent map read and map write`).

So the pool is gone: a `Conn` is allocated per upgrade and never reused, which closes the whole use-after-release class — including the retained-wrapper hazard three reviewers reproduced against the *base*, where a wrapper kept after the handler returned wrote into the next client's socket (`GOMAXPROCS=1`, 3/3 runs). `acquireConn`, `releaseConn`, `reset`, `resetMap` and the entry cap go with it. What stays is the cheap part: each map is created only when the request carries that kind of data, and no map takes a size hint request input can inflate (`Args.Len()` counts repeated keys the assignments collapse to one — measured at 656 KB of buckets for 10k repetitions of a single key). Net per upgrade: within 6% of `main` with two fewer allocations (table above); the 6% is the header canonicalisation pass from §4. The earlier revision's claim of six allocations saved per handshake is withdrawn.

### 6. Work moved off the rejection path

A request that carries neither an `Upgrade` header nor an `upgrade` token in `Connection` (plain GETs, crawlers) answers `426` before any request copy is made; a request that carries one of the two signals but not both is a malformed handshake and goes on to the upgrader for its `400` (a Codex finding; an earlier revision answered those `426` too). Route param *names* are no longer copied (they belong to the parsed route and outlive every request); the origin policy is resolved once in `New` instead of searching for `"*"` per request; and `ensureKeepHijackedConns` is a `sync.Map` of `*sync.Once` instead of a mutex taken on every upgrade.

The request copy itself still runs **before** `Upgrade`, while the middleware chain is on the stack. An intermediate revision moved it into the hijack callback so a rejected handshake paid nothing for it, but fasthttp runs that callback only after the whole Fiber chain has unwound, so a local an outer middleware sets for the request and clears after `c.Next` (auth claims, typically) had vanished by the time the handler looked. Codex caught it; reverted.

### 7. The listener registry took a read lock on every frame (round 2)

Every connection's read goroutine consulted the global registry through `RWMutex.RLock` on every frame. A read lock is an atomic add on one shared cache line, so every read goroutine on the server contended on it — the cost grows with cores, not with work. The registry is now copy-on-write: `On`/`Off` replace the whole map under a mutex, `get` loads an `atomic.Pointer` and indexes. The slices handed out were already immutable snapshots; nothing about ordering or visibility changes.

### 8. The pool snapshot is cached until membership changes (round 2)

`Broadcast`, global `Fire` and `CloseAll` each rebuilt a slice of every connection. The slice is now kept until a connection joins, leaves or is renamed, so a burst of broadcasts to 4096 connections shares one 64 KB slice instead of allocating it per call. Rebuild cost is unchanged when membership does change, so the worst case is exactly what it was.

### 9. Frames are read through pooled buffers and handed out exact-size (round 2)

`ReadMessage` is `NextReader` plus `io.ReadAll`: a 512-byte start and doubling growth, so a 64 KB frame cost seventeen allocations and twice its size in garbage before the fan-out ever saw it. The read loop now reads through `NextReader` into a buffer taken from a `sync.Pool` (512 bytes to start, grown by doubling, not returned to the pool if it grew past 64 KB) and hands the fan-out an exact-size copy. An idle connection holds no buffer: memory follows the frames in flight, not the number of connections, and the GC trims what the pool keeps — Codex's security review caught an intermediate revision that kept the buffer per connection, which let a client with many idle connections pin 64 KB on each. The owned-`Data` contract is unchanged — `TestEventPayloadDataIsIndependentOfReadBuffer` still holds and the frame-reader test checks that reading a frame never touches the message handed out before it — at two allocations per frame regardless of size.

### Deliberately not optimised

- **Copy-on-write attributes** (would make `SocketAttributes` zero-cost per event): a listener that writes to the snapshot would then corrupt a map `GetAttribute` reads concurrently — fatal — where today it harmlessly writes to a private copy. Kept the safe side.
- **Interning known header names** (~13 allocs/handshake) and an **arena copy in `capture`** (measured 1.70 → 1.29 µs and 38 → 11 allocs per handshake): both are per-handshake savings against a loopback upgrade of ~130 µs, and the arena needs `unsafe`-backed string aliasing. Not worth the review surface.
- **Sharing one `EventPayload` across listeners**: a listener reassigning `Data` or `Error` would leak into the next one. Each listener gets its own struct value; the map and byte slice behind it are shared, as they always were.
- **`PreparedMessage` for `Broadcast`**: identical to `WriteMessage` up to 1 KB, faster at 4–16 KB, slower at 64 KB on loopback; it only pays off reliably with compression enabled.
- **Throttling the per-message `SetWriteDeadline`**: ~200 ns of a ~6 µs write, and it would loosen the documented per-write timeout.
- **Raising the default `ReadBufferSize` from 1024 to the library's 4096**: measured 10–22% faster reads at every frame size for 3 KB more per connection, but it is a documented default and a user-visible change, so it is left for the maintainers to decide.

---

## RFC compliance

- **Rejected handshakes carry the status RFC 6455 defines and go through the app's `ErrorHandler`.** Previously every rejection was flattened to `426`. Now `FastHTTPUpgrader.Error` records the status and the handler returns a `*fiber.Error` with it — `403` for an unaccepted `Origin` (§4.2.2), `400` for a malformed handshake (including one that carries only one of the `Upgrade`/`Connection` signals), `405` for a non-`GET` — so custom error formats, logging and metrics see it. Taking the `Error` hook also means fasthttp's `ctx.Error` never runs its `Response.Reset()`, which was wiping headers earlier middleware had set (request IDs, CORS) along with the `Sec-WebSocket-Version: 13` header §4.4 requires; that header is set explicitly. `426` is still returned for a request that never asked to switch protocols at all.
- **Origins compare case-insensitively** (RFC 6454 §4). `utils.EqualFold` is ASCII-only, so no Unicode fold-collision bypass.
- **Close reasons stay valid UTF-8** (§5.5.1): the cut lands on a rune boundary and invalid input is scrubbed.
- **Only close codes a peer accepts are sent**: `1000-1003`, `1007-1013`, `3000-4999`; anything else becomes `1000`. That covers the codes §7.4.1 forbids (`1005`, `1006`, `1015`), `1004` (reserved, no meaning), and `1014`/`1016-2999`, which `fasthttp/websocket`'s receive-side validator rejects with a protocol error — the end-to-end test demonstrates it for each. `1005` is the exception: `FormatCloseMessage` renders it as an empty close frame, which is how "no status" is expressed, so a reason passed with it is necessarily dropped.
- Corrected the `Subprotocols` doc (it is the *server's* supported list in preference order) and the close-code doc comment.

---

## Bug fixes

- **The `Conn` pool is removed** (the *why* is in §5). Beyond the shutdown race, two consequences: a handler that keeps using the connection after it returns — the existing `TestWebSocketCompressionAfterHandlerReturns` does — now does so on an object nobody else will ever touch, and `v3/socketio`, which has the same closures and is pinned to `v1.2.4`, no longer inherits the hazard on its next bump. `TestCloseAllListenersStillSeeRequestData` and `TestCloseAllListenersSurviveConcurrentUpgrades` (upgrades keep arriving throughout `CloseAll` while disconnect listeners read request data) both fail against the pooled variant with `-race` reports and are clean now.
- **A panic in an event connect callback stranded the connection in the global pool** with its `done` channel never closed — goroutine leak, socket never closed, every later `Broadcast` eventually blocked on the full queue. On the panic path the helper now leaves the pool, detaches `kws.Conn` so `conn()` and `IsAlive` agree the connection is gone, and fires `EventDisconnect`/`EventError` with `ErrorCallbackPanic` rather than reporting a crash as a clean close; the middleware closes the socket once `RecoverHandler` has written its error frame. A callback that had already closed its connection itself and *then* panicked was still reported as nothing but that clean close, because the disconnect is once-only; it now fires `EventError` with `ErrorCallbackPanic` on top (Codex, round 2).
- **A panicking handler's socket is now closed** once `RecoverHandler` has written its error frame; with `KeepHijackedConns` set nothing else ever closes it.
- **Optimisations from this branch that changed semantics or cost memory, caught by Codex and reverted**: a global `Fire` handed every connection the same cloned slice, so a listener mutating `Data` for one connection changed what another connection's listeners saw (`main` copied per connection; restored); the request copy had moved into the hijack callback, which runs after the middleware chain has unwound (§6; restored); header canonicalisation was gated on the server-wide flag and missed names added under a request-level `DisableNormalizing` (§4; now unconditional); the early `426` swallowed partial handshakes the upgrader answers with `400` (§6); and the frame buffer was kept per connection, up to 64 KB, which a client holding many idle connections could pin (§9; now pooled). All have regression tests; see *Testing* for which negative checks were verified.
- **`defaultRecover` no longer puts anything derived from the panic on the wire** — `panic("...")` was sent verbatim, and a custom error type could expose exported fields or its own `MarshalJSON`. The peer gets a fixed `{"error":"internal error"}`; the operator keeps the full value and stack on stderr.
- `conn()` and `closeConn` check the embedded connection under the lock (the base did; an intermediate revision didn't). The ping handler gets the same shutdown short-circuit the pong handler had, so `EventPing` cannot fire after `EventDisconnect`. `New`/`NewWithConfig` reject a nil handler at wiring time.

---

## Behaviour changes to be aware of

| Change | Before | After |
|:---|:---|:---|
| Rejected `Origin` | `426` via `ErrorHandler` | `403` via `ErrorHandler` (`*fiber.Error`) |
| Bad/unsupported handshake | `426` | `400` (+ `Sec-WebSocket-Version: 13`) |
| Partial handshake (only one of `Upgrade` / `Connection: upgrade`) | `426` | `400` (+ `Sec-WebSocket-Version: 13`) |
| Non-`GET` upgrade attempt | `426` | `405` |
| `Origins` matching | case-sensitive | case-insensitive (ASCII) |
| `defaultRecover` response body | the recovered panic value | fixed `{"error":"internal error"}` |
| Handler panics | socket left open | socket closed after `RecoverHandler` |
| Event callback panics | `EventDisconnect` with `Error == nil` | `EventDisconnect` + `EventError` with `ErrorCallbackPanic` (`EventError` alone if the callback had already closed the connection) |
| Close code a peer rejects (`1004`, `1006`, `1014`, …) | sent verbatim | replaced with `1000` |
| `*websocket.Conn` after the handler returns | recycled through a `sync.Pool` for the next upgrade | owned by that connection; collected when nothing references it |

The `defaultRecover` change is the one most likely to be noticed — applications that relied on the panic text reaching the client should supply a `RecoverHandler`. Both READMEs are updated; the existing tests that asserted the old `426` and the old recover body were updated with them. The second-round changes (§7–§9) are internal; frame buffers are pooled rather than kept per connection, so an idle connection holds no more than it did on `main`.

---

## Testing

- `go test -race -count=2 ./...` passes for both packages; `go vet` and `gofmt` clean; the `lint` job is green on every pushed head.
- **Regression tests verified to fail against the behaviour they guard**: the pooled wrapper (`TestCloseAllListenersSurviveConcurrentUpgrades`: three `-race` reports against the pooled variant), the shared clone in a global `Fire` (the other connection's listener sees the mutated byte), the `return nil` rejection (`ErrorHandler` invoked 0 times), the close reordering (client receives `close 1006` instead of the error frame), the middleware close-on-panic (connection stays open until the read deadline), the close-code sanitiser (`1004`, `1014`, `2999` rejected by the peer as protocol errors), the partial handshakes (`426` against the previous commit), the request-level `DisableNormalizing` header (`Headers` returned `""`), and the panic after `Close` (no `EventError`). One exception for the record: `TestWebSocketConnLocalsSeeMiddlewareStateAtUpgradeTime` passes on this head, but my run of it against the intermediate revision did not build, so its negative check is **not** verified.
- **Round 2 tests**: the registry's copy-on-write semantics (a slice handed out earlier is unchanged by later registrations; removal; concurrent set/remove/get under the race detector), snapshot caching and invalidation including `SetUUID`, the frame reader over messages of every size around its thresholds (0, 1, 511, 512, 513, 3000, 65536, 65537, 16 bytes) sent through a 256-byte client write buffer so they arrive fragmented — each checked byte-for-byte, with the previous message verified untouched by the next read — and the pool's retention policy (keep up to 64 KB, drop larger) on its own.
- New tests also cover: case-insensitive origins; `426`/`403`/`400` and the version header; `ErrorHandler` invocation with a prior middleware header (`X-Request-ID`) preserved; lazy map allocation in the request copy and canonical header lookup under a request-level `DisableNormalizing`; close-reason rune-boundary truncation and UTF-8 scrubbing; close-code sanitising end to end over a real socket; the `Broadcast` self-skip and dead-target `EventError`; the panic path reporting `ErrorCallbackPanic` with the connection detached; and that neither a string nor an error panic leaks its text to the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fb9Khty7Xr8UrwTjfuKtEY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified WebSocket handshake rejection, panic recovery, graceful shutdown, timeout handling, close-code normalization, and connection lifecycle behavior.

- **Bug Fixes**
  - Improved origin matching, including case-insensitive checks and allow-all configuration.
  - Rejected upgrades now preserve relevant response headers and provide clearer application errors.
  - Panic recovery now returns a consistent client-safe error and closes affected connections.
  - Improved idle timeout handling, event delivery isolation, broadcasting, and close-frame compliance.
  - Prevented connection data from being reused across upgrades, improving listener consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->