### PR TITLE
chore(ci): lint on Go 1.27 and hold gobwas/glob at v0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,11 @@ updates:
       open-pull-requests-limit: 20
       allow:
           - dependency-type: "all"
+      ignore:
+          # v1 is an API-breaking rewrite (glob.Glob is gone). Lift once OPA ships the migration
+          # from open-policy-agent/opa#9116, which is merged upstream but not released yet.
+          - dependency-name: "github.com/gobwas/glob"
+            versions: [">= 1.0.0"]
       directories:
           - "/v3/a*"
           - "/v3/b*"
@@ -121,6 +126,11 @@ updates:
       open-pull-requests-limit: 20
       allow:
           - dependency-type: "all"
+      ignore:
+          # v1 is an API-breaking rewrite (glob.Glob is gone). Lift once OPA ships the migration
+          # from open-policy-agent/opa#9116, which is merged upstream but not released yet.
+          - dependency-name: "github.com/gobwas/glob"
+            versions: [">= 1.0.0"]
       directories:
           - "/v3/m*"
           - "/v3/n*"
@@ -220,6 +230,11 @@ updates:
       open-pull-requests-limit: 20
       allow:
           - dependency-type: "all"
+      ignore:
+          # v1 is an API-breaking rewrite (glob.Glob is gone). Lift once OPA ships the migration
+          # from open-policy-agent/opa#9116, which is merged upstream but not released yet.
+          - dependency-name: "github.com/gobwas/glob"
+            versions: [">= 1.0.0"]
       directories:
           - "/v3/s*"
           - "/v3/t*"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,4 +32,6 @@ jobs:
     uses: gofiber/.github/.github/workflows/go-lint-multi.yml@main
     with:
       module-dir: v3
+      # v2.6.2 ships x/tools v0.38.0, which cannot decode Go 1.27 export data.
+      golangci-lint-version: "v2.13.2"
       golangci-lint-args: "--tests=false --timeout=5m"

--- a/.github/workflows/test-coraza.yml
+++ b/.github/workflows/test-coraza.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.26.x
+          # jsonschema (via coraza) needs Go 1.27, so 1.26 cannot build this module.
           - 1.27.x
     steps:
       - name: Fetch Repository


### PR DESCRIPTION
Unblocks the two dependabot PRs that are currently red, #2263 and #2268.

## golangci-lint v2.6.2 -> v2.13.2

v2.6.2 pins `golang.org/x/tools` v0.38.0, whose `pkgbits` decoder supports export data up to V2. Go 1.25 and 1.26 emit V2, Go 1.27 emits V4, so any module on Go 1.27 fails the lint job with:

```
cannot decode "internal/goarch", export data version 4 is greater than maximum supported version 2
```

x/tools v0.44.0 and later know V3 and V4, which first lands in golangci-lint v2.12.2.

Verified locally against `v3/coraza` on Go 1.27.0: v2.6.2 reproduces the error exactly, v2.13.2 reports `0 issues`. v2.13.2 was also run over all 24 `v3` modules, all clean, so the version jump brings no new findings.

## coraza test matrix

`kaptinlin/jsonschema` 0.9.9 moved to the stdlib JSON v2 API and requires Go 1.27, which raises the `go` directive of `v3/coraza` in #2263. The 1.26 matrix entry can then never build the module because the workflow runs with `GOTOOLCHAIN=local`, so it is dropped. Every other module stays on Go 1.25 and keeps the 1.26/1.27 matrix.

Verified: `v3/coraza` with jsonschema 0.9.9 builds and tests clean on Go 1.27.0.

## gobwas/glob ignore

glob v1.0.0 is an API-breaking rewrite that replaced the `glob.Glob` interface with a concrete `*glob.Pattern` while keeping the module path, so a transitive upgrade breaks the OPA build. Nothing in this repo imports glob, it is only an indirect dependency of OPA.

OPA merged the migration in open-policy-agent/opa#9116, but the latest release v1.20.2 still requires glob v0.2.3. The ignore holds glob at v0 until an OPA release ships the fix, at which point it can be dropped.
