### PR TITLE
⚡ perf(websocket): coalesce pipelined writes, pooled ReadMessage, Socket.IO heartbeat defaults

### DIFF
--- a/v3/websocket/README.md
+++ b/v3/websocket/README.md
@@ -36,7 +36,7 @@ func New(handler func(*websocket.Conn), config ...websocket.Config) fiber.Handle
 | Property            | Type                         | Description                                                                                                                   | Default                |
 |:--------------------|:-----------------------------|:------------------------------------------------------------------------------------------------------------------------------|:-----------------------|
 | Next                | `func(fiber.Ctx) bool`       | Defines a function to skip this middleware when it returns true.                                                              | `nil`                  |
-| HandshakeTimeout    | `time.Duration`              | HandshakeTimeout specifies the duration for the handshake to complete.                                                        | `0` (No timeout)       |
+| HandshakeTimeout    | `time.Duration`              | Bounds sending the 101 response, which fasthttp writes once the handler chain returns. The server's `WriteTimeout`, when set, applies instead. | `0` (No timeout)       |
 | Subprotocols        | `[]string`                   | Subprotocols this server supports, in order of preference. The first entry the client also offers is negotiated.               | `nil`                  |
 | Origins             | `[]string`                   | Allowed Origins based on the Origin header, compared case-insensitively. If empty, everything is allowed.                     | `nil`                  |
 | AllowEmptyOrigin    | `bool`                       | Allows connections without an Origin header when Origins is configured. Useful for non-browser clients.                       | `false`                |

--- a/v3/websocket/README.md
+++ b/v3/websocket/README.md
@@ -45,6 +45,7 @@ func New(handler func(*websocket.Conn), config ...websocket.Config) fiber.Handle
 | WriteBufferPool     | `websocket.BufferPool`       | WriteBufferPool is a pool of buffers for write operations.                                                                    | `nil`                  |
 | EnableCompression   | `bool`                       | EnableCompression specifies if the client should attempt to negotiate per message compression (RFC 7692).                     | `false`                |
 | RecoverHandler      | `func(*websocket.Conn)`      | RecoverHandler is a panic handler function that recovers from panics.                                                         | `defaultRecover`       |
+| CoalesceWrites      | `bool`                       | Answers a burst of pipelined frames with one write instead of one per frame. See [Write coalescing](#write-coalescing).      | `false`                |
 
 ## Example
 
@@ -125,6 +126,52 @@ there:
 Rejected handshakes also carry `Sec-WebSocket-Version: 13` so a client that asked for
 another version learns which one the server speaks (RFC 6455 section 4.4). Headers set
 by earlier middleware are left in place.
+
+## Write coalescing
+
+`fasthttp/websocket` puts every frame on the wire with its own write syscall. When a peer
+pipelines frames, sending several before it waits for the replies, the server reads them
+all in one go but still answers them one packet at a time. With `CoalesceWrites: true`
+the replies to such a burst leave in a single write instead.
+
+The rule is narrow so that nothing else changes:
+
+- A write is held back only while the handler is still working through frames the peer
+  already sent, that is between one read that delivered input and the next.
+- What is held leaves the moment the handler asks for the next frame, on `Close`, when it
+  reaches 64 KiB, or after one millisecond, whichever comes first.
+- A write made while nothing is waiting to be read goes out immediately. A handler that
+  only pushes, or a goroutine writing while the reader is parked on the socket, is not
+  delayed at all.
+- Frames are never reordered: a frame that does not fit is written after what was pending.
+
+What it costs and buys, measured with 5-byte frames on a server pinned to one core with
+`GOMAXPROCS=1`, the shape of one prefork child under the
+[HttpArena](https://github.com/MDA2AV/HttpArena) `echo-ws` profiles:
+
+| workload                          | default            | `CoalesceWrites`   |
+|:----------------------------------|:-------------------|:-------------------|
+| 1 frame in flight, 8 connections  | 12.6 µs CPU/frame  | unchanged, within run-to-run noise |
+| 16 frames in flight, 8 connections | 5.7 µs CPU/frame  | 1.0 µs CPU/frame   |
+| 16 frames in flight, 64 connections | 5.7 µs CPU/frame | 0.8 µs CPU/frame   |
+| syscalls per frame, 16 in flight  | 1.06               | 0.13               |
+
+A held frame costs one extra copy into the pending buffer, and an idle connection holds no
+pending buffer at all.
+
+The library only ever sees a `net.Conn`, so coalescing means owning it. With the option on,
+the upgrade runs through the library's `net/http` `Upgrader` on a fasthttp-backed hijack
+instead of `FastHTTPUpgrader`. Three things follow:
+
+- The `101 Switching Protocols` response carries the handshake headers and whatever earlier
+  middleware set (a cookie, a request id), but not fasthttp's `Server` and `Date` defaults.
+- `Sec-WebSocket-Key` is validated as RFC 6455 asks, a base64 encoding of 16 bytes; the
+  fasthttp upgrader only checks that it is present.
+- A message larger than the write buffer, which the library hands to the socket as two
+  writes, leaves as one when it is held back with the rest of a batch.
+
+Everything else, `Locals`, `Params`, `Query`, `Cookies`, `Headers`, `IP`, the rejection
+statuses, compression, subprotocols and `RecoverHandler`, behaves the same.
 
 ## Note with cache middleware
 

--- a/v3/websocket/README.md
+++ b/v3/websocket/README.md
@@ -45,7 +45,6 @@ func New(handler func(*websocket.Conn), config ...websocket.Config) fiber.Handle
 | WriteBufferPool     | `websocket.BufferPool`       | WriteBufferPool is a pool of buffers for write operations.                                                                    | `nil`                  |
 | EnableCompression   | `bool`                       | EnableCompression specifies if the client should attempt to negotiate per message compression (RFC 7692).                     | `false`                |
 | RecoverHandler      | `func(*websocket.Conn)`      | RecoverHandler is a panic handler function that recovers from panics.                                                         | `defaultRecover`       |
-| CoalesceWrites      | `bool`                       | Answers a burst of pipelined frames with one write. See [Write coalescing](#write-coalescing).                              | `false`                |
 
 ## Example
 
@@ -127,20 +126,21 @@ Rejected handshakes also carry `Sec-WebSocket-Version: 13` so a client that aske
 another version learns which one the server speaks (RFC 6455 section 4.4). Headers set
 by earlier middleware are left in place.
 
-## Write coalescing
+## Reads and writes
 
-`CoalesceWrites: true` answers a burst of pipelined frames with one write instead of one
-per frame: writes made while the handler still has unread frames wait until it asks for the
-next one, at most 64 KiB or 1 ms. Writes made while nothing is waiting to be read go out
-immediately, so push-only handlers are unaffected, and frames are never reordered.
+`c.ReadMessage()` reads into a pooled buffer and returns an exact-size copy, where the
+library's `ReadMessage` grows a fresh buffer per message; for zero-copy reads use
+`NextReader` with your own buffer.
 
-With 5-byte frames and 16 in flight per connection, server CPU per frame goes from 5.7 µs to
-1.0 µs and syscalls per frame from 1.06 to 0.13; one frame in flight is unchanged.
+Replies to a burst of pipelined frames leave in one write instead of one per frame: writes
+made while the handler still has unread frames wait until it asks for the next one, at most
+64 KiB or 1 ms. Writes made while nothing is waiting to be read go out immediately, so
+push-only handlers are unaffected, and frames are never reordered. With 5-byte frames and
+16 in flight per connection, server CPU per frame goes from 5.7 µs to 1.0 µs.
 
-The upgrade then runs through the library's `net/http` `Upgrader` on a fasthttp-backed
-hijack: the 101 carries the handshake headers and what earlier middleware set but not
-fasthttp's `Server` and `Date` defaults, and `Sec-WebSocket-Key` is validated as RFC 6455
-requires.
+To own the connection the upgrade runs through the library's `net/http` `Upgrader` on a
+fasthttp-backed hijack: the 101 carries the handshake headers and what earlier middleware
+set, but not fasthttp's `Date`, and `Sec-WebSocket-Key` is validated as RFC 6455 requires.
 
 ## Note with cache middleware
 

--- a/v3/websocket/README.md
+++ b/v3/websocket/README.md
@@ -45,7 +45,7 @@ func New(handler func(*websocket.Conn), config ...websocket.Config) fiber.Handle
 | WriteBufferPool     | `websocket.BufferPool`       | WriteBufferPool is a pool of buffers for write operations.                                                                    | `nil`                  |
 | EnableCompression   | `bool`                       | EnableCompression specifies if the client should attempt to negotiate per message compression (RFC 7692).                     | `false`                |
 | RecoverHandler      | `func(*websocket.Conn)`      | RecoverHandler is a panic handler function that recovers from panics.                                                         | `defaultRecover`       |
-| CoalesceWrites      | `bool`                       | Answers a burst of pipelined frames with one write instead of one per frame. See [Write coalescing](#write-coalescing).      | `false`                |
+| CoalesceWrites      | `bool`                       | Answers a burst of pipelined frames with one write. See [Write coalescing](#write-coalescing).                              | `false`                |
 
 ## Example
 
@@ -129,49 +129,18 @@ by earlier middleware are left in place.
 
 ## Write coalescing
 
-`fasthttp/websocket` puts every frame on the wire with its own write syscall. When a peer
-pipelines frames, sending several before it waits for the replies, the server reads them
-all in one go but still answers them one packet at a time. With `CoalesceWrites: true`
-the replies to such a burst leave in a single write instead.
+`CoalesceWrites: true` answers a burst of pipelined frames with one write instead of one
+per frame: writes made while the handler still has unread frames wait until it asks for the
+next one, at most 64 KiB or 1 ms. Writes made while nothing is waiting to be read go out
+immediately, so push-only handlers are unaffected, and frames are never reordered.
 
-The rule is narrow so that nothing else changes:
+With 5-byte frames and 16 in flight per connection, server CPU per frame goes from 5.7 µs to
+1.0 µs and syscalls per frame from 1.06 to 0.13; one frame in flight is unchanged.
 
-- A write is held back only while the handler is still working through frames the peer
-  already sent, that is between one read that delivered input and the next.
-- What is held leaves the moment the handler asks for the next frame, on `Close`, when it
-  reaches 64 KiB, or after one millisecond, whichever comes first.
-- A write made while nothing is waiting to be read goes out immediately. A handler that
-  only pushes, or a goroutine writing while the reader is parked on the socket, is not
-  delayed at all.
-- Frames are never reordered: a frame that does not fit is written after what was pending.
-
-What it costs and buys, measured with 5-byte frames on a server pinned to one core with
-`GOMAXPROCS=1`, the shape of one prefork child under the
-[HttpArena](https://github.com/MDA2AV/HttpArena) `echo-ws` profiles:
-
-| workload                          | default            | `CoalesceWrites`   |
-|:----------------------------------|:-------------------|:-------------------|
-| 1 frame in flight, 8 connections  | 12.6 µs CPU/frame  | unchanged, within run-to-run noise |
-| 16 frames in flight, 8 connections | 5.7 µs CPU/frame  | 1.0 µs CPU/frame   |
-| 16 frames in flight, 64 connections | 5.7 µs CPU/frame | 0.8 µs CPU/frame   |
-| syscalls per frame, 16 in flight  | 1.06               | 0.13               |
-
-A held frame costs one extra copy into the pending buffer, and an idle connection holds no
-pending buffer at all.
-
-The library only ever sees a `net.Conn`, so coalescing means owning it. With the option on,
-the upgrade runs through the library's `net/http` `Upgrader` on a fasthttp-backed hijack
-instead of `FastHTTPUpgrader`. Three things follow:
-
-- The `101 Switching Protocols` response carries the handshake headers and whatever earlier
-  middleware set (a cookie, a request id), but not fasthttp's `Server` and `Date` defaults.
-- `Sec-WebSocket-Key` is validated as RFC 6455 asks, a base64 encoding of 16 bytes; the
-  fasthttp upgrader only checks that it is present.
-- A message larger than the write buffer, which the library hands to the socket as two
-  writes, leaves as one when it is held back with the rest of a batch.
-
-Everything else, `Locals`, `Params`, `Query`, `Cookies`, `Headers`, `IP`, the rejection
-statuses, compression, subprotocols and `RecoverHandler`, behaves the same.
+The upgrade then runs through the library's `net/http` `Upgrader` on a fasthttp-backed
+hijack: the 101 carries the handshake headers and what earlier middleware set but not
+fasthttp's `Server` and `Date` defaults, and `Sec-WebSocket-Key` is validated as RFC 6455
+requires.
 
 ## Note with cache middleware
 

--- a/v3/websocket/README.md
+++ b/v3/websocket/README.md
@@ -139,8 +139,11 @@ push-only handlers are unaffected, and frames are never reordered. With 5-byte f
 16 in flight per connection, server CPU per frame goes from 5.7 µs to 1.0 µs.
 
 To own the connection the upgrade runs through the library's `net/http` `Upgrader` on a
-fasthttp-backed hijack: the 101 carries the handshake headers and what earlier middleware
-set, but not fasthttp's `Date`, and `Sec-WebSocket-Key` is validated as RFC 6455 requires.
+fasthttp-backed hijack. fasthttp still sends the 101, so middleware running after `c.Next()`
+sees the status and headers and can add its own, and `Sec-WebSocket-Key` is validated as
+RFC 6455 requires. `c.NetConn()` returns the middleware's connection; its `UnsafeConn()`
+is the socket underneath. `Close` sends what is pending, waiting at most 100 ms for a peer
+that is not reading, and interrupts a write stalled on that peer.
 
 ## Note with cache middleware
 

--- a/v3/websocket/coalesce.go
+++ b/v3/websocket/coalesce.go
@@ -16,47 +16,19 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-// Write coalescing.
-//
-// fasthttp/websocket puts every frame on the wire with a write syscall of its
-// own. A peer that pipelines frames gets its replies one packet at a time, and
-// the server pays a syscall per frame however many arrived in a single read.
-// The library never batches, but it only ever talks to a net.Conn, so a
-// net.Conn the middleware owns can: hold replies while the reader is still
-// working through input it already has, and push them out in one write the
-// moment it comes back for more.
-//
-// Owning that net.Conn rules out FastHTTPUpgrader, which hijacks with
-// fasthttp's own connection. With Config.CoalesceWrites the upgrade goes
-// through the library's net/http Upgrader instead, handed a request built from
-// the fasthttp one and an http.Hijacker backed by fasthttp's Hijack, so the
-// handshake stays the library's while the connection underneath is ours.
+// Config.CoalesceWrites upgrades through the library's net/http Upgrader on a
+// fasthttp-backed Hijacker, so the middleware owns the net.Conn the library
+// writes to and can answer a burst of frames with one write.
 
 const (
-	// coalesceLimit caps what is held back. A frame that would not fit is
-	// written directly, after whatever was pending, so order holds.
-	coalesceLimit = 64 << 10
-	// coalesceMaxDelay bounds how long a reply can wait for the reader to come
-	// back. It only matters for a handler that writes and then does not read
-	// again promptly. The timer is armed at most once per delay and is left to
-	// expire, so a reply usually costs no timer operation at all.
-	coalesceMaxDelay = time.Millisecond
-	// coalesceRetain is the largest pending buffer kept between batches, so a
-	// single big burst does not pin its memory to the connection for good.
-	coalesceRetain = 16 << 10
-	// hijackBufferSize sizes the bufio pair the library is given on hijack. It
-	// is below the sizes at which the library would reuse them, so it allocates
-	// its own read and write buffers from Config exactly as the fasthttp
-	// upgrader does.
-	hijackBufferSize = 16
+	coalesceLimit    = 64 << 10         // flush once this much is pending
+	coalesceMaxDelay = time.Millisecond // flush if the reader has not returned by then
+	coalesceRetain   = 16 << 10         // largest pending buffer kept between bursts
+	hijackBufferSize = 16               // below the sizes the library would reuse
 )
 
-// errNotAttached is returned by a read before fasthttp handed the socket over,
-// which the library never attempts: during Upgrade it only writes.
 var errNotAttached = errors.New("websocket: connection not attached yet")
 
-// handshakeHeaders are the request headers the library's Upgrader looks at,
-// in the canonical form its http.Header lookups index by.
 var handshakeHeaders = [...]string{
 	http.CanonicalHeaderKey(fiber.HeaderConnection),
 	http.CanonicalHeaderKey(fiber.HeaderUpgrade),
@@ -67,26 +39,14 @@ var handshakeHeaders = [...]string{
 	http.CanonicalHeaderKey(fiber.HeaderOrigin),
 }
 
-// coalescingConn is the net.Conn handed to fasthttp/websocket when
-// Config.CoalesceWrites is set.
-//
-// A write is deferred only while batch && !parked: the reader was handed
-// input by its last fill and has not come back for more. Everything else goes
-// straight to the socket, after anything pending, so nothing is ever
-// reordered and a handler that only pushes never waits. Deferred bytes leave
-// when the reader is about to block, when they pass coalesceLimit, on Close,
-// or after coalesceMaxDelay, whichever comes first.
+// coalescingConn defers a write only while batch && !parked: the reader was
+// handed input by its last fill and has not come back for more. Pending bytes
+// leave before a blocking read, at coalesceLimit, on Close, or after
+// coalesceMaxDelay.
 type coalescingConn struct {
-	// src is fasthttp's hijacked connection. It owns whatever fasthttp buffered
-	// past the upgrade request, so every read goes through it.
-	src net.Conn
-	// raw is the socket underneath src. Writes, deadlines and addresses go to
-	// it directly; src adds only the read buffer and a Close that also returns
-	// fasthttp's pooled wrapper. Nil until attach.
-	raw net.Conn
+	src net.Conn // fasthttp's hijacked conn: reads, and the Close fasthttp expects
+	raw net.Conn // the socket: writes, deadlines, addresses; nil until attach
 
-	// batch: the last fill handed the reader input it may still be handling.
-	// parked: the reader is blocked waiting for the peer.
 	batch  atomic.Bool
 	parked atomic.Bool
 
@@ -96,21 +56,17 @@ type coalescingConn struct {
 	maxDelay time.Duration
 	armed    bool
 	closed   bool
-	err      error // first write failure, sticky
+	err      error
 }
 
 func newCoalescingConn() *coalescingConn {
 	return &coalescingConn{maxDelay: coalesceMaxDelay}
 }
 
-// attach binds the connection fasthttp handed over and sends what the library
-// wrote during the handshake, the 101 response, under the handshake deadline
-// when there is one.
+// attach binds the hijacked conn and sends the 101 the library wrote meanwhile.
 func (c *coalescingConn) attach(src net.Conn, handshakeTimeout time.Duration) error {
 	raw := src
 	if u, ok := src.(interface{ UnsafeConn() net.Conn }); ok {
-		// Reads must stay on src, which may hold bytes fasthttp buffered past the
-		// request; writes can go to the socket itself.
 		raw = u.UnsafeConn()
 	}
 	c.mu.Lock()
@@ -130,9 +86,6 @@ func (c *coalescingConn) attach(src net.Conn, handshakeTimeout time.Duration) er
 	return nil
 }
 
-// Read refills the library's buffer. The library asks only once it has handled
-// everything it already read, so every reply owed so far leaves first, in one
-// write, and then the reader waits for the peer.
 func (c *coalescingConn) Read(p []byte) (int, error) {
 	if c.src == nil {
 		return 0, errNotAttached
@@ -153,9 +106,6 @@ func (c *coalescingConn) Read(p []byte) (int, error) {
 	return n, err
 }
 
-// Write holds a reply back while the reader still has input to handle and
-// writes it through otherwise. Before attach only the handshake response comes
-// through, and attach sends it.
 func (c *coalescingConn) Write(p []byte) (int, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -182,9 +132,7 @@ func (c *coalescingConn) Write(p []byte) (int, error) {
 	return n, err
 }
 
-// arm starts the safety timer for the bytes just deferred. It is never
-// stopped early: expiring with nothing pending is a no-op, and not touching it
-// on every flush keeps the per-reply cost to a copy. Caller holds mu.
+// arm starts the safety timer; it is left to expire rather than stopped per flush.
 func (c *coalescingConn) arm() {
 	if c.timer == nil {
 		c.timer = time.AfterFunc(c.maxDelay, c.onTimer)
@@ -194,8 +142,6 @@ func (c *coalescingConn) arm() {
 	c.armed = true
 }
 
-// onTimer sends whatever a reader that did not come back left pending, and
-// stops deferring until the next fill proves the reader is still consuming.
 func (c *coalescingConn) onTimer() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -207,7 +153,6 @@ func (c *coalescingConn) onTimer() {
 	_ = c.flushLocked()
 }
 
-// flushLocked writes everything pending in one syscall. Caller holds mu.
 func (c *coalescingConn) flushLocked() error {
 	if len(c.pending) == 0 {
 		return nil
@@ -224,8 +169,6 @@ func (c *coalescingConn) flushLocked() error {
 	return err
 }
 
-// Close sends what is pending and closes the hijacked connection. A second
-// Close is a no-op: fasthttp recycles its hijacked connection on the first.
 func (c *coalescingConn) Close() error {
 	c.mu.Lock()
 	if c.closed {
@@ -263,10 +206,6 @@ func (c *coalescingConn) RemoteAddr() net.Addr {
 	return c.raw.RemoteAddr()
 }
 
-// The deadline setters are no-ops before attach: fasthttp clears every
-// deadline before it hands the socket over, and attach applies the handshake
-// timeout itself.
-
 func (c *coalescingConn) SetDeadline(t time.Time) error {
 	if c.raw == nil {
 		return nil
@@ -288,9 +227,8 @@ func (c *coalescingConn) SetWriteDeadline(t time.Time) error {
 	return c.raw.SetWriteDeadline(t)
 }
 
-// upgradeResponseWriter is the http.ResponseWriter handed to the library's
-// net/http Upgrader. It never writes a response: a rejected handshake records
-// its status for Fiber to answer, an accepted one is hijacked into conn.
+// upgradeResponseWriter never writes: a rejection records its status for
+// Fiber to answer, an accepted handshake is hijacked into conn.
 type upgradeResponseWriter struct {
 	conn   *coalescingConn
 	header http.Header
@@ -310,17 +248,11 @@ func (w *upgradeResponseWriter) Write([]byte) (int, error) {
 
 func (w *upgradeResponseWriter) WriteHeader(int) {}
 
-// Hijack hands the library the coalescing connection. The bufio pair is sized
-// below what the library would reuse, so it allocates its own buffers from
-// Config, exactly as the fasthttp upgrader does.
 func (w *upgradeResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	rw := bufio.NewReadWriter(bufio.NewReaderSize(w.conn, hijackBufferSize), bufio.NewWriterSize(w.conn, hijackBufferSize))
 	return w.conn, rw, nil
 }
 
-// upgradeRequest builds the http.Request the library validates: the method and
-// the handshake headers. Values are copied; the subprotocol the library selects
-// lives on the connection for as long as it does.
 func upgradeRequest(fctx *fasthttp.RequestCtx) *http.Request {
 	h := &fctx.Request.Header
 	header := make(http.Header, len(handshakeHeaders))
@@ -336,14 +268,9 @@ func upgradeRequest(fctx *fasthttp.RequestCtx) *http.Request {
 	return &http.Request{Method: method, Header: header}
 }
 
-// upgradeResponseHeader carries what earlier middleware set on the response, a
-// cookie or a CORS header, into the 101 the library writes. fasthttp's own
-// defaults and the handshake headers the library sets itself are left out.
-//
-// The subprotocol is negotiated here rather than by the library: its net/http
-// upgrader prefers the client's order, the fasthttp one and this middleware's
-// documentation the server's. The library takes the choice from the header,
-// which is how it treats a subprotocol chosen by the application.
+// upgradeResponseHeader forwards what earlier middleware set and negotiates
+// the subprotocol in server-preference order, which the net/http upgrader
+// would not.
 func upgradeResponseHeader(fctx *fasthttp.RequestCtx, subprotocols []string) http.Header {
 	var header http.Header
 	for key, value := range fctx.Response.Header.All() {
@@ -371,8 +298,6 @@ func upgradeResponseHeader(fctx *fasthttp.RequestCtx, subprotocols []string) htt
 	return header
 }
 
-// selectSubprotocol returns the first server subprotocol the client offered,
-// or "" when none matches (RFC 6455 section 4.2.2).
 func selectSubprotocol(offered []byte, subprotocols []string) string {
 	for _, serverProtocol := range subprotocols {
 		for clientProtocol := range strings.SplitSeq(utils.UnsafeString(offered), ",") {
@@ -384,21 +309,14 @@ func selectSubprotocol(offered []byte, subprotocols []string) string {
 	return ""
 }
 
-// newCoalescingUpgrader configures the library's net/http Upgrader from cfg.
-// HandshakeTimeout is not passed on: the 101 is written once fasthttp hands
-// the socket over, and attach applies the timeout to that write.
 func newCoalescingUpgrader(cfg *Config, originAllowed func(origin string) bool) websocket.Upgrader {
 	return websocket.Upgrader{
-		// Subprotocols stay nil: upgradeResponseHeader negotiates them.
 		ReadBufferSize:    cfg.ReadBufferSize,
 		WriteBufferSize:   cfg.WriteBufferSize,
 		WriteBufferPool:   cfg.WriteBufferPool,
 		EnableCompression: cfg.EnableCompression,
 		Error: func(w http.ResponseWriter, _ *http.Request, status int, _ error) {
-			// The net/http upgrader answers a Connection header without its
-			// Upgrade counterpart with 426; keep the 400 documented for a partial
-			// handshake, which is also what the fasthttp upgrader sends.
-			if status == fiber.StatusUpgradeRequired {
+			if status == fiber.StatusUpgradeRequired { // partial handshake: 400, as documented
 				status = fiber.StatusBadRequest
 			}
 			if uw, ok := w.(*upgradeResponseWriter); ok {
@@ -406,13 +324,11 @@ func newCoalescingUpgrader(cfg *Config, originAllowed func(origin string) bool) 
 			}
 		},
 		CheckOrigin: func(r *http.Request) bool {
-			return originAllowed(r.Header.Get(fiber.HeaderOrigin)) // Get canonicalizes the key
+			return originAllowed(r.Header.Get(fiber.HeaderOrigin))
 		},
 	}
 }
 
-// upgradeCoalescing performs the handshake through the library's net/http
-// Upgrader and hijacks the fasthttp connection into a coalescingConn.
 func upgradeCoalescing(c fiber.Ctx, upgrader *websocket.Upgrader, conn *Conn, cfg *Config, handler func(*Conn)) error {
 	fctx := c.RequestCtx()
 	cc := newCoalescingConn()
@@ -425,9 +341,7 @@ func upgradeCoalescing(c fiber.Ctx, upgrader *websocket.Upgrader, conn *Conn, cf
 		fctx.SetStatusCode(w.status)
 		return rejectHandshake(c, w.status)
 	}
-	// The library has already written the 101 into cc, where attach sends it;
-	// fasthttp must not add a response of its own.
-	fctx.HijackSetNoResponse(true)
+	fctx.HijackSetNoResponse(true) // the 101 is already in cc; attach sends it
 	fctx.Hijack(func(netConn net.Conn) {
 		if err := cc.attach(netConn, cfg.HandshakeTimeout); err != nil {
 			_ = cc.Close()

--- a/v3/websocket/coalesce.go
+++ b/v3/websocket/coalesce.go
@@ -1,0 +1,439 @@
+package websocket
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/fasthttp/websocket"
+	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/utils/v2"
+	"github.com/valyala/fasthttp"
+)
+
+// Write coalescing.
+//
+// fasthttp/websocket puts every frame on the wire with a write syscall of its
+// own. A peer that pipelines frames gets its replies one packet at a time, and
+// the server pays a syscall per frame however many arrived in a single read.
+// The library never batches, but it only ever talks to a net.Conn, so a
+// net.Conn the middleware owns can: hold replies while the reader is still
+// working through input it already has, and push them out in one write the
+// moment it comes back for more.
+//
+// Owning that net.Conn rules out FastHTTPUpgrader, which hijacks with
+// fasthttp's own connection. With Config.CoalesceWrites the upgrade goes
+// through the library's net/http Upgrader instead, handed a request built from
+// the fasthttp one and an http.Hijacker backed by fasthttp's Hijack, so the
+// handshake stays the library's while the connection underneath is ours.
+
+const (
+	// coalesceLimit caps what is held back. A frame that would not fit is
+	// written directly, after whatever was pending, so order holds.
+	coalesceLimit = 64 << 10
+	// coalesceMaxDelay bounds how long a reply can wait for the reader to come
+	// back. It only matters for a handler that writes and then does not read
+	// again promptly. The timer is armed at most once per delay and is left to
+	// expire, so a reply usually costs no timer operation at all.
+	coalesceMaxDelay = time.Millisecond
+	// coalesceRetain is the largest pending buffer kept between batches, so a
+	// single big burst does not pin its memory to the connection for good.
+	coalesceRetain = 16 << 10
+	// hijackBufferSize sizes the bufio pair the library is given on hijack. It
+	// is below the sizes at which the library would reuse them, so it allocates
+	// its own read and write buffers from Config exactly as the fasthttp
+	// upgrader does.
+	hijackBufferSize = 16
+)
+
+// errNotAttached is returned by a read before fasthttp handed the socket over,
+// which the library never attempts: during Upgrade it only writes.
+var errNotAttached = errors.New("websocket: connection not attached yet")
+
+// handshakeHeaders are the request headers the library's Upgrader looks at,
+// in the canonical form its http.Header lookups index by.
+var handshakeHeaders = [...]string{
+	http.CanonicalHeaderKey(fiber.HeaderConnection),
+	http.CanonicalHeaderKey(fiber.HeaderUpgrade),
+	http.CanonicalHeaderKey(fiber.HeaderSecWebSocketVersion),
+	http.CanonicalHeaderKey(fiber.HeaderSecWebSocketKey),
+	http.CanonicalHeaderKey(fiber.HeaderSecWebSocketExtensions),
+	http.CanonicalHeaderKey(fiber.HeaderSecWebSocketProtocol),
+	http.CanonicalHeaderKey(fiber.HeaderOrigin),
+}
+
+// coalescingConn is the net.Conn handed to fasthttp/websocket when
+// Config.CoalesceWrites is set.
+//
+// A write is deferred only while batch && !parked: the reader was handed
+// input by its last fill and has not come back for more. Everything else goes
+// straight to the socket, after anything pending, so nothing is ever
+// reordered and a handler that only pushes never waits. Deferred bytes leave
+// when the reader is about to block, when they pass coalesceLimit, on Close,
+// or after coalesceMaxDelay, whichever comes first.
+type coalescingConn struct {
+	// src is fasthttp's hijacked connection. It owns whatever fasthttp buffered
+	// past the upgrade request, so every read goes through it.
+	src net.Conn
+	// raw is the socket underneath src. Writes, deadlines and addresses go to
+	// it directly; src adds only the read buffer and a Close that also returns
+	// fasthttp's pooled wrapper. Nil until attach.
+	raw net.Conn
+
+	// batch: the last fill handed the reader input it may still be handling.
+	// parked: the reader is blocked waiting for the peer.
+	batch  atomic.Bool
+	parked atomic.Bool
+
+	mu       sync.Mutex
+	pending  []byte
+	timer    *time.Timer
+	maxDelay time.Duration
+	armed    bool
+	closed   bool
+	err      error // first write failure, sticky
+}
+
+func newCoalescingConn() *coalescingConn {
+	return &coalescingConn{maxDelay: coalesceMaxDelay}
+}
+
+// attach binds the connection fasthttp handed over and sends what the library
+// wrote during the handshake, the 101 response, under the handshake deadline
+// when there is one.
+func (c *coalescingConn) attach(src net.Conn, handshakeTimeout time.Duration) error {
+	raw := src
+	if u, ok := src.(interface{ UnsafeConn() net.Conn }); ok {
+		// Reads must stay on src, which may hold bytes fasthttp buffered past the
+		// request; writes can go to the socket itself.
+		raw = u.UnsafeConn()
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.src, c.raw = src, raw
+	if handshakeTimeout > 0 {
+		if err := raw.SetWriteDeadline(time.Now().Add(handshakeTimeout)); err != nil {
+			return err
+		}
+	}
+	if err := c.flushLocked(); err != nil {
+		return err
+	}
+	if handshakeTimeout > 0 {
+		return raw.SetWriteDeadline(time.Time{})
+	}
+	return nil
+}
+
+// Read refills the library's buffer. The library asks only once it has handled
+// everything it already read, so every reply owed so far leaves first, in one
+// write, and then the reader waits for the peer.
+func (c *coalescingConn) Read(p []byte) (int, error) {
+	if c.src == nil {
+		return 0, errNotAttached
+	}
+	c.batch.Store(false)
+	c.mu.Lock()
+	err := c.flushLocked()
+	c.mu.Unlock()
+	if err != nil {
+		return 0, err
+	}
+	c.parked.Store(true)
+	n, err := c.src.Read(p)
+	c.parked.Store(false)
+	if n > 0 {
+		c.batch.Store(true)
+	}
+	return n, err
+}
+
+// Write holds a reply back while the reader still has input to handle and
+// writes it through otherwise. Before attach only the handshake response comes
+// through, and attach sends it.
+func (c *coalescingConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.err != nil {
+		return 0, c.err
+	}
+	if c.closed {
+		return 0, net.ErrClosed
+	}
+	if c.raw == nil || (c.batch.Load() && !c.parked.Load() && len(c.pending)+len(p) <= coalesceLimit) {
+		c.pending = append(c.pending, p...)
+		if c.raw != nil && !c.armed {
+			c.arm()
+		}
+		return len(p), nil
+	}
+	if err := c.flushLocked(); err != nil {
+		return 0, err
+	}
+	n, err := c.raw.Write(p)
+	if err != nil {
+		c.err = err
+	}
+	return n, err
+}
+
+// arm starts the safety timer for the bytes just deferred. It is never
+// stopped early: expiring with nothing pending is a no-op, and not touching it
+// on every flush keeps the per-reply cost to a copy. Caller holds mu.
+func (c *coalescingConn) arm() {
+	if c.timer == nil {
+		c.timer = time.AfterFunc(c.maxDelay, c.onTimer)
+	} else {
+		c.timer.Reset(c.maxDelay)
+	}
+	c.armed = true
+}
+
+// onTimer sends whatever a reader that did not come back left pending, and
+// stops deferring until the next fill proves the reader is still consuming.
+func (c *coalescingConn) onTimer() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.armed = false
+	if len(c.pending) == 0 {
+		return
+	}
+	c.batch.Store(false)
+	_ = c.flushLocked()
+}
+
+// flushLocked writes everything pending in one syscall. Caller holds mu.
+func (c *coalescingConn) flushLocked() error {
+	if len(c.pending) == 0 {
+		return nil
+	}
+	_, err := c.raw.Write(c.pending)
+	if cap(c.pending) > coalesceRetain {
+		c.pending = nil
+	} else {
+		c.pending = c.pending[:0]
+	}
+	if err != nil {
+		c.err = err
+	}
+	return err
+}
+
+// Close sends what is pending and closes the hijacked connection. A second
+// Close is a no-op: fasthttp recycles its hijacked connection on the first.
+func (c *coalescingConn) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	if c.raw != nil {
+		_ = c.flushLocked()
+	}
+	if c.armed {
+		c.timer.Stop()
+		c.armed = false
+	}
+	c.pending = nil
+	src := c.src
+	c.mu.Unlock()
+	if src == nil {
+		return nil
+	}
+	return src.Close()
+}
+
+func (c *coalescingConn) LocalAddr() net.Addr {
+	if c.raw == nil {
+		return nil
+	}
+	return c.raw.LocalAddr()
+}
+
+func (c *coalescingConn) RemoteAddr() net.Addr {
+	if c.raw == nil {
+		return nil
+	}
+	return c.raw.RemoteAddr()
+}
+
+// The deadline setters are no-ops before attach: fasthttp clears every
+// deadline before it hands the socket over, and attach applies the handshake
+// timeout itself.
+
+func (c *coalescingConn) SetDeadline(t time.Time) error {
+	if c.raw == nil {
+		return nil
+	}
+	return c.raw.SetDeadline(t)
+}
+
+func (c *coalescingConn) SetReadDeadline(t time.Time) error {
+	if c.raw == nil {
+		return nil
+	}
+	return c.raw.SetReadDeadline(t)
+}
+
+func (c *coalescingConn) SetWriteDeadline(t time.Time) error {
+	if c.raw == nil {
+		return nil
+	}
+	return c.raw.SetWriteDeadline(t)
+}
+
+// upgradeResponseWriter is the http.ResponseWriter handed to the library's
+// net/http Upgrader. It never writes a response: a rejected handshake records
+// its status for Fiber to answer, an accepted one is hijacked into conn.
+type upgradeResponseWriter struct {
+	conn   *coalescingConn
+	header http.Header
+	status int
+}
+
+func (w *upgradeResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = http.Header{}
+	}
+	return w.header
+}
+
+func (w *upgradeResponseWriter) Write([]byte) (int, error) {
+	return 0, http.ErrHijacked
+}
+
+func (w *upgradeResponseWriter) WriteHeader(int) {}
+
+// Hijack hands the library the coalescing connection. The bufio pair is sized
+// below what the library would reuse, so it allocates its own buffers from
+// Config, exactly as the fasthttp upgrader does.
+func (w *upgradeResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	rw := bufio.NewReadWriter(bufio.NewReaderSize(w.conn, hijackBufferSize), bufio.NewWriterSize(w.conn, hijackBufferSize))
+	return w.conn, rw, nil
+}
+
+// upgradeRequest builds the http.Request the library validates: the method and
+// the handshake headers. Values are copied; the subprotocol the library selects
+// lives on the connection for as long as it does.
+func upgradeRequest(fctx *fasthttp.RequestCtx) *http.Request {
+	h := &fctx.Request.Header
+	header := make(http.Header, len(handshakeHeaders))
+	for _, name := range handshakeHeaders {
+		if v := h.Peek(name); len(v) > 0 {
+			header[name] = []string{string(v)}
+		}
+	}
+	method := http.MethodGet
+	if !fctx.IsGet() {
+		method = string(fctx.Method())
+	}
+	return &http.Request{Method: method, Header: header}
+}
+
+// upgradeResponseHeader carries what earlier middleware set on the response, a
+// cookie or a CORS header, into the 101 the library writes. fasthttp's own
+// defaults and the handshake headers the library sets itself are left out.
+//
+// The subprotocol is negotiated here rather than by the library: its net/http
+// upgrader prefers the client's order, the fasthttp one and this middleware's
+// documentation the server's. The library takes the choice from the header,
+// which is how it treats a subprotocol chosen by the application.
+func upgradeResponseHeader(fctx *fasthttp.RequestCtx, subprotocols []string) http.Header {
+	var header http.Header
+	for key, value := range fctx.Response.Header.All() {
+		switch utils.UnsafeString(key) {
+		case fiber.HeaderContentType, fiber.HeaderContentLength, fiber.HeaderServer, fiber.HeaderDate,
+			fiber.HeaderConnection, fiber.HeaderUpgrade, fiber.HeaderSecWebSocketAccept:
+			continue
+		}
+		if header == nil {
+			header = http.Header{}
+		}
+		name := http.CanonicalHeaderKey(string(key))
+		header[name] = append(header[name], string(value))
+	}
+	if subprotocols != nil {
+		protocol := http.CanonicalHeaderKey(fiber.HeaderSecWebSocketProtocol)
+		delete(header, protocol)
+		if chosen := selectSubprotocol(fctx.Request.Header.Peek(fiber.HeaderSecWebSocketProtocol), subprotocols); chosen != "" {
+			if header == nil {
+				header = http.Header{}
+			}
+			header[protocol] = []string{chosen}
+		}
+	}
+	return header
+}
+
+// selectSubprotocol returns the first server subprotocol the client offered,
+// or "" when none matches (RFC 6455 section 4.2.2).
+func selectSubprotocol(offered []byte, subprotocols []string) string {
+	for _, serverProtocol := range subprotocols {
+		for clientProtocol := range strings.SplitSeq(utils.UnsafeString(offered), ",") {
+			if strings.TrimSpace(clientProtocol) == serverProtocol {
+				return serverProtocol
+			}
+		}
+	}
+	return ""
+}
+
+// newCoalescingUpgrader configures the library's net/http Upgrader from cfg.
+// HandshakeTimeout is not passed on: the 101 is written once fasthttp hands
+// the socket over, and attach applies the timeout to that write.
+func newCoalescingUpgrader(cfg *Config, originAllowed func(origin string) bool) websocket.Upgrader {
+	return websocket.Upgrader{
+		// Subprotocols stay nil: upgradeResponseHeader negotiates them.
+		ReadBufferSize:    cfg.ReadBufferSize,
+		WriteBufferSize:   cfg.WriteBufferSize,
+		WriteBufferPool:   cfg.WriteBufferPool,
+		EnableCompression: cfg.EnableCompression,
+		Error: func(w http.ResponseWriter, _ *http.Request, status int, _ error) {
+			// The net/http upgrader answers a Connection header without its
+			// Upgrade counterpart with 426; keep the 400 documented for a partial
+			// handshake, which is also what the fasthttp upgrader sends.
+			if status == fiber.StatusUpgradeRequired {
+				status = fiber.StatusBadRequest
+			}
+			if uw, ok := w.(*upgradeResponseWriter); ok {
+				uw.status = status
+			}
+		},
+		CheckOrigin: func(r *http.Request) bool {
+			return originAllowed(r.Header.Get(fiber.HeaderOrigin)) // Get canonicalizes the key
+		},
+	}
+}
+
+// upgradeCoalescing performs the handshake through the library's net/http
+// Upgrader and hijacks the fasthttp connection into a coalescingConn.
+func upgradeCoalescing(c fiber.Ctx, upgrader *websocket.Upgrader, conn *Conn, cfg *Config, handler func(*Conn)) error {
+	fctx := c.RequestCtx()
+	cc := newCoalescingConn()
+	w := &upgradeResponseWriter{conn: cc}
+	fconn, err := upgrader.Upgrade(w, upgradeRequest(fctx), upgradeResponseHeader(fctx, cfg.Subprotocols))
+	if err != nil {
+		if w.status == 0 {
+			w.status = fiber.StatusInternalServerError
+		}
+		fctx.SetStatusCode(w.status)
+		return rejectHandshake(c, w.status)
+	}
+	// The library has already written the 101 into cc, where attach sends it;
+	// fasthttp must not add a response of its own.
+	fctx.HijackSetNoResponse(true)
+	fctx.Hijack(func(netConn net.Conn) {
+		if err := cc.attach(netConn, cfg.HandshakeTimeout); err != nil {
+			_ = cc.Close()
+			return
+		}
+		runHandler(conn, fconn, cfg.RecoverHandler, handler)
+	})
+	return nil
+}

--- a/v3/websocket/coalesce.go
+++ b/v3/websocket/coalesce.go
@@ -26,6 +26,10 @@ const (
 	coalesceLimit    = 64 << 10               // a write that would push pending past this goes out
 	coalesceMaxDelay = time.Millisecond       // flush if the reader has not returned by then
 	closeFlushGrace  = 100 * time.Millisecond // how long Close waits to send what is pending
+	// minCoalesceFill is the smallest fill that can hold two client frames, each
+	// at least 6 bytes of header and mask; a smaller one has nothing to
+	// coalesce a reply with, so the reply goes straight out.
+	minCoalesceFill = 12
 )
 
 var handshakeHeaders = [...]string{
@@ -44,8 +48,8 @@ var hijackReadWriter = bufio.NewReadWriter(bufio.NewReaderSize(bytes.NewReader(n
 
 var scratchPool = sync.Pool{New: func() any { b := make([]byte, 4096); return &b }}
 
-// coalescingConn defers a write only while batch is set: the reader was
-// handed input by its last fill and has not come back for more. Pending bytes
+// coalescingConn defers a write only while batch is set: the reader's last
+// fill could hold more than one frame and it has not come back for more. Pending bytes
 // leave before the reader blocks, when a write would not fit, on Close, or
 // after coalesceMaxDelay.
 //
@@ -116,13 +120,11 @@ func (c *coalescingConn) Read(p []byte) (int, error) {
 	if len(c.stash) > 0 {
 		n := copy(p, c.stash)
 		c.stash = c.stash[n:]
-		c.batch.Store(true)
+		c.batch.Store(n >= minCoalesceFill)
 		return n, nil
 	}
 	n, err := c.raw.Read(p)
-	if n > 0 {
-		c.batch.Store(true)
-	}
+	c.batch.Store(n >= minCoalesceFill)
 	return n, err
 }
 

--- a/v3/websocket/coalesce.go
+++ b/v3/websocket/coalesce.go
@@ -2,32 +2,31 @@ package websocket
 
 import (
 	"bufio"
-	"errors"
+	"bytes"
+	"io"
 	"net"
 	"net/http"
-	"strings"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/fasthttp/websocket"
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
 
-// The upgrade runs through the library's net/http Upgrader on a fasthttp-backed
-// Hijacker, so the middleware owns the net.Conn the library writes to and can
-// answer a burst of pipelined frames with one write.
+// The handshake runs through the library's net/http Upgrader on a
+// fasthttp-backed Hijacker, so the middleware owns the net.Conn the library
+// writes to and can answer a burst of pipelined frames with one write.
+// fasthttp still sends the 101: the headers the library composed are mirrored
+// onto the response before the hijack, where later middleware sees them.
 
 const (
-	coalesceLimit    = 64 << 10         // flush once this much is pending
-	coalesceMaxDelay = time.Millisecond // flush if the reader has not returned by then
-	coalesceRetain   = 16 << 10         // largest pending buffer kept between bursts
-	hijackBufferSize = 16               // below the sizes the library would reuse
+	coalesceLimit    = 64 << 10               // a write that would push pending past this goes out
+	coalesceMaxDelay = time.Millisecond       // flush if the reader has not returned by then
+	closeFlushGrace  = 100 * time.Millisecond // how long Close waits to send what is pending
 )
-
-var errNotAttached = errors.New("websocket: connection not attached yet")
 
 var handshakeHeaders = [...]string{
 	http.CanonicalHeaderKey(fiber.HeaderConnection),
@@ -39,16 +38,25 @@ var handshakeHeaders = [...]string{
 	http.CanonicalHeaderKey(fiber.HeaderOrigin),
 }
 
-// coalescingConn defers a write only while batch && !parked: the reader was
-// handed input by its last fill and has not come back for more. Pending bytes
-// leave before a blocking read, at coalesceLimit, on Close, or after
-// coalesceMaxDelay.
-type coalescingConn struct {
-	src net.Conn // fasthttp's hijacked conn: reads, and the Close fasthttp expects
-	raw net.Conn // the socket: writes, deadlines, addresses; nil until attach
+// hijackReadWriter is handed to the library on hijack. It only inspects the
+// pair and, at these sizes, allocates its own buffers from Config.
+var hijackReadWriter = bufio.NewReadWriter(bufio.NewReaderSize(bytes.NewReader(nil), 16), bufio.NewWriterSize(io.Discard, 16))
 
-	batch  atomic.Bool
-	parked atomic.Bool
+var scratchPool = sync.Pool{New: func() any { b := make([]byte, 4096); return &b }}
+
+// coalescingConn defers a write only while batch is set: the reader was
+// handed input by its last fill and has not come back for more. Pending bytes
+// leave before the reader blocks, when a write would not fit, on Close, or
+// after coalesceMaxDelay.
+//
+// mu guards pending and the flags; wmu orders socket writes and is never
+// taken under mu, so Close and the reader never wait behind a stalled writer.
+type coalescingConn struct {
+	src   net.Conn // fasthttp's hijacked conn; its Close is the one fasthttp expects
+	raw   net.Conn // the socket underneath, nil until attach
+	stash []byte   // bytes fasthttp had read past the handshake
+
+	batch atomic.Bool
 
 	mu       sync.Mutex
 	pending  []byte
@@ -57,49 +65,61 @@ type coalescingConn struct {
 	armed    bool
 	closed   bool
 	err      error
+
+	wmu sync.Mutex
 }
 
 func newCoalescingConn() *coalescingConn {
 	return &coalescingConn{maxDelay: coalesceMaxDelay}
 }
 
-// attach binds the hijacked conn and sends the 101 the library wrote meanwhile.
-func (c *coalescingConn) attach(src net.Conn, handshakeTimeout time.Duration) error {
+// takeHandshake returns what the library wrote during Upgrade, the 101 that
+// fasthttp sends instead.
+func (c *coalescingConn) takeHandshake() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	p := c.pending
+	c.pending = nil
+	return p
+}
+
+// attach binds the hijacked conn. Whatever fasthttp buffered past the
+// handshake is stashed so reads can go straight to the socket; with that
+// buffer empty the expired deadline fails before any syscall.
+func (c *coalescingConn) attach(src net.Conn) {
 	raw := src
 	if u, ok := src.(interface{ UnsafeConn() net.Conn }); ok {
 		raw = u.UnsafeConn()
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.src, c.raw = src, raw
-	if handshakeTimeout > 0 {
-		if err := raw.SetWriteDeadline(time.Now().Add(handshakeTimeout)); err != nil {
-			return err
+	_ = src.SetReadDeadline(time.Unix(1, 0))
+	scratch := scratchPool.Get().(*[]byte)
+	var stash []byte
+	for {
+		n, err := src.Read(*scratch)
+		stash = append(stash, (*scratch)[:n]...)
+		if err != nil {
+			break
 		}
 	}
-	if err := c.flushLocked(); err != nil {
-		return err
-	}
-	if handshakeTimeout > 0 {
-		return raw.SetWriteDeadline(time.Time{})
-	}
-	return nil
+	scratchPool.Put(scratch)
+	_ = raw.SetReadDeadline(time.Time{})
+	c.mu.Lock()
+	c.src, c.raw, c.stash = src, raw, stash
+	c.mu.Unlock()
 }
 
 func (c *coalescingConn) Read(p []byte) (int, error) {
-	if c.src == nil {
-		return 0, errNotAttached
-	}
 	c.batch.Store(false)
-	c.mu.Lock()
-	err := c.flushLocked()
-	c.mu.Unlock()
-	if err != nil {
+	if err := c.flush(); err != nil {
 		return 0, err
 	}
-	c.parked.Store(true)
-	n, err := c.src.Read(p)
-	c.parked.Store(false)
+	if len(c.stash) > 0 {
+		n := copy(p, c.stash)
+		c.stash = c.stash[n:]
+		c.batch.Store(true)
+		return n, nil
+	}
+	n, err := c.raw.Read(p)
 	if n > 0 {
 		c.batch.Store(true)
 	}
@@ -108,31 +128,110 @@ func (c *coalescingConn) Read(p []byte) (int, error) {
 
 func (c *coalescingConn) Write(p []byte) (int, error) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if c.err != nil {
-		return 0, c.err
+		err := c.err
+		c.mu.Unlock()
+		return 0, err
 	}
 	if c.closed {
+		c.mu.Unlock()
 		return 0, net.ErrClosed
 	}
-	if c.raw == nil || (c.batch.Load() && !c.parked.Load() && len(c.pending)+len(p) <= coalesceLimit) {
+	if c.raw == nil || (c.batch.Load() && len(c.pending)+len(p) <= coalesceLimit) {
 		c.pending = append(c.pending, p...)
 		if c.raw != nil && !c.armed {
 			c.arm()
 		}
+		c.mu.Unlock()
 		return len(p), nil
 	}
-	if err := c.flushLocked(); err != nil {
+	c.mu.Unlock()
+
+	c.wmu.Lock()
+	defer c.wmu.Unlock()
+	var err error
+	if pending := c.take(); len(pending) > 0 {
+		bufs := net.Buffers{pending, p} // one writev on a TCP socket
+		_, err = bufs.WriteTo(c.raw)
+		c.recycle(pending)
+	} else {
+		_, err = c.raw.Write(p)
+	}
+	if err != nil {
+		c.fail(err)
 		return 0, err
 	}
-	n, err := c.raw.Write(p)
-	if err != nil {
-		c.err = err
-	}
-	return n, err
+	_ = c.drainLocked()
+	return len(p), nil
 }
 
-// arm starts the safety timer; it is left to expire rather than stopped per flush.
+// flush sends what is pending unless a writer holds the socket, which then
+// drains it before releasing.
+func (c *coalescingConn) flush() error {
+	c.mu.Lock()
+	empty, err := len(c.pending) == 0, c.err
+	c.mu.Unlock()
+	if err != nil || empty {
+		return err
+	}
+	if !c.wmu.TryLock() {
+		return nil
+	}
+	defer c.wmu.Unlock()
+	return c.drainLocked()
+}
+
+// drainLocked writes pending until it is empty. Caller holds wmu.
+func (c *coalescingConn) drainLocked() error {
+	for {
+		pending := c.take()
+		if len(pending) == 0 {
+			return nil
+		}
+		_, err := c.raw.Write(pending)
+		c.recycle(pending)
+		if err != nil {
+			c.fail(err)
+			return err
+		}
+	}
+}
+
+// take removes the pending bytes, or returns nil when there are none or the
+// connection has already failed.
+func (c *coalescingConn) take() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.armed {
+		c.timer.Stop()
+		c.armed = false
+	}
+	if len(c.pending) == 0 || c.err != nil {
+		return nil
+	}
+	p := c.pending
+	c.pending = nil
+	return p
+}
+
+// recycle keeps a written buffer for the next batch.
+func (c *coalescingConn) recycle(p []byte) {
+	c.mu.Lock()
+	if c.pending == nil && cap(p) <= coalesceLimit {
+		c.pending = p[:0]
+	}
+	c.mu.Unlock()
+}
+
+func (c *coalescingConn) fail(err error) {
+	c.mu.Lock()
+	if c.err == nil {
+		c.err = err
+	}
+	c.mu.Unlock()
+}
+
+// arm starts the safety timer. Caller holds mu.
 func (c *coalescingConn) arm() {
 	if c.timer == nil {
 		c.timer = time.AfterFunc(c.maxDelay, c.onTimer)
@@ -142,33 +241,26 @@ func (c *coalescingConn) arm() {
 	c.armed = true
 }
 
+// onTimer sends what a reader that did not come back left pending, and stops
+// deferring until the next fill proves the reader is still consuming.
 func (c *coalescingConn) onTimer() {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.armed = false
-	if len(c.pending) == 0 {
+	empty := len(c.pending) == 0
+	if !empty {
+		c.batch.Store(false)
+	}
+	c.mu.Unlock()
+	if empty || !c.wmu.TryLock() {
 		return
 	}
-	c.batch.Store(false)
-	_ = c.flushLocked()
+	_ = c.drainLocked()
+	c.wmu.Unlock()
 }
 
-func (c *coalescingConn) flushLocked() error {
-	if len(c.pending) == 0 {
-		return nil
-	}
-	_, err := c.raw.Write(c.pending)
-	if cap(c.pending) > coalesceRetain {
-		c.pending = nil
-	} else {
-		c.pending = c.pending[:0]
-	}
-	if err != nil {
-		c.err = err
-	}
-	return err
-}
-
+// Close sends what is pending, within closeFlushGrace, and closes the socket.
+// A writer stalled on a full window is expired first so it cannot hold the
+// close up. A second Close is a no-op: fasthttp recycles its conn on the first.
 func (c *coalescingConn) Close() error {
 	c.mu.Lock()
 	if c.closed {
@@ -176,35 +268,29 @@ func (c *coalescingConn) Close() error {
 		return nil
 	}
 	c.closed = true
-	if c.raw != nil {
-		_ = c.flushLocked()
-	}
-	if c.armed {
-		c.timer.Stop()
-		c.armed = false
-	}
-	c.pending = nil
-	src := c.src
+	src, raw := c.src, c.raw
 	c.mu.Unlock()
-	if src == nil {
+	if raw == nil {
 		return nil
 	}
+	if !c.wmu.TryLock() {
+		_ = raw.SetWriteDeadline(time.Unix(1, 0))
+		c.wmu.Lock()
+	}
+	_ = raw.SetWriteDeadline(time.Now().Add(closeFlushGrace))
+	_ = c.drainLocked()
+	c.wmu.Unlock()
 	return src.Close()
 }
 
-func (c *coalescingConn) LocalAddr() net.Addr {
-	if c.raw == nil {
-		return nil
-	}
-	return c.raw.LocalAddr()
-}
+// UnsafeConn returns the socket underneath, as fasthttp's hijacked conn does.
+func (c *coalescingConn) UnsafeConn() net.Conn { return c.raw }
 
-func (c *coalescingConn) RemoteAddr() net.Addr {
-	if c.raw == nil {
-		return nil
-	}
-	return c.raw.RemoteAddr()
-}
+func (c *coalescingConn) LocalAddr() net.Addr  { return c.raw.LocalAddr() }
+func (c *coalescingConn) RemoteAddr() net.Addr { return c.raw.RemoteAddr() }
+
+// The deadline setters tolerate a nil raw: the library clears the deadlines
+// during Upgrade, before fasthttp has handed the socket over.
 
 func (c *coalescingConn) SetDeadline(t time.Time) error {
 	if c.raw == nil {
@@ -227,8 +313,8 @@ func (c *coalescingConn) SetWriteDeadline(t time.Time) error {
 	return c.raw.SetWriteDeadline(t)
 }
 
-// upgradeResponseWriter never writes: a rejection records its status for
-// Fiber to answer, an accepted handshake is hijacked into conn.
+// upgradeResponseWriter never writes a response: a rejection records its
+// status for Fiber to answer, an accepted handshake is hijacked into conn.
 type upgradeResponseWriter struct {
 	conn   *coalescingConn
 	header http.Header
@@ -242,23 +328,19 @@ func (w *upgradeResponseWriter) Header() http.Header {
 	return w.header
 }
 
-func (w *upgradeResponseWriter) Write([]byte) (int, error) {
-	return 0, http.ErrHijacked
-}
-
-func (w *upgradeResponseWriter) WriteHeader(int) {}
+func (w *upgradeResponseWriter) Write([]byte) (int, error) { return 0, http.ErrHijacked }
+func (w *upgradeResponseWriter) WriteHeader(code int)      { w.status = code }
 
 func (w *upgradeResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	rw := bufio.NewReadWriter(bufio.NewReaderSize(w.conn, hijackBufferSize), bufio.NewWriterSize(w.conn, hijackBufferSize))
-	return w.conn, rw, nil
+	return w.conn, hijackReadWriter, nil
 }
 
 func upgradeRequest(fctx *fasthttp.RequestCtx) *http.Request {
 	h := &fctx.Request.Header
 	header := make(http.Header, len(handshakeHeaders))
 	for _, name := range handshakeHeaders {
-		if v := h.Peek(name); len(v) > 0 {
-			header[name] = []string{string(v)}
+		for _, v := range h.PeekAll(name) {
+			header[name] = append(header[name], string(v))
 		}
 	}
 	method := http.MethodGet
@@ -268,45 +350,27 @@ func upgradeRequest(fctx *fasthttp.RequestCtx) *http.Request {
 	return &http.Request{Method: method, Header: header}
 }
 
-// upgradeResponseHeader forwards what earlier middleware set and negotiates
-// the subprotocol in server-preference order, which the net/http upgrader
-// would not.
-func upgradeResponseHeader(fctx *fasthttp.RequestCtx, subprotocols []string) http.Header {
-	var header http.Header
-	for key, value := range fctx.Response.Header.All() {
-		switch utils.UnsafeString(key) {
-		case fiber.HeaderContentType, fiber.HeaderContentLength, fiber.HeaderDate,
-			fiber.HeaderConnection, fiber.HeaderUpgrade, fiber.HeaderSecWebSocketAccept:
-			continue
-		}
-		if header == nil {
-			header = http.Header{}
-		}
-		name := http.CanonicalHeaderKey(string(key))
-		header[name] = append(header[name], string(value))
-	}
-	if subprotocols != nil {
-		protocol := http.CanonicalHeaderKey(fiber.HeaderSecWebSocketProtocol)
-		delete(header, protocol)
-		if chosen := selectSubprotocol(fctx.Request.Header.Peek(fiber.HeaderSecWebSocketProtocol), subprotocols); chosen != "" {
-			if header == nil {
-				header = http.Header{}
-			}
-			header[protocol] = []string{chosen}
-		}
-	}
-	return header
-}
-
-func selectSubprotocol(offered []byte, subprotocols []string) string {
-	for _, serverProtocol := range subprotocols {
-		for clientProtocol := range strings.SplitSeq(utils.UnsafeString(offered), ",") {
-			if strings.TrimSpace(clientProtocol) == serverProtocol {
-				return serverProtocol
+// subprotocolHeader hands the library the negotiated subprotocol, chosen in
+// the server's order of preference, which the library's own selection would
+// not keep. With no Subprotocols configured, one set on the response by
+// earlier middleware stands.
+func subprotocolHeader(fctx *fasthttp.RequestCtx, req *http.Request, subprotocols []string) http.Header {
+	var chosen string
+	if subprotocols == nil {
+		chosen = string(fctx.Response.Header.Peek(fiber.HeaderSecWebSocketProtocol))
+	} else {
+		offered := websocket.Subprotocols(req)
+		for _, s := range subprotocols {
+			if slices.Contains(offered, s) {
+				chosen = s
+				break
 			}
 		}
 	}
-	return ""
+	if chosen == "" {
+		return nil
+	}
+	return http.Header{http.CanonicalHeaderKey(fiber.HeaderSecWebSocketProtocol): {chosen}}
 }
 
 func newUpgrader(cfg *Config, originAllowed func(origin string) bool) websocket.Upgrader {
@@ -315,14 +379,6 @@ func newUpgrader(cfg *Config, originAllowed func(origin string) bool) websocket.
 		WriteBufferSize:   cfg.WriteBufferSize,
 		WriteBufferPool:   cfg.WriteBufferPool,
 		EnableCompression: cfg.EnableCompression,
-		Error: func(w http.ResponseWriter, _ *http.Request, status int, _ error) {
-			if status == fiber.StatusUpgradeRequired { // partial handshake: 400, as documented
-				status = fiber.StatusBadRequest
-			}
-			if uw, ok := w.(*upgradeResponseWriter); ok {
-				uw.status = status
-			}
-		},
 		CheckOrigin: func(r *http.Request) bool {
 			return originAllowed(r.Header.Get(fiber.HeaderOrigin))
 		},
@@ -331,22 +387,36 @@ func newUpgrader(cfg *Config, originAllowed func(origin string) bool) websocket.
 
 func upgrade(c fiber.Ctx, upgrader *websocket.Upgrader, conn *Conn, cfg *Config, handler func(*Conn)) error {
 	fctx := c.RequestCtx()
+	if len(fctx.Response.Header.Peek(fiber.HeaderSecWebSocketExtensions)) > 0 {
+		// Application extensions are unsupported, as on the fasthttp upgrader.
+		fctx.SetStatusCode(fiber.StatusInternalServerError)
+		return rejectHandshake(c, fiber.StatusInternalServerError)
+	}
 	cc := newCoalescingConn()
 	w := &upgradeResponseWriter{conn: cc}
-	fconn, err := upgrader.Upgrade(w, upgradeRequest(fctx), upgradeResponseHeader(fctx, cfg.Subprotocols))
+	req := upgradeRequest(fctx)
+	fconn, err := upgrader.Upgrade(w, req, subprotocolHeader(fctx, req, cfg.Subprotocols))
 	if err != nil {
-		if w.status == 0 {
-			w.status = fiber.StatusInternalServerError
+		status := w.status
+		switch status {
+		case 0:
+			status = fiber.StatusInternalServerError
+		case fiber.StatusUpgradeRequired: // a Connection header without its Upgrade counterpart: 400, as documented
+			status = fiber.StatusBadRequest
 		}
-		fctx.SetStatusCode(w.status)
-		return rejectHandshake(c, w.status)
+		fctx.SetStatusCode(status)
+		return rejectHandshake(c, status)
 	}
-	fctx.HijackSetNoResponse(true) // the 101 is already in cc; attach sends it
-	fctx.Hijack(func(netConn net.Conn) {
-		if err := cc.attach(netConn, cfg.HandshakeTimeout); err != nil {
-			_ = cc.Close()
-			return
+	// The library wrote the 101 into cc. fasthttp sends the response once the
+	// chain has unwound, so mirror those headers onto it.
+	fctx.SetStatusCode(fiber.StatusSwitchingProtocols)
+	for line := range bytes.SplitSeq(cc.takeHandshake(), []byte("\r\n")) {
+		if key, value, ok := bytes.Cut(line, []byte(": ")); ok {
+			fctx.Response.Header.SetBytesKV(key, value)
 		}
+	}
+	fctx.Hijack(func(netConn net.Conn) {
+		cc.attach(netConn)
 		runHandler(conn, fconn, cfg.RecoverHandler, handler)
 	})
 	return nil

--- a/v3/websocket/coalesce.go
+++ b/v3/websocket/coalesce.go
@@ -56,9 +56,10 @@ var scratchPool = sync.Pool{New: func() any { b := make([]byte, 4096); return &b
 // mu guards pending and the flags; wmu orders socket writes and is never
 // taken under mu, so Close and the reader never wait behind a stalled writer.
 type coalescingConn struct {
-	src   net.Conn // fasthttp's hijacked conn; its Close is the one fasthttp expects
-	raw   net.Conn // the socket underneath, nil until attach
-	stash []byte   // bytes fasthttp had read past the handshake
+	src   net.Conn  // fasthttp's hijacked conn; its Close is the one fasthttp expects
+	raw   net.Conn  // the socket underneath, nil until attach
+	rd    io.Reader // raw once fasthttp's buffer is in stash, else src
+	stash []byte    // bytes fasthttp had read past the handshake
 
 	batch atomic.Bool
 
@@ -89,26 +90,31 @@ func (c *coalescingConn) takeHandshake() []byte {
 
 // attach binds the hijacked conn. Whatever fasthttp buffered past the
 // handshake is stashed so reads can go straight to the socket; with that
-// buffer empty the expired deadline fails before any syscall.
+// buffer empty the expired deadline fails before any syscall. A conn that
+// refuses the deadline would block the drain instead, so it keeps reading
+// through fasthttp's buffer.
 func (c *coalescingConn) attach(src net.Conn) {
 	raw := src
+	var rd io.Reader = src
+	var stash []byte
 	if u, ok := src.(interface{ UnsafeConn() net.Conn }); ok {
 		raw = u.UnsafeConn()
-	}
-	_ = src.SetReadDeadline(time.Unix(1, 0))
-	scratch := scratchPool.Get().(*[]byte)
-	var stash []byte
-	for {
-		n, err := src.Read(*scratch)
-		stash = append(stash, (*scratch)[:n]...)
-		if err != nil {
-			break
+		if src.SetReadDeadline(time.Unix(1, 0)) == nil {
+			scratch := scratchPool.Get().(*[]byte)
+			for {
+				n, err := src.Read(*scratch)
+				stash = append(stash, (*scratch)[:n]...)
+				if err != nil {
+					break
+				}
+			}
+			scratchPool.Put(scratch)
+			_ = raw.SetReadDeadline(time.Time{})
+			rd = raw
 		}
 	}
-	scratchPool.Put(scratch)
-	_ = raw.SetReadDeadline(time.Time{})
 	c.mu.Lock()
-	c.src, c.raw, c.stash = src, raw, stash
+	c.src, c.raw, c.rd, c.stash = src, raw, rd, stash
 	c.mu.Unlock()
 }
 
@@ -123,7 +129,7 @@ func (c *coalescingConn) Read(p []byte) (int, error) {
 		c.batch.Store(n >= minCoalesceFill)
 		return n, nil
 	}
-	n, err := c.raw.Read(p)
+	n, err := c.rd.Read(p)
 	c.batch.Store(n >= minCoalesceFill)
 	return n, err
 }
@@ -150,7 +156,6 @@ func (c *coalescingConn) Write(p []byte) (int, error) {
 	c.mu.Unlock()
 
 	c.wmu.Lock()
-	defer c.wmu.Unlock()
 	var err error
 	if pending := c.take(); len(pending) > 0 {
 		bufs := net.Buffers{pending, p} // one writev on a TCP socket
@@ -161,9 +166,10 @@ func (c *coalescingConn) Write(p []byte) (int, error) {
 	}
 	if err != nil {
 		c.fail(err)
+		c.wmu.Unlock()
 		return 0, err
 	}
-	_ = c.drainLocked()
+	_ = c.drainAndRelease()
 	return len(p), nil
 }
 
@@ -179,21 +185,34 @@ func (c *coalescingConn) flush() error {
 	if !c.wmu.TryLock() {
 		return nil
 	}
-	defer c.wmu.Unlock()
-	return c.drainLocked()
+	return c.drainAndRelease()
 }
 
-// drainLocked writes pending until it is empty. Caller holds wmu.
-func (c *coalescingConn) drainLocked() error {
+// drainAndRelease writes pending until it is empty, then releases wmu. Caller
+// holds wmu. The release happens under mu, after the last look at pending, so
+// a write that lands later arms a timer that finds the socket free: a holder
+// never leaves bytes behind that nothing would send.
+func (c *coalescingConn) drainAndRelease() error {
 	for {
-		pending := c.take()
-		if len(pending) == 0 {
-			return nil
+		c.mu.Lock()
+		if c.armed {
+			c.timer.Stop()
+			c.armed = false
 		}
+		if len(c.pending) == 0 || c.err != nil {
+			err := c.err
+			c.wmu.Unlock()
+			c.mu.Unlock()
+			return err
+		}
+		pending := c.pending
+		c.pending = nil
+		c.mu.Unlock()
 		_, err := c.raw.Write(pending)
 		c.recycle(pending)
 		if err != nil {
 			c.fail(err)
+			c.wmu.Unlock()
 			return err
 		}
 	}
@@ -244,7 +263,8 @@ func (c *coalescingConn) arm() {
 }
 
 // onTimer sends what a reader that did not come back left pending, and stops
-// deferring until the next fill proves the reader is still consuming.
+// deferring until the next fill proves the reader is still consuming. A
+// writer that holds the socket sends it instead, before letting go.
 func (c *coalescingConn) onTimer() {
 	c.mu.Lock()
 	c.armed = false
@@ -256,13 +276,14 @@ func (c *coalescingConn) onTimer() {
 	if empty || !c.wmu.TryLock() {
 		return
 	}
-	_ = c.drainLocked()
-	c.wmu.Unlock()
+	_ = c.drainAndRelease()
 }
 
 // Close sends what is pending, within closeFlushGrace, and closes the socket.
 // A writer stalled on a full window is expired first so it cannot hold the
-// close up. A second Close is a no-op: fasthttp recycles its conn on the first.
+// close up. A conn that refuses deadlines is closed under such a writer
+// instead, and pending bytes are dropped rather than sent without a bound on
+// the wait. A second Close is a no-op.
 func (c *coalescingConn) Close() error {
 	c.mu.Lock()
 	if c.closed {
@@ -276,12 +297,16 @@ func (c *coalescingConn) Close() error {
 		return nil
 	}
 	if !c.wmu.TryLock() {
-		_ = raw.SetWriteDeadline(time.Unix(1, 0))
+		if raw.SetWriteDeadline(time.Unix(1, 0)) != nil {
+			_ = raw.Close()
+		}
 		c.wmu.Lock()
 	}
-	_ = raw.SetWriteDeadline(time.Now().Add(closeFlushGrace))
-	_ = c.drainLocked()
-	c.wmu.Unlock()
+	if raw.SetWriteDeadline(time.Now().Add(closeFlushGrace)) == nil {
+		_ = c.drainAndRelease()
+	} else {
+		c.wmu.Unlock()
+	}
 	return src.Close()
 }
 
@@ -416,6 +441,11 @@ func upgrade(c fiber.Ctx, upgrader *websocket.Upgrader, conn *Conn, cfg *Config,
 		if key, value, ok := bytes.Cut(line, []byte(": ")); ok {
 			fctx.Response.Header.SetBytesKV(key, value)
 		}
+	}
+	if netConn := fctx.Conn(); netConn != nil && cfg.HandshakeTimeout > 0 {
+		// Bounds fasthttp's write of the 101; fasthttp clears it before the
+		// hijack, and replaces it with its own when the server has a WriteTimeout.
+		_ = netConn.SetWriteDeadline(time.Now().Add(cfg.HandshakeTimeout))
 	}
 	fctx.Hijack(func(netConn net.Conn) {
 		cc.attach(netConn)

--- a/v3/websocket/coalesce.go
+++ b/v3/websocket/coalesce.go
@@ -16,9 +16,9 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-// Config.CoalesceWrites upgrades through the library's net/http Upgrader on a
-// fasthttp-backed Hijacker, so the middleware owns the net.Conn the library
-// writes to and can answer a burst of frames with one write.
+// The upgrade runs through the library's net/http Upgrader on a fasthttp-backed
+// Hijacker, so the middleware owns the net.Conn the library writes to and can
+// answer a burst of pipelined frames with one write.
 
 const (
 	coalesceLimit    = 64 << 10         // flush once this much is pending
@@ -275,7 +275,7 @@ func upgradeResponseHeader(fctx *fasthttp.RequestCtx, subprotocols []string) htt
 	var header http.Header
 	for key, value := range fctx.Response.Header.All() {
 		switch utils.UnsafeString(key) {
-		case fiber.HeaderContentType, fiber.HeaderContentLength, fiber.HeaderServer, fiber.HeaderDate,
+		case fiber.HeaderContentType, fiber.HeaderContentLength, fiber.HeaderDate,
 			fiber.HeaderConnection, fiber.HeaderUpgrade, fiber.HeaderSecWebSocketAccept:
 			continue
 		}
@@ -309,7 +309,7 @@ func selectSubprotocol(offered []byte, subprotocols []string) string {
 	return ""
 }
 
-func newCoalescingUpgrader(cfg *Config, originAllowed func(origin string) bool) websocket.Upgrader {
+func newUpgrader(cfg *Config, originAllowed func(origin string) bool) websocket.Upgrader {
 	return websocket.Upgrader{
 		ReadBufferSize:    cfg.ReadBufferSize,
 		WriteBufferSize:   cfg.WriteBufferSize,
@@ -329,7 +329,7 @@ func newCoalescingUpgrader(cfg *Config, originAllowed func(origin string) bool) 
 	}
 }
 
-func upgradeCoalescing(c fiber.Ctx, upgrader *websocket.Upgrader, conn *Conn, cfg *Config, handler func(*Conn)) error {
+func upgrade(c fiber.Ctx, upgrader *websocket.Upgrader, conn *Conn, cfg *Config, handler func(*Conn)) error {
 	fctx := c.RequestCtx()
 	cc := newCoalescingConn()
 	w := &upgradeResponseWriter{conn: cc}

--- a/v3/websocket/coalesce_test.go
+++ b/v3/websocket/coalesce_test.go
@@ -1,0 +1,553 @@
+package websocket
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fasthttp/websocket"
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scriptedConn is a net.Conn whose reads the test feeds and whose writes are
+// recorded one entry per call, which is one syscall on a real socket.
+type scriptedConn struct {
+	reads chan []byte
+
+	mu        sync.Mutex
+	writes    [][]byte
+	closed    bool
+	deadlines []time.Time
+	writeErr  error
+}
+
+func newScriptedConn() *scriptedConn {
+	return &scriptedConn{reads: make(chan []byte, 8)}
+}
+
+func (s *scriptedConn) Read(p []byte) (int, error) {
+	b, ok := <-s.reads
+	if !ok {
+		return 0, io.EOF
+	}
+	return copy(p, b), nil
+}
+
+func (s *scriptedConn) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.writeErr != nil {
+		return 0, s.writeErr
+	}
+	s.writes = append(s.writes, bytes.Clone(p))
+	return len(p), nil
+}
+
+func (s *scriptedConn) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	return nil
+}
+
+func (*scriptedConn) LocalAddr() net.Addr             { return &net.TCPAddr{} }
+func (*scriptedConn) RemoteAddr() net.Addr            { return &net.TCPAddr{} }
+func (*scriptedConn) SetDeadline(time.Time) error     { return nil }
+func (*scriptedConn) SetReadDeadline(time.Time) error { return nil }
+
+func (s *scriptedConn) SetWriteDeadline(t time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deadlines = append(s.deadlines, t)
+	return nil
+}
+
+func (s *scriptedConn) written() [][]byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.writes)
+}
+
+func (s *scriptedConn) writeCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.writes)
+}
+
+func (s *scriptedConn) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+func (s *scriptedConn) failWrites(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.writeErr = err
+}
+
+func (s *scriptedConn) writeDeadlines() []time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.deadlines)
+}
+
+// hijackedConn mimics fasthttp's hijacked connection: reads through it, and
+// UnsafeConn exposes the socket underneath.
+type hijackedConn struct {
+	*scriptedConn
+	raw *scriptedConn
+}
+
+func (h *hijackedConn) UnsafeConn() net.Conn { return h.raw }
+
+// attachedConn returns a coalescing conn attached to a scripted socket, with
+// the safety timer effectively off so tests observe only the reader-driven
+// behaviour.
+func attachedConn(t *testing.T) (*coalescingConn, *scriptedConn) {
+	t.Helper()
+	src := newScriptedConn()
+	c := newCoalescingConn()
+	c.maxDelay = time.Hour
+	require.NoError(t, c.attach(src, 0))
+	return c, src
+}
+
+// feedAndRead delivers data to the reader, which leaves it holding a batch.
+func feedAndRead(t *testing.T, c *coalescingConn, src *scriptedConn, data string) {
+	t.Helper()
+	src.reads <- []byte(data)
+	buf := make([]byte, 64)
+	n, err := c.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, data, string(buf[:n]))
+}
+
+// readInBackground parks the reader on the socket and returns a function that
+// releases it.
+func readInBackground(t *testing.T, c *coalescingConn, src *scriptedConn) func() {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 64)
+		_, _ = c.Read(buf)
+	}()
+	require.Eventually(t, c.parked.Load, time.Second, time.Millisecond)
+	return func() {
+		close(src.reads)
+		<-done
+	}
+}
+
+func TestCoalescingConnHoldsRepliesUntilReaderReturns(t *testing.T) {
+	c, src := attachedConn(t)
+	feedAndRead(t, c, src, "frame1frame2")
+
+	_, err := c.Write([]byte("reply1"))
+	require.NoError(t, err)
+	_, err = c.Write([]byte("reply2"))
+	require.NoError(t, err)
+	assert.Equal(t, 0, src.writeCount(), "replies must wait while the reader still has input")
+
+	// The reader comes back for more: everything owed leaves in one write.
+	release := readInBackground(t, c, src)
+	defer release()
+	assert.Equal(t, [][]byte{[]byte("reply1reply2")}, src.written())
+}
+
+func TestCoalescingConnWritesThroughWithoutPendingInput(t *testing.T) {
+	c, src := attachedConn(t)
+
+	// Nothing has been read: a push must not wait for a reader that may never come.
+	_, err := c.Write([]byte("push"))
+	require.NoError(t, err)
+	assert.Equal(t, [][]byte{[]byte("push")}, src.written())
+}
+
+func TestCoalescingConnWritesThroughWhileReaderParked(t *testing.T) {
+	c, src := attachedConn(t)
+	feedAndRead(t, c, src, "hello")
+	release := readInBackground(t, c, src)
+	defer release()
+
+	// The reader is waiting on the peer, so nothing would flush a deferred write.
+	_, err := c.Write([]byte("push"))
+	require.NoError(t, err)
+	assert.Equal(t, [][]byte{[]byte("push")}, src.written())
+}
+
+func TestCoalescingConnTimerFlushesWhenReaderStalls(t *testing.T) {
+	c, src := attachedConn(t)
+	c.maxDelay = 5 * time.Millisecond
+	feedAndRead(t, c, src, "hello")
+
+	_, err := c.Write([]byte("late"))
+	require.NoError(t, err)
+	assert.Eventually(t, func() bool { return src.writeCount() == 1 }, time.Second, time.Millisecond)
+
+	// A reader that did not come back is not consuming: later writes go straight through.
+	require.Eventually(t, func() bool { return !c.batch.Load() }, time.Second, time.Millisecond)
+	_, err = c.Write([]byte("next"))
+	require.NoError(t, err)
+	assert.Equal(t, [][]byte{[]byte("late"), []byte("next")}, src.written())
+}
+
+func TestCoalescingConnLargeWriteGoesDirectAfterPending(t *testing.T) {
+	c, src := attachedConn(t)
+	feedAndRead(t, c, src, "hello")
+
+	_, err := c.Write([]byte("small"))
+	require.NoError(t, err)
+	big := bytes.Repeat([]byte{'x'}, coalesceLimit)
+	_, err = c.Write(big)
+	require.NoError(t, err)
+	assert.Equal(t, [][]byte{[]byte("small"), big}, src.written(), "pending bytes leave first, then the frame that did not fit")
+}
+
+func TestCoalescingConnCloseFlushesAndIsIdempotent(t *testing.T) {
+	c, src := attachedConn(t)
+	feedAndRead(t, c, src, "hello")
+
+	_, err := c.Write([]byte("bye"))
+	require.NoError(t, err)
+	require.NoError(t, c.Close())
+	assert.Equal(t, [][]byte{[]byte("bye")}, src.written())
+	assert.True(t, src.isClosed())
+
+	require.NoError(t, c.Close())
+	_, err = c.Write([]byte("after"))
+	assert.ErrorIs(t, err, net.ErrClosed)
+}
+
+func TestCoalescingConnHandshakeWaitsForAttach(t *testing.T) {
+	c := newCoalescingConn()
+	response := []byte("HTTP/1.1 101 Switching Protocols\r\n\r\n")
+	_, err := c.Write(response)
+	require.NoError(t, err)
+
+	src := newScriptedConn()
+	require.NoError(t, c.attach(src, time.Second))
+	assert.Equal(t, [][]byte{response}, src.written())
+
+	deadlines := src.writeDeadlines()
+	require.Len(t, deadlines, 2, "the handshake timeout is set for the 101 and cleared after it")
+	assert.False(t, deadlines[0].IsZero())
+	assert.True(t, deadlines[1].IsZero())
+}
+
+func TestCoalescingConnReadBeforeAttachFails(t *testing.T) {
+	c := newCoalescingConn()
+	_, err := c.Read(make([]byte, 1))
+	assert.ErrorIs(t, err, errNotAttached)
+}
+
+func TestCoalescingConnWritesBypassHijackedReader(t *testing.T) {
+	src, raw := newScriptedConn(), newScriptedConn()
+	c := newCoalescingConn()
+	c.maxDelay = time.Hour
+	require.NoError(t, c.attach(&hijackedConn{scriptedConn: src, raw: raw}, 0))
+
+	_, err := c.Write([]byte("out"))
+	require.NoError(t, err)
+	assert.Equal(t, [][]byte{[]byte("out")}, raw.written(), "writes go to the socket underneath")
+	assert.Equal(t, 0, src.writeCount())
+
+	feedAndRead(t, c, src, "in")
+
+	require.NoError(t, c.Close())
+	assert.True(t, src.isClosed(), "closing the hijacked conn is what hands it back to fasthttp")
+}
+
+func TestCoalescingConnWriteErrorIsSticky(t *testing.T) {
+	c, src := attachedConn(t)
+	src.failWrites(errors.New("boom"))
+
+	_, err := c.Write([]byte("x"))
+	require.EqualError(t, err, "boom")
+	src.failWrites(nil)
+	_, err = c.Write([]byte("y"))
+	require.EqualError(t, err, "boom")
+}
+
+// clientFrame builds one masked client frame for a payload of up to 125 bytes.
+func clientFrame(op int, payload []byte) []byte {
+	key := [4]byte{1, 2, 3, 4}
+	f := []byte{0x80 | byte(op), 0x80 | byte(len(payload))}
+	f = append(f, key[:]...)
+	for i, b := range payload {
+		f = append(f, b^key[i&3])
+	}
+	return f
+}
+
+func TestCoalesceWritesHandshakeAndMessage(t *testing.T) {
+	app := setupTestApp(Config{CoalesceWrites: true}, nil)
+	defer app.Shutdown()
+
+	conn, resp, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
+	require.NoError(t, err)
+	defer conn.Close()
+	assert.Equal(t, fiber.StatusSwitchingProtocols, resp.StatusCode)
+	assert.Equal(t, "websocket", resp.Header.Get(fiber.HeaderUpgrade))
+
+	var msg fiber.Map
+	require.NoError(t, conn.ReadJSON(&msg))
+	assert.Equal(t, "hello websocket", msg["message"])
+}
+
+func TestCoalesceWritesPipelinedEcho(t *testing.T) {
+	app := setupTestApp(Config{CoalesceWrites: true}, func(c *Conn) {
+		defer c.Close()
+		for {
+			mt, p, err := c.ReadMessage()
+			if err != nil {
+				return
+			}
+			if err := c.WriteMessage(mt, p); err != nil {
+				return
+			}
+		}
+	})
+	defer app.Shutdown()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Sixteen frames in one write, as a pipelining peer sends them: every echo
+	// must come back, in order, and nothing may wait for a frame that never comes.
+	const frames = 16
+	var burst []byte
+	for i := range frames {
+		burst = append(burst, clientFrame(websocket.TextMessage, fmt.Appendf(nil, "frame-%02d", i))...)
+	}
+	_, err = conn.NetConn().Write(burst)
+	require.NoError(t, err)
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	for i := range frames {
+		mt, p, err := conn.ReadMessage()
+		require.NoError(t, err)
+		assert.Equal(t, websocket.TextMessage, mt)
+		assert.Equal(t, fmt.Sprintf("frame-%02d", i), string(p))
+	}
+}
+
+func TestCoalesceWritesRejectionsKeepStatuses(t *testing.T) {
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.Set("X-Request-ID", "req-1")
+		return c.Next()
+	})
+	// All rather than Get, so a POST reaches the middleware and its 405 rather
+	// than the router's.
+	app.All("/ws", New(func(*Conn) {}, Config{CoalesceWrites: true, Origins: []string{"http://allowed"}}))
+
+	full := [][2]string{
+		{fiber.HeaderConnection, "Upgrade"},
+		{fiber.HeaderUpgrade, "websocket"},
+		{fiber.HeaderSecWebSocketVersion, "13"},
+		{fiber.HeaderSecWebSocketKey, "dGhlIHNhbXBsZSBub25jZQ=="},
+	}
+	with := func(extra ...[2]string) [][2]string { return append(slices.Clone(full), extra...) }
+	cases := []struct {
+		name    string
+		method  string
+		headers [][2]string
+		status  int
+	}{
+		{"no upgrade signal", fiber.MethodGet, nil, fiber.StatusUpgradeRequired},
+		{"connection without upgrade", fiber.MethodGet, [][2]string{{fiber.HeaderConnection, "Upgrade"}}, fiber.StatusBadRequest},
+		{"upgrade without connection", fiber.MethodGet, [][2]string{{fiber.HeaderUpgrade, "websocket"}}, fiber.StatusBadRequest},
+		{"wrong protocol", fiber.MethodGet, [][2]string{{fiber.HeaderConnection, "Upgrade"}, {fiber.HeaderUpgrade, "h2c"}}, fiber.StatusBadRequest},
+		{"unsupported version", fiber.MethodGet, with([2]string{fiber.HeaderSecWebSocketVersion, "12"}), fiber.StatusBadRequest},
+		{"malformed key", fiber.MethodGet, with([2]string{fiber.HeaderOrigin, "http://allowed"}, [2]string{fiber.HeaderSecWebSocketKey, "not-base64"}), fiber.StatusBadRequest},
+		{"forbidden origin", fiber.MethodGet, with([2]string{fiber.HeaderOrigin, "http://evil"}), fiber.StatusForbidden},
+		{"not a GET", fiber.MethodPost, full, fiber.StatusMethodNotAllowed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "/ws", nil)
+			for _, h := range tc.headers {
+				req.Header.Set(h[0], h[1])
+			}
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, tc.status, resp.StatusCode)
+			assert.Equal(t, "req-1", resp.Header.Get("X-Request-ID"))
+			if tc.status != fiber.StatusUpgradeRequired {
+				assert.Equal(t, supportedVersion, resp.Header.Get(fiber.HeaderSecWebSocketVersion))
+			}
+		})
+	}
+}
+
+func TestCoalesceWritesAcceptsAllowedOrigin(t *testing.T) {
+	app := setupTestApp(Config{CoalesceWrites: true, Origins: []string{"http://localhost:3000"}}, nil)
+	defer app.Shutdown()
+
+	conn, resp, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", http.Header{
+		fiber.HeaderOrigin: []string{"HTTP://LOCALHOST:3000"},
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+	assert.Equal(t, fiber.StatusSwitchingProtocols, resp.StatusCode)
+}
+
+func TestCoalesceWritesKeepsMiddlewareResponseHeaders(t *testing.T) {
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.Set("X-Request-ID", "req-1")
+		c.Cookie(&fiber.Cookie{Name: "session", Value: "s1"})
+		return c.Next()
+	})
+	app.Get("/ws", New(func(*Conn) {}, Config{CoalesceWrites: true}))
+	listenTestApp(t, app)
+	defer app.Shutdown()
+
+	conn, resp, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws", nil)
+	require.NoError(t, err)
+	defer conn.Close()
+	assert.Equal(t, fiber.StatusSwitchingProtocols, resp.StatusCode)
+	assert.Equal(t, "req-1", resp.Header.Get("X-Request-ID"))
+	assert.Contains(t, resp.Header.Get(fiber.HeaderSetCookie), "session=s1")
+	assert.Equal(t, "websocket", resp.Header.Get(fiber.HeaderUpgrade))
+}
+
+func TestCoalesceWritesCapturesRequest(t *testing.T) {
+	app := setupTestApp(Config{CoalesceWrites: true}, func(c *Conn) {
+		_ = c.WriteJSON(fiber.Map{
+			"param":  c.Params("param1"),
+			"query":  c.Query("q"),
+			"header": c.Headers("X-Test"),
+			"cookie": c.Cookies("session"),
+			"local":  c.Locals("allowed"),
+			"ip":     c.IP(),
+		})
+	})
+	defer app.Shutdown()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message/a/b?q=1", http.Header{
+		"X-Test": []string{"v"},
+		"Cookie": []string{"session=s1"},
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	var msg fiber.Map
+	require.NoError(t, conn.ReadJSON(&msg))
+	assert.Equal(t, "a", msg["param"])
+	assert.Equal(t, "1", msg["query"])
+	assert.Equal(t, "v", msg["header"])
+	assert.Equal(t, "s1", msg["cookie"])
+	assert.Equal(t, true, msg["local"])
+	assert.Equal(t, "127.0.0.1", msg["ip"])
+}
+
+func TestCoalesceWritesCompression(t *testing.T) {
+	app := setupTestApp(Config{CoalesceWrites: true, EnableCompression: true}, func(c *Conn) {
+		c.EnableWriteCompression(true)
+		_ = c.WriteJSON(fiber.Map{"message": "hello websocket"})
+	})
+	defer app.Shutdown()
+
+	dialer := websocket.Dialer{EnableCompression: true}
+	conn, resp, err := dialer.Dial("ws://localhost:3000/ws/message", nil)
+	require.NoError(t, err)
+	defer conn.Close()
+	assert.Contains(t, resp.Header.Get(fiber.HeaderSecWebSocketExtensions), "permessage-deflate")
+
+	var msg fiber.Map
+	require.NoError(t, conn.ReadJSON(&msg))
+	assert.Equal(t, "hello websocket", msg["message"])
+}
+
+func TestCoalesceWritesSubprotocol(t *testing.T) {
+	app := setupTestApp(Config{CoalesceWrites: true, Subprotocols: []string{"chat", "json"}}, func(c *Conn) {
+		_ = c.WriteMessage(websocket.TextMessage, []byte(c.Subprotocol()))
+	})
+	defer app.Shutdown()
+
+	dialer := websocket.Dialer{Subprotocols: []string{"json", "chat"}}
+	conn, resp, err := dialer.Dial("ws://localhost:3000/ws/message", nil)
+	require.NoError(t, err)
+	defer conn.Close()
+	assert.Equal(t, "chat", resp.Header.Get(fiber.HeaderSecWebSocketProtocol))
+
+	_, p, err := conn.ReadMessage()
+	require.NoError(t, err)
+	assert.Equal(t, "chat", string(p))
+}
+
+func TestCoalesceWritesPanicClosesConnection(t *testing.T) {
+	app := setupTestApp(Config{CoalesceWrites: true}, func(*Conn) {
+		panic("test panic")
+	})
+	defer app.Shutdown()
+
+	conn, resp, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
+	require.NoError(t, err)
+	defer conn.Close()
+	assert.Equal(t, fiber.StatusSwitchingProtocols, resp.StatusCode)
+
+	var msg fiber.Map
+	require.NoError(t, conn.ReadJSON(&msg))
+	assert.Equal(t, defaultRecoverMessage, msg["error"])
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	_, _, err = conn.ReadMessage()
+	require.Error(t, err)
+	var netErr net.Error
+	assert.False(t, errors.As(err, &netErr) && netErr.Timeout(),
+		"panicking handler left the connection open: %v", err)
+}
+
+func TestCoalesceWritesHandlerReturnLeavesSocketOpen(t *testing.T) {
+	writeErr := make(chan error, 1)
+	app := setupTestApp(Config{CoalesceWrites: true}, func(c *Conn) {
+		conn := c.Conn
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			writeErr <- conn.WriteMessage(websocket.TextMessage, []byte("after return"))
+		}()
+	})
+	defer app.Shutdown()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	_, p, err := conn.ReadMessage()
+	require.NoError(t, err)
+	assert.Equal(t, "after return", string(p))
+	assert.NoError(t, <-writeErr)
+}
+
+// listenTestApp serves app on :3000 and returns once it accepts connections.
+func listenTestApp(t *testing.T, app *fiber.App) {
+	t.Helper()
+	go func() {
+		_ = app.Listen(":3000", fiber.ListenConfig{DisableStartupMessage: true})
+	}()
+	require.Eventually(t, func() bool {
+		conn, err := net.Dial("tcp", "localhost:3000")
+		if err != nil {
+			return false
+		}
+		conn.Close()
+		return true
+	}, 5*time.Second, 10*time.Millisecond)
+}

--- a/v3/websocket/coalesce_test.go
+++ b/v3/websocket/coalesce_test.go
@@ -18,22 +18,51 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// scriptedConn feeds reads from a channel and records each write.
-type scriptedConn struct {
-	reads chan []byte
+var errScriptedTimeout = errors.New("scripted: i/o timeout")
 
-	mu        sync.Mutex
-	writes    [][]byte
-	closed    bool
-	deadlines []time.Time
-	writeErr  error
+// scriptedConn feeds reads from a channel and records each write. A past read
+// deadline makes a read with nothing queued fail at once; a past write
+// deadline, or Close, releases a write that was told to block.
+type scriptedConn struct {
+	reads   chan []byte
+	entered chan struct{} // one token per read that reached the socket
+	writing chan struct{} // one token per write that blocked
+
+	mu             sync.Mutex
+	writes         [][]byte
+	closed         bool
+	writeErr       error
+	blockWrites    bool
+	unblock        chan struct{}
+	readDeadline   time.Time
+	writeDeadlines []time.Time
 }
 
 func newScriptedConn() *scriptedConn {
-	return &scriptedConn{reads: make(chan []byte, 8)}
+	return &scriptedConn{
+		reads:   make(chan []byte, 8),
+		entered: make(chan struct{}, 8),
+		writing: make(chan struct{}, 8),
+		unblock: make(chan struct{}),
+	}
 }
 
 func (s *scriptedConn) Read(p []byte) (int, error) {
+	s.mu.Lock()
+	expired := !s.readDeadline.IsZero() && s.readDeadline.Before(time.Now())
+	s.mu.Unlock()
+	if expired {
+		select {
+		case b := <-s.reads:
+			return copy(p, b), nil
+		default:
+			return 0, errScriptedTimeout
+		}
+	}
+	select {
+	case s.entered <- struct{}{}:
+	default:
+	}
 	b, ok := <-s.reads
 	if !ok {
 		return 0, io.EOF
@@ -43,30 +72,66 @@ func (s *scriptedConn) Read(p []byte) (int, error) {
 
 func (s *scriptedConn) Write(p []byte) (int, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.writeErr != nil {
-		return 0, s.writeErr
+		err := s.writeErr
+		s.mu.Unlock()
+		return 0, err
 	}
+	block := s.blockWrites
+	s.mu.Unlock()
+	if block {
+		select {
+		case s.writing <- struct{}{}:
+		default:
+		}
+		<-s.unblock
+		return 0, errScriptedTimeout
+	}
+	s.mu.Lock()
 	s.writes = append(s.writes, bytes.Clone(p))
+	s.mu.Unlock()
 	return len(p), nil
 }
 
 func (s *scriptedConn) Close() error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.closed = true
+	s.mu.Unlock()
+	s.release()
 	return nil
 }
 
-func (*scriptedConn) LocalAddr() net.Addr             { return &net.TCPAddr{} }
-func (*scriptedConn) RemoteAddr() net.Addr            { return &net.TCPAddr{} }
-func (*scriptedConn) SetDeadline(time.Time) error     { return nil }
-func (*scriptedConn) SetReadDeadline(time.Time) error { return nil }
+func (s *scriptedConn) release() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.blockWrites {
+		s.blockWrites = false
+		close(s.unblock)
+	}
+}
+
+func (*scriptedConn) LocalAddr() net.Addr  { return &net.TCPAddr{} }
+func (*scriptedConn) RemoteAddr() net.Addr { return &net.TCPAddr{} }
+
+func (s *scriptedConn) SetDeadline(t time.Time) error {
+	_ = s.SetReadDeadline(t)
+	return s.SetWriteDeadline(t)
+}
+
+func (s *scriptedConn) SetReadDeadline(t time.Time) error {
+	s.mu.Lock()
+	s.readDeadline = t
+	s.mu.Unlock()
+	return nil
+}
 
 func (s *scriptedConn) SetWriteDeadline(t time.Time) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.deadlines = append(s.deadlines, t)
+	s.writeDeadlines = append(s.writeDeadlines, t)
+	s.mu.Unlock()
+	if !t.IsZero() && t.Before(time.Now()) {
+		s.release()
+	}
 	return nil
 }
 
@@ -94,13 +159,14 @@ func (s *scriptedConn) failWrites(err error) {
 	s.writeErr = err
 }
 
-func (s *scriptedConn) writeDeadlines() []time.Time {
+func (s *scriptedConn) stallWrites() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return slices.Clone(s.deadlines)
+	s.blockWrites = true
 }
 
-// hijackedConn mimics fasthttp's hijacked conn; UnsafeConn is the socket underneath.
+// hijackedConn mimics fasthttp's hijacked conn: reads come through it,
+// UnsafeConn is the socket underneath.
 type hijackedConn struct {
 	*scriptedConn
 	raw *scriptedConn
@@ -114,7 +180,7 @@ func attachedConn(t *testing.T) (*coalescingConn, *scriptedConn) {
 	src := newScriptedConn()
 	c := newCoalescingConn()
 	c.maxDelay = time.Hour
-	require.NoError(t, c.attach(src, 0))
+	c.attach(src)
 	return c, src
 }
 
@@ -128,20 +194,27 @@ func feedAndRead(t *testing.T, c *coalescingConn, src *scriptedConn, data string
 	require.Equal(t, data, string(buf[:n]))
 }
 
-// readInBackground parks the reader and returns a function that releases it.
-func readInBackground(t *testing.T, c *coalescingConn, src *scriptedConn) func() {
+// readInBackground parks the reader on the socket and releases it at cleanup.
+func readInBackground(t *testing.T, c *coalescingConn, src *scriptedConn) {
 	t.Helper()
+	for len(src.entered) > 0 {
+		<-src.entered
+	}
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		buf := make([]byte, 64)
 		_, _ = c.Read(buf)
 	}()
-	require.Eventually(t, c.parked.Load, time.Second, time.Millisecond)
-	return func() {
+	select {
+	case <-src.entered:
+	case <-time.After(time.Second):
+		t.Fatal("reader never reached the socket")
+	}
+	t.Cleanup(func() {
 		close(src.reads)
 		<-done
-	}
+	})
 }
 
 func TestCoalescingConnHoldsRepliesUntilReaderReturns(t *testing.T) {
@@ -154,8 +227,7 @@ func TestCoalescingConnHoldsRepliesUntilReaderReturns(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, src.writeCount())
 
-	release := readInBackground(t, c, src)
-	defer release()
+	readInBackground(t, c, src)
 	assert.Equal(t, [][]byte{[]byte("reply1reply2")}, src.written())
 }
 
@@ -170,8 +242,7 @@ func TestCoalescingConnWritesThroughWithoutPendingInput(t *testing.T) {
 func TestCoalescingConnWritesThroughWhileReaderParked(t *testing.T) {
 	c, src := attachedConn(t)
 	feedAndRead(t, c, src, "hello")
-	release := readInBackground(t, c, src)
-	defer release()
+	readInBackground(t, c, src)
 
 	_, err := c.Write([]byte("push"))
 	require.NoError(t, err)
@@ -220,43 +291,95 @@ func TestCoalescingConnCloseFlushesAndIsIdempotent(t *testing.T) {
 	assert.ErrorIs(t, err, net.ErrClosed)
 }
 
-func TestCoalescingConnHandshakeWaitsForAttach(t *testing.T) {
+func TestCoalescingConnCloseInterruptsStalledWriter(t *testing.T) {
+	c, src := attachedConn(t)
+	src.stallWrites()
+
+	writeErr := make(chan error, 1)
+	go func() {
+		_, err := c.Write([]byte("stuck"))
+		writeErr <- err
+	}()
+	select {
+	case <-src.writing:
+	case <-time.After(time.Second):
+		t.Fatal("writer never reached the socket")
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- c.Close() }()
+	select {
+	case err := <-closed:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Close waited behind a stalled writer")
+	}
+	require.Error(t, <-writeErr)
+	assert.True(t, src.isClosed())
+}
+
+func TestCoalescingConnReaderDoesNotWaitForStalledWriter(t *testing.T) {
+	c, src := attachedConn(t)
+	src.stallWrites()
+	go func() { _, _ = c.Write([]byte("stuck")) }()
+	select {
+	case <-src.writing:
+	case <-time.After(time.Second):
+		t.Fatal("writer never reached the socket")
+	}
+
+	src.reads <- []byte("in")
+	buf := make([]byte, 64)
+	read := make(chan int, 1)
+	go func() {
+		n, _ := c.Read(buf)
+		read <- n
+	}()
+	select {
+	case n := <-read:
+		assert.Equal(t, "in", string(buf[:n]))
+	case <-time.After(time.Second):
+		t.Fatal("reader waited behind a stalled writer")
+	}
+	src.release()
+}
+
+func TestCoalescingConnHandshakeIsTakenNotSent(t *testing.T) {
 	c := newCoalescingConn()
 	response := []byte("HTTP/1.1 101 Switching Protocols\r\n\r\n")
 	_, err := c.Write(response)
 	require.NoError(t, err)
+	assert.Equal(t, response, c.takeHandshake())
 
 	src := newScriptedConn()
-	require.NoError(t, c.attach(src, time.Second))
-	assert.Equal(t, [][]byte{response}, src.written())
-
-	deadlines := src.writeDeadlines()
-	require.Len(t, deadlines, 2)
-	assert.False(t, deadlines[0].IsZero())
-	assert.True(t, deadlines[1].IsZero())
+	c.attach(src)
+	assert.Equal(t, 0, src.writeCount())
 }
 
-func TestCoalescingConnReadBeforeAttachFails(t *testing.T) {
-	c := newCoalescingConn()
-	_, err := c.Read(make([]byte, 1))
-	assert.ErrorIs(t, err, errNotAttached)
-}
-
-func TestCoalescingConnWritesBypassHijackedReader(t *testing.T) {
+func TestCoalescingConnServesBytesFasthttpBufferedFirst(t *testing.T) {
 	src, raw := newScriptedConn(), newScriptedConn()
+	src.reads <- []byte("early")
 	c := newCoalescingConn()
 	c.maxDelay = time.Hour
-	require.NoError(t, c.attach(&hijackedConn{scriptedConn: src, raw: raw}, 0))
+	c.attach(&hijackedConn{scriptedConn: src, raw: raw})
 
-	_, err := c.Write([]byte("out"))
+	buf := make([]byte, 64)
+	n, err := c.Read(buf)
 	require.NoError(t, err)
-	assert.Equal(t, [][]byte{[]byte("out")}, raw.written())
-	assert.Equal(t, 0, src.writeCount())
+	assert.Equal(t, "early", string(buf[:n]))
+	assert.Empty(t, raw.entered, "the stash is served without touching the socket")
 
-	feedAndRead(t, c, src, "in")
+	raw.reads <- []byte("later")
+	n, err = c.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, "later", string(buf[:n]))
 
+	_, err = c.Write([]byte("out")) // held: the reader has a batch in hand
+	require.NoError(t, err)
 	require.NoError(t, c.Close())
-	assert.True(t, src.isClosed())
+	assert.Equal(t, 0, src.writeCount())
+	assert.Equal(t, [][]byte{[]byte("out")}, raw.written(), "writes reach the socket, not fasthttp's wrapper")
+	assert.True(t, src.isClosed(), "closing the hijacked conn hands it back to fasthttp")
 }
 
 func TestCoalescingConnWriteErrorIsSticky(t *testing.T) {
@@ -270,6 +393,22 @@ func TestCoalescingConnWriteErrorIsSticky(t *testing.T) {
 	require.EqualError(t, err, "boom")
 }
 
+func TestFrameReaderCopyIsExactAndTrimmed(t *testing.T) {
+	fr := &frameReader{}
+	msg, err := fr.readAll(bytes.NewReader(bytes.Repeat([]byte{'x'}, frameBufferRetained)))
+	require.NoError(t, err)
+	assert.Len(t, msg, frameBufferRetained)
+	assert.Equal(t, len(msg), cap(msg))
+	fr.trim()
+	assert.Equal(t, frameBufferRetained, cap(fr.buf), "a buffer within the cap is kept")
+
+	msg, err = fr.readAll(bytes.NewReader(bytes.Repeat([]byte{'x'}, frameBufferRetained+1)))
+	require.NoError(t, err)
+	assert.Len(t, msg, frameBufferRetained+1)
+	fr.trim()
+	assert.Nil(t, fr.buf, "a buffer past the cap is dropped")
+}
+
 // clientFrame builds one masked client frame (payload up to 125 bytes).
 func clientFrame(op int, payload []byte) []byte {
 	key := [4]byte{1, 2, 3, 4}
@@ -281,19 +420,30 @@ func clientFrame(op int, payload []byte) []byte {
 	return f
 }
 
-func TestPipelinedEcho(t *testing.T) {
-	app := setupTestApp(Config{}, func(c *Conn) {
-		defer c.Close()
-		for {
-			mt, p, err := c.ReadMessage()
-			if err != nil {
-				return
-			}
-			if err := c.WriteMessage(mt, p); err != nil {
-				return
-			}
+func echoHandler(c *Conn) {
+	defer c.Close()
+	for {
+		mt, p, err := c.ReadMessage()
+		if err != nil {
+			return
 		}
-	})
+		if err := c.WriteMessage(mt, p); err != nil {
+			return
+		}
+	}
+}
+
+func handshakeRequestHeaders() [][2]string {
+	return [][2]string{
+		{fiber.HeaderConnection, "Upgrade"},
+		{fiber.HeaderUpgrade, "websocket"},
+		{fiber.HeaderSecWebSocketVersion, "13"},
+		{fiber.HeaderSecWebSocketKey, "dGhlIHNhbXBsZSBub25jZQ=="},
+	}
+}
+
+func TestPipelinedEcho(t *testing.T) {
+	app := setupTestApp(Config{}, echoHandler)
 	defer app.Shutdown()
 
 	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
@@ -326,12 +476,7 @@ func TestHandshakeRejectionStatuses(t *testing.T) {
 	// All, so a POST reaches the middleware's 405 rather than the router's.
 	app.All("/ws", New(func(*Conn) {}, Config{Origins: []string{"http://allowed"}}))
 
-	full := [][2]string{
-		{fiber.HeaderConnection, "Upgrade"},
-		{fiber.HeaderUpgrade, "websocket"},
-		{fiber.HeaderSecWebSocketVersion, "13"},
-		{fiber.HeaderSecWebSocketKey, "dGhlIHNhbXBsZSBub25jZQ=="},
-	}
+	full := handshakeRequestHeaders()
 	with := func(extra ...[2]string) [][2]string { return append(slices.Clone(full), extra...) }
 	cases := []struct {
 		name    string
@@ -367,12 +512,37 @@ func TestHandshakeRejectionStatuses(t *testing.T) {
 	}
 }
 
-func TestUpgradeResponseKeepsMiddlewareHeaders(t *testing.T) {
+func TestUpgradeThroughAppTest(t *testing.T) {
+	app := fiber.New()
+	app.Get("/ws", New(func(*Conn) {}))
+
+	req := httptest.NewRequest(fiber.MethodGet, "/ws", nil)
+	for _, h := range handshakeRequestHeaders() {
+		req.Header.Set(h[0], h[1])
+	}
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusSwitchingProtocols, resp.StatusCode)
+	assert.Equal(t, "websocket", resp.Header.Get(fiber.HeaderUpgrade))
+	assert.Equal(t, "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=", resp.Header.Get(fiber.HeaderSecWebSocketAccept))
+}
+
+func TestUpgradeResponseIsVisibleAfterNext(t *testing.T) {
+	type seen struct {
+		status  int
+		upgrade string
+	}
+	observed := make(chan seen, 1)
 	app := fiber.New(fiber.Config{ServerHeader: "Fiber"})
 	app.Use(func(c fiber.Ctx) error {
-		c.Set("X-Request-ID", "req-1")
+		err := c.Next()
+		// What logger, metrics and session middleware see and do after Next.
+		observed <- seen{c.Response().StatusCode(), string(c.Response().Header.Peek(fiber.HeaderUpgrade))}
+		c.Set("X-After", "1")
 		c.Cookie(&fiber.Cookie{Name: "session", Value: "s1"})
-		return c.Next()
+		return err
 	})
 	app.Get("/ws", New(func(*Conn) {}))
 	listenTestApp(t, app)
@@ -381,26 +551,36 @@ func TestUpgradeResponseKeepsMiddlewareHeaders(t *testing.T) {
 	conn, resp, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws", nil)
 	require.NoError(t, err)
 	defer conn.Close()
+
+	assert.Equal(t, seen{fiber.StatusSwitchingProtocols, "websocket"}, <-observed)
 	assert.Equal(t, fiber.StatusSwitchingProtocols, resp.StatusCode)
-	assert.Equal(t, "req-1", resp.Header.Get("X-Request-ID"))
+	assert.Equal(t, "1", resp.Header.Get("X-After"))
 	assert.Contains(t, resp.Header.Get(fiber.HeaderSetCookie), "session=s1")
 	assert.Equal(t, "Fiber", resp.Header.Get(fiber.HeaderServer))
-	assert.Equal(t, "websocket", resp.Header.Get(fiber.HeaderUpgrade))
+	assert.NotEmpty(t, resp.Header.Get(fiber.HeaderDate))
+}
+
+func TestConnNetConnExposesSocket(t *testing.T) {
+	socket := make(chan net.Conn, 1)
+	app := setupTestApp(Config{}, func(c *Conn) {
+		u, ok := c.NetConn().(interface{ UnsafeConn() net.Conn })
+		if !ok {
+			socket <- nil
+			return
+		}
+		socket <- u.UnsafeConn()
+	})
+	defer app.Shutdown()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
+	require.NoError(t, err)
+	defer conn.Close()
+	_, isTCP := (<-socket).(*net.TCPConn)
+	assert.True(t, isTCP)
 }
 
 func TestConnReadMessageReturnsOwnedCopy(t *testing.T) {
-	app := setupTestApp(Config{}, func(c *Conn) {
-		defer c.Close()
-		for {
-			mt, p, err := c.ReadMessage()
-			if err != nil {
-				return
-			}
-			if err := c.WriteMessage(mt, p); err != nil {
-				return
-			}
-		}
-	})
+	app := setupTestApp(Config{}, echoHandler)
 	defer app.Shutdown()
 
 	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
@@ -417,22 +597,6 @@ func TestConnReadMessageReturnsOwnedCopy(t *testing.T) {
 		assert.Equal(t, websocket.BinaryMessage, mt)
 		assert.Equal(t, payload, p)
 	}
-}
-
-func TestFrameReaderCopyIsExactAndPoolIsTrimmed(t *testing.T) {
-	fr := &frameReader{}
-	msg, err := fr.readAll(bytes.NewReader(bytes.Repeat([]byte{'x'}, frameBufferRetained)))
-	require.NoError(t, err)
-	assert.Len(t, msg, frameBufferRetained)
-	assert.Equal(t, len(msg), cap(msg))
-	fr.release()
-	assert.Equal(t, frameBufferRetained, cap(fr.buf), "a buffer within the cap goes back to the pool")
-
-	msg, err = fr.readAll(bytes.NewReader(bytes.Repeat([]byte{'x'}, frameBufferRetained+1)))
-	require.NoError(t, err)
-	assert.Len(t, msg, frameBufferRetained+1)
-	fr.release()
-	assert.Nil(t, fr.buf, "a buffer past the cap is dropped")
 }
 
 func TestSubprotocolServerPreference(t *testing.T) {

--- a/v3/websocket/coalesce_test.go
+++ b/v3/websocket/coalesce_test.go
@@ -231,6 +231,15 @@ func TestCoalescingConnHoldsRepliesUntilReaderReturns(t *testing.T) {
 	assert.Equal(t, [][]byte{[]byte("reply1reply2")}, src.written())
 }
 
+func TestCoalescingConnWritesThroughAfterSingleFrameFill(t *testing.T) {
+	c, src := attachedConn(t)
+	feedAndRead(t, c, src, "hello") // too small to hold two frames
+
+	_, err := c.Write([]byte("reply"))
+	require.NoError(t, err)
+	assert.Equal(t, [][]byte{[]byte("reply")}, src.written())
+}
+
 func TestCoalescingConnWritesThroughWithoutPendingInput(t *testing.T) {
 	c, src := attachedConn(t)
 
@@ -252,7 +261,7 @@ func TestCoalescingConnWritesThroughWhileReaderParked(t *testing.T) {
 func TestCoalescingConnTimerFlushesWhenReaderStalls(t *testing.T) {
 	c, src := attachedConn(t)
 	c.maxDelay = 5 * time.Millisecond
-	feedAndRead(t, c, src, "hello")
+	feedAndRead(t, c, src, "hello, world")
 
 	_, err := c.Write([]byte("late"))
 	require.NoError(t, err)
@@ -266,7 +275,7 @@ func TestCoalescingConnTimerFlushesWhenReaderStalls(t *testing.T) {
 
 func TestCoalescingConnLargeWriteGoesDirectAfterPending(t *testing.T) {
 	c, src := attachedConn(t)
-	feedAndRead(t, c, src, "hello")
+	feedAndRead(t, c, src, "hello, world")
 
 	_, err := c.Write([]byte("small"))
 	require.NoError(t, err)
@@ -278,7 +287,7 @@ func TestCoalescingConnLargeWriteGoesDirectAfterPending(t *testing.T) {
 
 func TestCoalescingConnCloseFlushesAndIsIdempotent(t *testing.T) {
 	c, src := attachedConn(t)
-	feedAndRead(t, c, src, "hello")
+	feedAndRead(t, c, src, "hello, world")
 
 	_, err := c.Write([]byte("bye"))
 	require.NoError(t, err)
@@ -358,7 +367,7 @@ func TestCoalescingConnHandshakeIsTakenNotSent(t *testing.T) {
 
 func TestCoalescingConnServesBytesFasthttpBufferedFirst(t *testing.T) {
 	src, raw := newScriptedConn(), newScriptedConn()
-	src.reads <- []byte("early")
+	src.reads <- []byte("early frames")
 	c := newCoalescingConn()
 	c.maxDelay = time.Hour
 	c.attach(&hijackedConn{scriptedConn: src, raw: raw})
@@ -366,7 +375,7 @@ func TestCoalescingConnServesBytesFasthttpBufferedFirst(t *testing.T) {
 	buf := make([]byte, 64)
 	n, err := c.Read(buf)
 	require.NoError(t, err)
-	assert.Equal(t, "early", string(buf[:n]))
+	assert.Equal(t, "early frames", string(buf[:n]))
 	assert.Empty(t, raw.entered, "the stash is served without touching the socket")
 
 	raw.reads <- []byte("later")

--- a/v3/websocket/coalesce_test.go
+++ b/v3/websocket/coalesce_test.go
@@ -18,11 +18,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var errScriptedTimeout = errors.New("scripted: i/o timeout")
+var (
+	errScriptedTimeout = errors.New("scripted: i/o timeout")
+	errNoDeadlines     = errors.New("scripted: deadlines unsupported")
+)
 
 // scriptedConn feeds reads from a channel and records each write. A past read
 // deadline makes a read with nothing queued fail at once; a past write
-// deadline, or Close, releases a write that was told to block.
+// deadline, or Close, releases a write that was told to block. Told to refuse
+// deadlines, it rejects them as a net.Conn may.
 type scriptedConn struct {
 	reads   chan []byte
 	entered chan struct{} // one token per read that reached the socket
@@ -34,6 +38,7 @@ type scriptedConn struct {
 	writeErr       error
 	blockWrites    bool
 	unblock        chan struct{}
+	noDeadlines    bool
 	readDeadline   time.Time
 	writeDeadlines []time.Time
 }
@@ -120,13 +125,20 @@ func (s *scriptedConn) SetDeadline(t time.Time) error {
 
 func (s *scriptedConn) SetReadDeadline(t time.Time) error {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.noDeadlines {
+		return errNoDeadlines
+	}
 	s.readDeadline = t
-	s.mu.Unlock()
 	return nil
 }
 
 func (s *scriptedConn) SetWriteDeadline(t time.Time) error {
 	s.mu.Lock()
+	if s.noDeadlines {
+		s.mu.Unlock()
+		return errNoDeadlines
+	}
 	s.writeDeadlines = append(s.writeDeadlines, t)
 	s.mu.Unlock()
 	if !t.IsZero() && t.Before(time.Now()) {
@@ -163,6 +175,12 @@ func (s *scriptedConn) stallWrites() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.blockWrites = true
+}
+
+func (s *scriptedConn) refuseDeadlines() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.noDeadlines = true
 }
 
 // hijackedConn mimics fasthttp's hijacked conn: reads come through it,
@@ -327,6 +345,34 @@ func TestCoalescingConnCloseInterruptsStalledWriter(t *testing.T) {
 	assert.True(t, src.isClosed())
 }
 
+func TestCoalescingConnCloseFailsStalledWriterWithoutWriteDeadline(t *testing.T) {
+	c, src := attachedConn(t)
+	src.refuseDeadlines()
+	src.stallWrites()
+
+	writeErr := make(chan error, 1)
+	go func() {
+		_, err := c.Write([]byte("stuck"))
+		writeErr <- err
+	}()
+	select {
+	case <-src.writing:
+	case <-time.After(time.Second):
+		t.Fatal("writer never reached the socket")
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- c.Close() }()
+	select {
+	case err := <-closed:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Close waited behind a writer it could not expire")
+	}
+	require.Error(t, <-writeErr)
+	assert.True(t, src.isClosed())
+}
+
 func TestCoalescingConnReaderDoesNotWaitForStalledWriter(t *testing.T) {
 	c, src := attachedConn(t)
 	src.stallWrites()
@@ -391,6 +437,41 @@ func TestCoalescingConnServesBytesFasthttpBufferedFirst(t *testing.T) {
 	assert.True(t, src.isClosed(), "closing the hijacked conn hands it back to fasthttp")
 }
 
+func TestCoalescingConnReadsThroughSourceWithoutReadDeadline(t *testing.T) {
+	src, raw := newScriptedConn(), newScriptedConn()
+	src.refuseDeadlines()
+	src.reads <- []byte("early frames")
+	c := newCoalescingConn()
+	c.maxDelay = time.Hour
+
+	attached := make(chan struct{})
+	go func() {
+		c.attach(&hijackedConn{scriptedConn: src, raw: raw})
+		close(attached)
+	}()
+	select {
+	case <-attached:
+	case <-time.After(time.Second):
+		t.Fatal("attach blocked draining a conn that refuses read deadlines")
+	}
+
+	buf := make([]byte, 64)
+	n, err := c.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, "early frames", string(buf[:n]))
+
+	src.reads <- []byte("later")
+	n, err = c.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, "later", string(buf[:n]), "reads stay on fasthttp's conn")
+	assert.Empty(t, raw.entered)
+
+	_, err = c.Write([]byte("out"))
+	require.NoError(t, err)
+	require.NoError(t, c.Close())
+	assert.Equal(t, [][]byte{[]byte("out")}, raw.written(), "writes still reach the socket")
+}
+
 func TestCoalescingConnWriteErrorIsSticky(t *testing.T) {
 	c, src := attachedConn(t)
 	src.failWrites(errors.New("boom"))
@@ -452,7 +533,7 @@ func handshakeRequestHeaders() [][2]string {
 }
 
 func TestPipelinedEcho(t *testing.T) {
-	app := setupTestApp(Config{}, echoHandler)
+	app := setupTestApp(Config{HandshakeTimeout: time.Second}, echoHandler)
 	defer app.Shutdown()
 
 	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
@@ -554,10 +635,9 @@ func TestUpgradeResponseIsVisibleAfterNext(t *testing.T) {
 		return err
 	})
 	app.Get("/ws", New(func(*Conn) {}))
-	listenTestApp(t, app)
-	defer app.Shutdown()
+	addr := listenTestApp(t, app)
 
-	conn, resp, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws", nil)
+	conn, resp, err := websocket.DefaultDialer.Dial("ws://"+addr+"/ws", nil)
 	require.NoError(t, err)
 	defer conn.Close()
 
@@ -625,18 +705,32 @@ func TestSubprotocolServerPreference(t *testing.T) {
 	assert.Equal(t, "chat", string(p))
 }
 
-// listenTestApp serves app on :3000 and waits until it accepts connections.
-func listenTestApp(t *testing.T, app *fiber.App) {
+func TestHandshakeTimeoutBoundsUpgradeResponse(t *testing.T) {
+	app := fiber.New()
+	app.Get("/ws", New(func(*Conn) {}, Config{HandshakeTimeout: time.Nanosecond}))
+	addr := listenTestApp(t, app)
+
+	// The deadline has passed by the time fasthttp writes the 101, so the
+	// connection is closed unanswered.
+	conn, resp, err := websocket.DefaultDialer.Dial("ws://"+addr+"/ws", nil)
+	require.Error(t, err)
+	assert.Nil(t, conn)
+	assert.Nil(t, resp)
+}
+
+// listenTestApp serves app on a free port until the test ends and returns the
+// address to dial.
+func listenTestApp(t *testing.T, app *fiber.App) string {
 	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	served := make(chan error, 1)
 	go func() {
-		_ = app.Listen(":3000", fiber.ListenConfig{DisableStartupMessage: true})
+		served <- app.Listener(ln, fiber.ListenConfig{DisableStartupMessage: true})
 	}()
-	require.Eventually(t, func() bool {
-		conn, err := net.Dial("tcp", "localhost:3000")
-		if err != nil {
-			return false
-		}
-		conn.Close()
-		return true
-	}, 5*time.Second, 10*time.Millisecond)
+	t.Cleanup(func() {
+		assert.NoError(t, app.Shutdown())
+		assert.NoError(t, <-served)
+	})
+	return ln.Addr().String()
 }

--- a/v3/websocket/coalesce_test.go
+++ b/v3/websocket/coalesce_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"net/http/httptest"
 	"slices"
 	"sync"
@@ -282,23 +281,8 @@ func clientFrame(op int, payload []byte) []byte {
 	return f
 }
 
-func TestCoalesceWritesHandshakeAndMessage(t *testing.T) {
-	app := setupTestApp(Config{CoalesceWrites: true}, nil)
-	defer app.Shutdown()
-
-	conn, resp, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
-	require.NoError(t, err)
-	defer conn.Close()
-	assert.Equal(t, fiber.StatusSwitchingProtocols, resp.StatusCode)
-	assert.Equal(t, "websocket", resp.Header.Get(fiber.HeaderUpgrade))
-
-	var msg fiber.Map
-	require.NoError(t, conn.ReadJSON(&msg))
-	assert.Equal(t, "hello websocket", msg["message"])
-}
-
-func TestCoalesceWritesPipelinedEcho(t *testing.T) {
-	app := setupTestApp(Config{CoalesceWrites: true}, func(c *Conn) {
+func TestPipelinedEcho(t *testing.T) {
+	app := setupTestApp(Config{}, func(c *Conn) {
 		defer c.Close()
 		for {
 			mt, p, err := c.ReadMessage()
@@ -333,14 +317,14 @@ func TestCoalesceWritesPipelinedEcho(t *testing.T) {
 	}
 }
 
-func TestCoalesceWritesRejectionsKeepStatuses(t *testing.T) {
+func TestHandshakeRejectionStatuses(t *testing.T) {
 	app := fiber.New()
 	app.Use(func(c fiber.Ctx) error {
 		c.Set("X-Request-ID", "req-1")
 		return c.Next()
 	})
 	// All, so a POST reaches the middleware's 405 rather than the router's.
-	app.All("/ws", New(func(*Conn) {}, Config{CoalesceWrites: true, Origins: []string{"http://allowed"}}))
+	app.All("/ws", New(func(*Conn) {}, Config{Origins: []string{"http://allowed"}}))
 
 	full := [][2]string{
 		{fiber.HeaderConnection, "Upgrade"},
@@ -383,26 +367,14 @@ func TestCoalesceWritesRejectionsKeepStatuses(t *testing.T) {
 	}
 }
 
-func TestCoalesceWritesAcceptsAllowedOrigin(t *testing.T) {
-	app := setupTestApp(Config{CoalesceWrites: true, Origins: []string{"http://localhost:3000"}}, nil)
-	defer app.Shutdown()
-
-	conn, resp, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", http.Header{
-		fiber.HeaderOrigin: []string{"HTTP://LOCALHOST:3000"},
-	})
-	require.NoError(t, err)
-	defer conn.Close()
-	assert.Equal(t, fiber.StatusSwitchingProtocols, resp.StatusCode)
-}
-
-func TestCoalesceWritesKeepsMiddlewareResponseHeaders(t *testing.T) {
-	app := fiber.New()
+func TestUpgradeResponseKeepsMiddlewareHeaders(t *testing.T) {
+	app := fiber.New(fiber.Config{ServerHeader: "Fiber"})
 	app.Use(func(c fiber.Ctx) error {
 		c.Set("X-Request-ID", "req-1")
 		c.Cookie(&fiber.Cookie{Name: "session", Value: "s1"})
 		return c.Next()
 	})
-	app.Get("/ws", New(func(*Conn) {}, Config{CoalesceWrites: true}))
+	app.Get("/ws", New(func(*Conn) {}))
 	listenTestApp(t, app)
 	defer app.Shutdown()
 
@@ -412,59 +384,59 @@ func TestCoalesceWritesKeepsMiddlewareResponseHeaders(t *testing.T) {
 	assert.Equal(t, fiber.StatusSwitchingProtocols, resp.StatusCode)
 	assert.Equal(t, "req-1", resp.Header.Get("X-Request-ID"))
 	assert.Contains(t, resp.Header.Get(fiber.HeaderSetCookie), "session=s1")
+	assert.Equal(t, "Fiber", resp.Header.Get(fiber.HeaderServer))
 	assert.Equal(t, "websocket", resp.Header.Get(fiber.HeaderUpgrade))
 }
 
-func TestCoalesceWritesCapturesRequest(t *testing.T) {
-	app := setupTestApp(Config{CoalesceWrites: true}, func(c *Conn) {
-		_ = c.WriteJSON(fiber.Map{
-			"param":  c.Params("param1"),
-			"query":  c.Query("q"),
-			"header": c.Headers("X-Test"),
-			"cookie": c.Cookies("session"),
-			"local":  c.Locals("allowed"),
-			"ip":     c.IP(),
-		})
+func TestConnReadMessageReturnsOwnedCopy(t *testing.T) {
+	app := setupTestApp(Config{}, func(c *Conn) {
+		defer c.Close()
+		for {
+			mt, p, err := c.ReadMessage()
+			if err != nil {
+				return
+			}
+			if err := c.WriteMessage(mt, p); err != nil {
+				return
+			}
+		}
 	})
 	defer app.Shutdown()
 
-	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message/a/b?q=1", http.Header{
-		"X-Test": []string{"v"},
-		"Cookie": []string{"session=s1"},
-	})
+	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
 	require.NoError(t, err)
 	defer conn.Close()
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
 
-	var msg fiber.Map
-	require.NoError(t, conn.ReadJSON(&msg))
-	assert.Equal(t, "a", msg["param"])
-	assert.Equal(t, "1", msg["query"])
-	assert.Equal(t, "v", msg["header"])
-	assert.Equal(t, "s1", msg["cookie"])
-	assert.Equal(t, true, msg["local"])
-	assert.Equal(t, "127.0.0.1", msg["ip"])
+	// Sizes around the pooled buffer's growth points, including an exact fill.
+	for _, size := range []int{0, 5, frameBufferInitial, frameBufferInitial + 1, 100 << 10} {
+		payload := bytes.Repeat([]byte{byte(size)}, size)
+		require.NoError(t, conn.WriteMessage(websocket.BinaryMessage, payload))
+		mt, p, err := conn.ReadMessage()
+		require.NoError(t, err)
+		assert.Equal(t, websocket.BinaryMessage, mt)
+		assert.Equal(t, payload, p)
+	}
 }
 
-func TestCoalesceWritesCompression(t *testing.T) {
-	app := setupTestApp(Config{CoalesceWrites: true, EnableCompression: true}, func(c *Conn) {
-		c.EnableWriteCompression(true)
-		_ = c.WriteJSON(fiber.Map{"message": "hello websocket"})
-	})
-	defer app.Shutdown()
-
-	dialer := websocket.Dialer{EnableCompression: true}
-	conn, resp, err := dialer.Dial("ws://localhost:3000/ws/message", nil)
+func TestFrameReaderCopyIsExactAndPoolIsTrimmed(t *testing.T) {
+	fr := &frameReader{}
+	msg, err := fr.readAll(bytes.NewReader(bytes.Repeat([]byte{'x'}, frameBufferRetained)))
 	require.NoError(t, err)
-	defer conn.Close()
-	assert.Contains(t, resp.Header.Get(fiber.HeaderSecWebSocketExtensions), "permessage-deflate")
+	assert.Len(t, msg, frameBufferRetained)
+	assert.Equal(t, len(msg), cap(msg))
+	fr.release()
+	assert.Equal(t, frameBufferRetained, cap(fr.buf), "a buffer within the cap goes back to the pool")
 
-	var msg fiber.Map
-	require.NoError(t, conn.ReadJSON(&msg))
-	assert.Equal(t, "hello websocket", msg["message"])
+	msg, err = fr.readAll(bytes.NewReader(bytes.Repeat([]byte{'x'}, frameBufferRetained+1)))
+	require.NoError(t, err)
+	assert.Len(t, msg, frameBufferRetained+1)
+	fr.release()
+	assert.Nil(t, fr.buf, "a buffer past the cap is dropped")
 }
 
-func TestCoalesceWritesSubprotocol(t *testing.T) {
-	app := setupTestApp(Config{CoalesceWrites: true, Subprotocols: []string{"chat", "json"}}, func(c *Conn) {
+func TestSubprotocolServerPreference(t *testing.T) {
+	app := setupTestApp(Config{Subprotocols: []string{"chat", "json"}}, func(c *Conn) {
 		_ = c.WriteMessage(websocket.TextMessage, []byte(c.Subprotocol()))
 	})
 	defer app.Shutdown()
@@ -478,51 +450,6 @@ func TestCoalesceWritesSubprotocol(t *testing.T) {
 	_, p, err := conn.ReadMessage()
 	require.NoError(t, err)
 	assert.Equal(t, "chat", string(p))
-}
-
-func TestCoalesceWritesPanicClosesConnection(t *testing.T) {
-	app := setupTestApp(Config{CoalesceWrites: true}, func(*Conn) {
-		panic("test panic")
-	})
-	defer app.Shutdown()
-
-	conn, resp, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
-	require.NoError(t, err)
-	defer conn.Close()
-	assert.Equal(t, fiber.StatusSwitchingProtocols, resp.StatusCode)
-
-	var msg fiber.Map
-	require.NoError(t, conn.ReadJSON(&msg))
-	assert.Equal(t, defaultRecoverMessage, msg["error"])
-
-	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
-	_, _, err = conn.ReadMessage()
-	require.Error(t, err)
-	var netErr net.Error
-	assert.False(t, errors.As(err, &netErr) && netErr.Timeout(),
-		"panicking handler left the connection open: %v", err)
-}
-
-func TestCoalesceWritesHandlerReturnLeavesSocketOpen(t *testing.T) {
-	writeErr := make(chan error, 1)
-	app := setupTestApp(Config{CoalesceWrites: true}, func(c *Conn) {
-		conn := c.Conn
-		go func() {
-			time.Sleep(50 * time.Millisecond)
-			writeErr <- conn.WriteMessage(websocket.TextMessage, []byte("after return"))
-		}()
-	})
-	defer app.Shutdown()
-
-	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:3000/ws/message", nil)
-	require.NoError(t, err)
-	defer conn.Close()
-
-	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
-	_, p, err := conn.ReadMessage()
-	require.NoError(t, err)
-	assert.Equal(t, "after return", string(p))
-	assert.NoError(t, <-writeErr)
 }
 
 // listenTestApp serves app on :3000 and waits until it accepts connections.

--- a/v3/websocket/coalesce_test.go
+++ b/v3/websocket/coalesce_test.go
@@ -19,8 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// scriptedConn is a net.Conn whose reads the test feeds and whose writes are
-// recorded one entry per call, which is one syscall on a real socket.
+// scriptedConn feeds reads from a channel and records each write.
 type scriptedConn struct {
 	reads chan []byte
 
@@ -102,8 +101,7 @@ func (s *scriptedConn) writeDeadlines() []time.Time {
 	return slices.Clone(s.deadlines)
 }
 
-// hijackedConn mimics fasthttp's hijacked connection: reads through it, and
-// UnsafeConn exposes the socket underneath.
+// hijackedConn mimics fasthttp's hijacked conn; UnsafeConn is the socket underneath.
 type hijackedConn struct {
 	*scriptedConn
 	raw *scriptedConn
@@ -111,9 +109,7 @@ type hijackedConn struct {
 
 func (h *hijackedConn) UnsafeConn() net.Conn { return h.raw }
 
-// attachedConn returns a coalescing conn attached to a scripted socket, with
-// the safety timer effectively off so tests observe only the reader-driven
-// behaviour.
+// attachedConn returns an attached conn with the safety timer effectively off.
 func attachedConn(t *testing.T) (*coalescingConn, *scriptedConn) {
 	t.Helper()
 	src := newScriptedConn()
@@ -123,7 +119,7 @@ func attachedConn(t *testing.T) (*coalescingConn, *scriptedConn) {
 	return c, src
 }
 
-// feedAndRead delivers data to the reader, which leaves it holding a batch.
+// feedAndRead leaves the reader holding a batch.
 func feedAndRead(t *testing.T, c *coalescingConn, src *scriptedConn, data string) {
 	t.Helper()
 	src.reads <- []byte(data)
@@ -133,8 +129,7 @@ func feedAndRead(t *testing.T, c *coalescingConn, src *scriptedConn, data string
 	require.Equal(t, data, string(buf[:n]))
 }
 
-// readInBackground parks the reader on the socket and returns a function that
-// releases it.
+// readInBackground parks the reader and returns a function that releases it.
 func readInBackground(t *testing.T, c *coalescingConn, src *scriptedConn) func() {
 	t.Helper()
 	done := make(chan struct{})
@@ -158,9 +153,8 @@ func TestCoalescingConnHoldsRepliesUntilReaderReturns(t *testing.T) {
 	require.NoError(t, err)
 	_, err = c.Write([]byte("reply2"))
 	require.NoError(t, err)
-	assert.Equal(t, 0, src.writeCount(), "replies must wait while the reader still has input")
+	assert.Equal(t, 0, src.writeCount())
 
-	// The reader comes back for more: everything owed leaves in one write.
 	release := readInBackground(t, c, src)
 	defer release()
 	assert.Equal(t, [][]byte{[]byte("reply1reply2")}, src.written())
@@ -169,7 +163,6 @@ func TestCoalescingConnHoldsRepliesUntilReaderReturns(t *testing.T) {
 func TestCoalescingConnWritesThroughWithoutPendingInput(t *testing.T) {
 	c, src := attachedConn(t)
 
-	// Nothing has been read: a push must not wait for a reader that may never come.
 	_, err := c.Write([]byte("push"))
 	require.NoError(t, err)
 	assert.Equal(t, [][]byte{[]byte("push")}, src.written())
@@ -181,7 +174,6 @@ func TestCoalescingConnWritesThroughWhileReaderParked(t *testing.T) {
 	release := readInBackground(t, c, src)
 	defer release()
 
-	// The reader is waiting on the peer, so nothing would flush a deferred write.
 	_, err := c.Write([]byte("push"))
 	require.NoError(t, err)
 	assert.Equal(t, [][]byte{[]byte("push")}, src.written())
@@ -196,7 +188,6 @@ func TestCoalescingConnTimerFlushesWhenReaderStalls(t *testing.T) {
 	require.NoError(t, err)
 	assert.Eventually(t, func() bool { return src.writeCount() == 1 }, time.Second, time.Millisecond)
 
-	// A reader that did not come back is not consuming: later writes go straight through.
 	require.Eventually(t, func() bool { return !c.batch.Load() }, time.Second, time.Millisecond)
 	_, err = c.Write([]byte("next"))
 	require.NoError(t, err)
@@ -212,7 +203,7 @@ func TestCoalescingConnLargeWriteGoesDirectAfterPending(t *testing.T) {
 	big := bytes.Repeat([]byte{'x'}, coalesceLimit)
 	_, err = c.Write(big)
 	require.NoError(t, err)
-	assert.Equal(t, [][]byte{[]byte("small"), big}, src.written(), "pending bytes leave first, then the frame that did not fit")
+	assert.Equal(t, [][]byte{[]byte("small"), big}, src.written())
 }
 
 func TestCoalescingConnCloseFlushesAndIsIdempotent(t *testing.T) {
@@ -241,7 +232,7 @@ func TestCoalescingConnHandshakeWaitsForAttach(t *testing.T) {
 	assert.Equal(t, [][]byte{response}, src.written())
 
 	deadlines := src.writeDeadlines()
-	require.Len(t, deadlines, 2, "the handshake timeout is set for the 101 and cleared after it")
+	require.Len(t, deadlines, 2)
 	assert.False(t, deadlines[0].IsZero())
 	assert.True(t, deadlines[1].IsZero())
 }
@@ -260,13 +251,13 @@ func TestCoalescingConnWritesBypassHijackedReader(t *testing.T) {
 
 	_, err := c.Write([]byte("out"))
 	require.NoError(t, err)
-	assert.Equal(t, [][]byte{[]byte("out")}, raw.written(), "writes go to the socket underneath")
+	assert.Equal(t, [][]byte{[]byte("out")}, raw.written())
 	assert.Equal(t, 0, src.writeCount())
 
 	feedAndRead(t, c, src, "in")
 
 	require.NoError(t, c.Close())
-	assert.True(t, src.isClosed(), "closing the hijacked conn is what hands it back to fasthttp")
+	assert.True(t, src.isClosed())
 }
 
 func TestCoalescingConnWriteErrorIsSticky(t *testing.T) {
@@ -280,7 +271,7 @@ func TestCoalescingConnWriteErrorIsSticky(t *testing.T) {
 	require.EqualError(t, err, "boom")
 }
 
-// clientFrame builds one masked client frame for a payload of up to 125 bytes.
+// clientFrame builds one masked client frame (payload up to 125 bytes).
 func clientFrame(op int, payload []byte) []byte {
 	key := [4]byte{1, 2, 3, 4}
 	f := []byte{0x80 | byte(op), 0x80 | byte(len(payload))}
@@ -325,8 +316,7 @@ func TestCoalesceWritesPipelinedEcho(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	// Sixteen frames in one write, as a pipelining peer sends them: every echo
-	// must come back, in order, and nothing may wait for a frame that never comes.
+	// Sixteen frames in one write, as a pipelining peer sends them.
 	const frames = 16
 	var burst []byte
 	for i := range frames {
@@ -349,8 +339,7 @@ func TestCoalesceWritesRejectionsKeepStatuses(t *testing.T) {
 		c.Set("X-Request-ID", "req-1")
 		return c.Next()
 	})
-	// All rather than Get, so a POST reaches the middleware and its 405 rather
-	// than the router's.
+	// All, so a POST reaches the middleware's 405 rather than the router's.
 	app.All("/ws", New(func(*Conn) {}, Config{CoalesceWrites: true, Origins: []string{"http://allowed"}}))
 
 	full := [][2]string{
@@ -536,7 +525,7 @@ func TestCoalesceWritesHandlerReturnLeavesSocketOpen(t *testing.T) {
 	assert.NoError(t, <-writeErr)
 }
 
-// listenTestApp serves app on :3000 and returns once it accepts connections.
+// listenTestApp serves app on :3000 and waits until it accepts connections.
 func listenTestApp(t *testing.T, app *fiber.App) {
 	t.Helper()
 	go func() {

--- a/v3/websocket/event/README.md
+++ b/v3/websocket/event/README.md
@@ -132,8 +132,8 @@ hard default.
 
 | Config field        | Default | Description |
 |:--------------------|:--------|:------------|
-| `PingInterval`      | `1s`    | Interval between server-originated Ping frames. Must be less than any upstream proxy or load balancer idle timeout. |
-| `ReadIdleTimeout`   | `3 * PingInterval` | Maximum silence before the read deadline fires and the connection is disconnected. |
+| `PingInterval`      | `25s`   | Interval between server-originated Ping frames. Socket.IO's default; must be less than any upstream proxy or load balancer idle timeout. |
+| `ReadIdleTimeout`   | `PingInterval + 20s` | Maximum silence before the connection is disconnected. The 20s is Socket.IO's ping timeout, so a peer that stops answering is dropped 45s into its silence. |
 | `WriteTimeout`      | `10s`   | Bounds a single `WriteMessage` / `WriteControl` call. |
 | `MaxMessageSize`    | `1 MiB` | Inbound frame size limit. Set to `math.MaxInt64` to opt out. |
 | `SendQueueSize`     | `100`   | Per-connection outbound message queue capacity. |

--- a/v3/websocket/event/README.md
+++ b/v3/websocket/event/README.md
@@ -133,7 +133,8 @@ hard default.
 | Config field        | Default | Description |
 |:--------------------|:--------|:------------|
 | `PingInterval`      | `25s`   | Interval between server-originated Ping frames. Socket.IO's default; must be less than any upstream proxy or load balancer idle timeout. |
-| `ReadIdleTimeout`   | `PingInterval + 20s` | Maximum silence before the connection is disconnected. The 20s is Socket.IO's ping timeout, so a peer that stops answering is dropped 45s into its silence. |
+| `PingTimeout`       | `20s`   | How long a peer may stay silent after a Ping before it is considered dead. Socket.IO's default. |
+| `ReadIdleTimeout`   | `PingInterval + PingTimeout` | Maximum silence before the connection is disconnected, 45s by default. |
 | `WriteTimeout`      | `10s`   | Bounds a single `WriteMessage` / `WriteControl` call. |
 | `MaxMessageSize`    | `1 MiB` | Inbound frame size limit. Set to `math.MaxInt64` to opt out. |
 | `SendQueueSize`     | `100`   | Per-connection outbound message queue capacity. |

--- a/v3/websocket/event/README.md
+++ b/v3/websocket/event/README.md
@@ -126,9 +126,11 @@ closes.
 
 ## Configuration
 
-Per-instance tuning via `event.Config` passed to `NewWithConfig`. Zero values
-fall back to the matching package-level var, which itself falls back to the
-hard default.
+Per-instance tuning via `event.Config` passed to `NewWithConfig`. A zero value
+falls back to the default below. `PingInterval` consults the package-level
+`PongTimeout` first, and `SendQueueSize`, `MaxSendRetry` and `RetrySendTimeout`
+the package-level vars of the same name; the other fields have no package-level
+counterpart.
 
 | Config field        | Default | Description |
 |:--------------------|:--------|:------------|

--- a/v3/websocket/event/event.go
+++ b/v3/websocket/event/event.go
@@ -75,13 +75,13 @@ var (
 var (
 	// PongTimeout is the interval between server-originated Ping frames.
 	// Despite its name, this helper uses Ping for liveness; the historical
-	// name is preserved for backwards compatibility. The value must be less
-	// than any upstream proxy or load balancer idle timeout.
+	// name is preserved for backwards compatibility. The default is
+	// Socket.IO's, chosen to stay under common proxy and NAT idle timeouts.
 	//
 	// Deprecated: prefer Config.PingInterval passed to NewWithConfig. The
 	// package-level value is read once per connection at upgrade time;
 	// mutating it after that has no effect on running connections.
-	PongTimeout = time.Second
+	PongTimeout = defaultPingInterval
 	// RetrySendTimeout controls how long a queued message waits before retrying.
 	RetrySendTimeout = 20 * time.Millisecond
 	// MaxSendRetry defines the max retries for transient socket write issues.
@@ -94,6 +94,13 @@ var (
 	// Deprecated: ReadTimeout is a no-op. Configure Config.ReadIdleTimeout
 	// on NewWithConfig for the actual read deadline behaviour.
 	ReadTimeout = 10 * time.Millisecond
+)
+
+// Socket.IO's heartbeat: a ping every 25s, and a peer that has not answered
+// 20s after one is gone, so 45s of silence ends a connection.
+const (
+	defaultPingInterval = 25 * time.Second
+	defaultPongTimeout  = 20 * time.Second
 )
 
 type message struct {
@@ -124,10 +131,10 @@ type EventPayload struct {
 type Config struct {
 	// PingInterval is the interval between server-originated Ping frames.
 	// Must be less than any upstream proxy or load balancer idle timeout.
-	// Zero falls back to PongTimeout, then 1s.
+	// Zero falls back to PongTimeout, then 25s.
 	PingInterval time.Duration
 	// ReadIdleTimeout bounds how long a connection may stay silent before
-	// it is considered dead. Zero falls back to 3 * PingInterval.
+	// it is considered dead. Zero falls back to PingInterval + 20s.
 	ReadIdleTimeout time.Duration
 	// WriteTimeout bounds a single WriteMessage or WriteControl call. Zero
 	// falls back to 10s.
@@ -175,11 +182,11 @@ func resolveSettings(cfg Config) settings {
 	if s.pingInterval <= 0 {
 		s.pingInterval = PongTimeout
 		if s.pingInterval <= 0 {
-			s.pingInterval = time.Second
+			s.pingInterval = defaultPingInterval
 		}
 	}
 	if s.readIdleTimeout <= 0 {
-		s.readIdleTimeout = 3 * s.pingInterval
+		s.readIdleTimeout = s.pingInterval + defaultPongTimeout
 	}
 	if s.writeTimeout <= 0 {
 		s.writeTimeout = 10 * time.Second

--- a/v3/websocket/event/event.go
+++ b/v3/websocket/event/event.go
@@ -100,7 +100,7 @@ var (
 // 20s after one is gone, so 45s of silence ends a connection.
 const (
 	defaultPingInterval = 25 * time.Second
-	defaultPongTimeout  = 20 * time.Second
+	defaultPingTimeout  = 20 * time.Second
 )
 
 type message struct {
@@ -133,8 +133,11 @@ type Config struct {
 	// Must be less than any upstream proxy or load balancer idle timeout.
 	// Zero falls back to PongTimeout, then 25s.
 	PingInterval time.Duration
+	// PingTimeout is how long a peer may stay silent after a Ping before it
+	// is considered dead. Zero falls back to 20s.
+	PingTimeout time.Duration
 	// ReadIdleTimeout bounds how long a connection may stay silent before
-	// it is considered dead. Zero falls back to PingInterval + 20s.
+	// it is considered dead. Zero falls back to PingInterval + PingTimeout.
 	ReadIdleTimeout time.Duration
 	// WriteTimeout bounds a single WriteMessage or WriteControl call. Zero
 	// falls back to 10s.
@@ -159,6 +162,7 @@ type Config struct {
 // settings is the per-connection immutable snapshot.
 type settings struct {
 	pingInterval     time.Duration
+	pingTimeout      time.Duration
 	readIdleTimeout  time.Duration
 	writeTimeout     time.Duration
 	maxMessageSize   int64
@@ -171,6 +175,7 @@ type settings struct {
 func resolveSettings(cfg Config) settings {
 	s := settings{
 		pingInterval:     cfg.PingInterval,
+		pingTimeout:      cfg.PingTimeout,
 		readIdleTimeout:  cfg.ReadIdleTimeout,
 		writeTimeout:     cfg.WriteTimeout,
 		maxMessageSize:   cfg.MaxMessageSize,
@@ -185,8 +190,11 @@ func resolveSettings(cfg Config) settings {
 			s.pingInterval = defaultPingInterval
 		}
 	}
+	if s.pingTimeout <= 0 {
+		s.pingTimeout = defaultPingTimeout
+	}
 	if s.readIdleTimeout <= 0 {
-		s.readIdleTimeout = s.pingInterval + defaultPongTimeout
+		s.readIdleTimeout = s.pingInterval + s.pingTimeout
 	}
 	if s.writeTimeout <= 0 {
 		s.writeTimeout = 10 * time.Second

--- a/v3/websocket/event/event.go
+++ b/v3/websocket/event/event.go
@@ -5,7 +5,6 @@ package event
 import (
 	"context"
 	"errors"
-	"io"
 	"maps"
 	"net"
 	"slices"
@@ -929,7 +928,7 @@ func (kws *Websocket) read(ctx context.Context) {
 		default:
 		}
 
-		mType, msg, err := readFrame(conn)
+		mType, msg, err := conn.ReadMessage()
 		if err != nil {
 			// Control frames (Ping, Pong, Close) are handled by the
 			// library's Set*Handler hooks above. An orderly client close
@@ -949,100 +948,12 @@ func (kws *Websocket) read(ctx context.Context) {
 
 		switch mType {
 		case TextMessage, BinaryMessage:
-			// readFrame returns a copy made for this frame, so the fan-out owns it.
+			// ReadMessage returns a copy made for this frame, so the fan-out owns it.
 			kws.fireOwnedEvent(EventMessage, msg, nil)
 		default:
 			// Defensive: NextReader never delivers control frames.
 		}
 	}
-}
-
-// frameReader reads one message into a growable buffer and returns an
-// exact-size copy, where ReadMessage's io.ReadAll starts at 512 bytes and
-// doubles. Readers are pooled: an idle connection holds no buffer and the GC
-// trims the pool.
-type frameReader struct {
-	buf   []byte
-	probe [1]byte
-}
-
-const (
-	// frameBufferInitial is what a fresh buffer starts at, io.ReadAll's own
-	// figure.
-	frameBufferInitial = 512
-	// frameBufferRetained caps what goes back into the pool, so one big frame does
-	// not leave its size behind.
-	frameBufferRetained = 64 << 10
-)
-
-var framePool = sync.Pool{New: func() interface{} { return new(frameReader) }}
-
-// readFrame reads the next data message from conn and returns a copy the
-// caller owns.
-func readFrame(conn *websocket.Conn) (int, []byte, error) {
-	mType, r, err := conn.NextReader()
-	if err != nil {
-		return mType, nil, err
-	}
-	fr := framePool.Get().(*frameReader)
-	msg, err := fr.readAll(r)
-	fr.release()
-	return mType, msg, err
-}
-
-func (fr *frameReader) readAll(r io.Reader) ([]byte, error) {
-	buf := fr.buf[:0]
-	if cap(buf) == 0 {
-		buf = make([]byte, 0, frameBufferInitial)
-	}
-	for {
-		if len(buf) == cap(buf) {
-			// Full: probe one byte so a message that exactly fills the buffer does not
-			// double it.
-			n, err := r.Read(fr.probe[:])
-			if n > 0 {
-				grown := make([]byte, len(buf), 2*cap(buf))
-				copy(grown, buf)
-				buf = append(grown, fr.probe[0])
-			}
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			if err != nil {
-				fr.buf = buf
-				return nil, err
-			}
-			continue
-		}
-		n, err := r.Read(buf[len(buf):cap(buf)])
-		buf = buf[:len(buf)+n]
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		if err != nil {
-			fr.buf = buf
-			return nil, err
-		}
-	}
-	msg := make([]byte, len(buf))
-	copy(msg, buf)
-	fr.buf = buf
-	return msg, nil
-}
-
-// release puts the reader back into the pool, minus a buffer that grew past
-// frameBufferRetained.
-func (fr *frameReader) release() {
-	fr.trim()
-	framePool.Put(fr)
-}
-
-func (fr *frameReader) trim() {
-	if cap(fr.buf) > frameBufferRetained {
-		fr.buf = nil
-		return
-	}
-	fr.buf = fr.buf[:0]
 }
 
 // disconnected tears the connection down once and reports whether this call

--- a/v3/websocket/event/event_test.go
+++ b/v3/websocket/event/event_test.go
@@ -587,6 +587,19 @@ func TestCloseConnNilsConnField(t *testing.T) {
 	require.Nil(t, kws.Conn)
 }
 
+func TestHeartbeatDefaultsMirrorSocketIO(t *testing.T) {
+	s := resolveSettings(Config{})
+	require.Equal(t, 25*time.Second, s.pingInterval)
+	require.Equal(t, 45*time.Second, s.readIdleTimeout)
+
+	// The idle timeout follows a custom interval by the same 20s allowance
+	// instead of a multiple of it, and an explicit value wins.
+	s = resolveSettings(Config{PingInterval: 10 * time.Second})
+	require.Equal(t, 30*time.Second, s.readIdleTimeout)
+	s = resolveSettings(Config{PingInterval: 10 * time.Second, ReadIdleTimeout: time.Minute})
+	require.Equal(t, time.Minute, s.readIdleTimeout)
+}
+
 func TestPingIsSentAtInterval(t *testing.T) {
 	resetState()
 

--- a/v3/websocket/event/event_test.go
+++ b/v3/websocket/event/event_test.go
@@ -592,10 +592,12 @@ func TestHeartbeatDefaultsMirrorSocketIO(t *testing.T) {
 	require.Equal(t, 25*time.Second, s.pingInterval)
 	require.Equal(t, 45*time.Second, s.readIdleTimeout)
 
-	// The idle timeout follows a custom interval by the same 20s allowance
-	// instead of a multiple of it, and an explicit value wins.
+	// The idle timeout follows a custom interval by the ping timeout instead
+	// of a multiple of it, and an explicit value wins.
 	s = resolveSettings(Config{PingInterval: 10 * time.Second})
 	require.Equal(t, 30*time.Second, s.readIdleTimeout)
+	s = resolveSettings(Config{PingInterval: 10 * time.Second, PingTimeout: 5 * time.Second})
+	require.Equal(t, 15*time.Second, s.readIdleTimeout)
 	s = resolveSettings(Config{PingInterval: 10 * time.Second, ReadIdleTimeout: time.Minute})
 	require.Equal(t, time.Minute, s.readIdleTimeout)
 }

--- a/v3/websocket/event/event_test.go
+++ b/v3/websocket/event/event_test.go
@@ -1603,7 +1603,7 @@ func TestFrameReaderHandsOutExactSizeOwnedCopies(t *testing.T) {
 	app.Get("/", fws.New(func(c *fws.Conn) {
 		var prev, prevCopy []byte
 		for {
-			_, msg, err := readFrame(c)
+			_, msg, err := c.ReadMessage()
 			if err != nil {
 				return
 			}
@@ -1629,7 +1629,8 @@ func TestFrameReaderHandsOutExactSizeOwnedCopies(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = conn.Close() }()
 
-	sizes := []int{0, 1, frameBufferInitial - 1, frameBufferInitial, frameBufferInitial + 1, 3000, frameBufferRetained, frameBufferRetained + 1, 16}
+	// Around the pooled reader's growth points: its 512-byte start and 64 KiB retain cap.
+	sizes := []int{0, 1, 511, 512, 513, 3000, 64 << 10, 64<<10 + 1, 16}
 	for _, size := range sizes {
 		want := make([]byte, size)
 		for i := range want {
@@ -1644,17 +1645,6 @@ func TestFrameReaderHandsOutExactSizeOwnedCopies(t *testing.T) {
 			t.Fatalf("no result for size %d", size)
 		}
 	}
-}
-
-func TestFrameReaderTrimDropsOversizedBuffers(t *testing.T) {
-	fr := &frameReader{buf: make([]byte, frameBufferRetained)}
-	fr.trim()
-	require.Equal(t, frameBufferRetained, cap(fr.buf), "a buffer within the cap goes back to the pool")
-	require.Empty(t, fr.buf)
-
-	fr = &frameReader{buf: make([]byte, frameBufferRetained+1)}
-	fr.trim()
-	require.Nil(t, fr.buf, "a buffer past the cap is dropped")
 }
 
 // frameBench is an upgraded loopback connection whose client side is a raw
@@ -1758,9 +1748,9 @@ func benchmarkFrameRead(b *testing.B, size int, exact bool) {
 		var msg []byte
 		var err error
 		if exact {
-			_, msg, err = readFrame(fb.server)
-		} else {
 			_, msg, err = fb.server.ReadMessage()
+		} else {
+			_, msg, err = fb.server.Conn.ReadMessage()
 		}
 		if err != nil {
 			b.Fatal(err)

--- a/v3/websocket/read.go
+++ b/v3/websocket/read.go
@@ -24,7 +24,7 @@ type frameReader struct {
 // exact-size copy the caller owns, where the library's ReadMessage grows a
 // fresh buffer per message. On error p is nil.
 func (conn *Conn) ReadMessage() (messageType int, p []byte, err error) {
-	messageType, r, err := conn.Conn.NextReader()
+	messageType, r, err := conn.NextReader()
 	if err != nil {
 		return messageType, nil, err
 	}

--- a/v3/websocket/read.go
+++ b/v3/websocket/read.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"io"
 	"sync"
+
+	"github.com/gofiber/utils/v2"
 )
 
 const (
@@ -65,15 +67,18 @@ func (fr *frameReader) readAll(r io.Reader) ([]byte, error) {
 			return nil, err
 		}
 	}
-	msg := make([]byte, len(buf))
-	copy(msg, buf)
 	fr.buf = buf
-	return msg, nil
+	return utils.CopyBytes(buf), nil
 }
 
 func (fr *frameReader) release() {
+	fr.trim()
+	framePool.Put(fr)
+}
+
+// trim drops a buffer that grew past frameBufferRetained.
+func (fr *frameReader) trim() {
 	if cap(fr.buf) > frameBufferRetained {
 		fr.buf = nil
 	}
-	framePool.Put(fr)
 }

--- a/v3/websocket/read.go
+++ b/v3/websocket/read.go
@@ -1,0 +1,79 @@
+package websocket
+
+import (
+	"errors"
+	"io"
+	"sync"
+)
+
+const (
+	frameBufferInitial  = 512
+	frameBufferRetained = 64 << 10
+)
+
+var framePool = sync.Pool{New: func() any { return new(frameReader) }}
+
+type frameReader struct {
+	buf   []byte
+	probe [1]byte
+}
+
+// ReadMessage reads the next data message into a pooled buffer and returns an
+// exact-size copy the caller owns, where the library's ReadMessage grows a
+// fresh buffer per message. On error p is nil.
+func (conn *Conn) ReadMessage() (messageType int, p []byte, err error) {
+	messageType, r, err := conn.Conn.NextReader()
+	if err != nil {
+		return messageType, nil, err
+	}
+	fr := framePool.Get().(*frameReader)
+	p, err = fr.readAll(r)
+	fr.release()
+	return messageType, p, err
+}
+
+func (fr *frameReader) readAll(r io.Reader) ([]byte, error) {
+	buf := fr.buf[:0]
+	if cap(buf) == 0 {
+		buf = make([]byte, 0, frameBufferInitial)
+	}
+	for {
+		if len(buf) == cap(buf) {
+			// Probe one byte so a message that exactly fills the buffer does not double it.
+			n, err := r.Read(fr.probe[:])
+			if n > 0 {
+				grown := make([]byte, len(buf), 2*cap(buf))
+				copy(grown, buf)
+				buf = append(grown, fr.probe[0])
+			}
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				fr.buf = buf
+				return nil, err
+			}
+			continue
+		}
+		n, err := r.Read(buf[len(buf):cap(buf)])
+		buf = buf[:len(buf)+n]
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			fr.buf = buf
+			return nil, err
+		}
+	}
+	msg := make([]byte, len(buf))
+	copy(msg, buf)
+	fr.buf = buf
+	return msg, nil
+}
+
+func (fr *frameReader) release() {
+	if cap(fr.buf) > frameBufferRetained {
+		fr.buf = nil
+	}
+	framePool.Put(fr)
+}

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -72,13 +72,6 @@ type Config struct {
 	// It prints stack trace to the stderr by default
 	// Optional. Default: defaultRecover
 	RecoverHandler func(*Conn)
-
-	// CoalesceWrites answers a burst of pipelined frames with one write instead
-	// of one per frame: writes made while the handler still has unread frames
-	// wait until it asks for the next one, at most 64 KiB or 1 ms. Writes made
-	// while nothing is waiting to be read go out immediately.
-	// Optional. Default: false
-	CoalesceWrites bool
 }
 
 // supportedVersion is the only WebSocket protocol version defined by RFC 6455.
@@ -164,28 +157,8 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 		return false
 	}
 
-	var coalescingUpgrader websocket.Upgrader
-	if cfg.CoalesceWrites {
-		coalescingUpgrader = newCoalescingUpgrader(&cfg, originAllowed)
-	}
+	upgrader := newUpgrader(&cfg, originAllowed)
 
-	var upgrader = websocket.FastHTTPUpgrader{
-		HandshakeTimeout:  cfg.HandshakeTimeout,
-		Subprotocols:      cfg.Subprotocols,
-		ReadBufferSize:    cfg.ReadBufferSize,
-		WriteBufferSize:   cfg.WriteBufferSize,
-		EnableCompression: cfg.EnableCompression,
-		WriteBufferPool:   cfg.WriteBufferPool,
-		// Record the status only. ctx.Error would Response.Reset, wiping headers
-		// earlier middleware set and the Sec-WebSocket-Version header; the handler
-		// returns a *fiber.Error instead.
-		Error: func(fctx *fasthttp.RequestCtx, status int, _ error) {
-			fctx.SetStatusCode(status)
-		},
-		CheckOrigin: func(fctx *fasthttp.RequestCtx) bool {
-			return originAllowed(utils.UnsafeString(fctx.Request.Header.Peek(fiber.HeaderOrigin)))
-		},
-	}
 	return func(c fiber.Ctx) error {
 		if cfg.Next != nil && cfg.Next(c) {
 			return c.Next()
@@ -211,17 +184,7 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 		// callback runs only after it has unwound.
 		conn.capture(fctx)
 
-		if cfg.CoalesceWrites {
-			return upgradeCoalescing(c, &coalescingUpgrader, conn, &cfg, handler)
-		}
-
-		if err := upgrader.Upgrade(fctx, func(fconn *websocket.Conn) {
-			runHandler(conn, fconn, cfg.RecoverHandler, handler)
-		}); err != nil { // Handshake rejected
-			return rejectHandshake(c, fctx.Response.StatusCode())
-		}
-
-		return nil
+		return upgrade(c, &upgrader, conn, &cfg, handler)
 	}
 }
 

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -73,18 +73,10 @@ type Config struct {
 	// Optional. Default: defaultRecover
 	RecoverHandler func(*Conn)
 
-	// CoalesceWrites sends the replies to a burst of pipelined frames in one
-	// write instead of one per frame. While the handler is still working
-	// through frames the peer already sent, its writes are held back and leave
-	// together the moment it asks for the next frame, on Close, when they reach
-	// 64 KiB, or after one millisecond, whichever comes first. A write made
-	// while nothing is waiting to be read goes out immediately, so a handler
-	// that only pushes is unaffected. Frames are never reordered.
-	//
-	// The upgrade then runs through the library's net/http Upgrader on a
-	// fasthttp-backed hijack. The 101 response carries the headers earlier
-	// middleware set and the handshake headers, not fasthttp's Server and Date
-	// defaults, and Sec-WebSocket-Key is validated as RFC 6455 requires.
+	// CoalesceWrites answers a burst of pipelined frames with one write instead
+	// of one per frame: writes made while the handler still has unread frames
+	// wait until it asks for the next one, at most 64 KiB or 1 ms. Writes made
+	// while nothing is waiting to be read go out immediately.
 	// Optional. Default: false
 	CoalesceWrites bool
 }
@@ -233,7 +225,6 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 	}
 }
 
-// runHandler runs the application handler on the hijacked connection.
 func runHandler(conn *Conn, fconn *websocket.Conn, recoverHandler, handler func(*Conn)) {
 	conn.Conn = fconn
 
@@ -251,8 +242,7 @@ func runHandler(conn *Conn, fconn *websocket.Conn, recoverHandler, handler func(
 	returned = true
 }
 
-// rejectHandshake turns a rejected handshake into a *fiber.Error. The
-// upgrader chose the RFC 6455 status: 403 for a bad Origin, 400 for a
+// The upgrader chose the RFC 6455 status: 403 for a bad Origin, 400 for a
 // malformed handshake, 405 for a non-GET; section 4.4 asks for the supported
 // version on rejection. A *fiber.Error keeps it on the ErrorHandler path.
 func rejectHandshake(c fiber.Ctx, status int) error {

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -26,7 +26,10 @@ type Config struct {
 	// Optional. Default: nil
 	Next func(fiber.Ctx) bool
 
-	// HandshakeTimeout specifies the duration for the handshake to complete.
+	// HandshakeTimeout bounds sending the 101 response, which fasthttp writes
+	// once the handler chain returns. The server's WriteTimeout, when set,
+	// applies instead.
+	// Optional. Default: 0 (no deadline)
 	HandshakeTimeout time.Duration
 
 	// Subprotocols lists the subprotocols the server supports in order of

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -72,6 +72,21 @@ type Config struct {
 	// It prints stack trace to the stderr by default
 	// Optional. Default: defaultRecover
 	RecoverHandler func(*Conn)
+
+	// CoalesceWrites sends the replies to a burst of pipelined frames in one
+	// write instead of one per frame. While the handler is still working
+	// through frames the peer already sent, its writes are held back and leave
+	// together the moment it asks for the next frame, on Close, when they reach
+	// 64 KiB, or after one millisecond, whichever comes first. A write made
+	// while nothing is waiting to be read goes out immediately, so a handler
+	// that only pushes is unaffected. Frames are never reordered.
+	//
+	// The upgrade then runs through the library's net/http Upgrader on a
+	// fasthttp-backed hijack. The 101 response carries the headers earlier
+	// middleware set and the handshake headers, not fasthttp's Server and Date
+	// defaults, and Sec-WebSocket-Key is validated as RFC 6455 requires.
+	// Optional. Default: false
+	CoalesceWrites bool
 }
 
 // supportedVersion is the only WebSocket protocol version defined by RFC 6455.
@@ -141,6 +156,26 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 	// mutation of cfg.Origins from changing a mounted handler.
 	allowAllOrigins := len(cfg.Origins) == 0 || slices.Contains(cfg.Origins, "*")
 	allowedOrigins := slices.Clone(cfg.Origins)
+	originAllowed := func(origin string) bool {
+		if allowAllOrigins {
+			return true
+		}
+		if origin == "" {
+			return cfg.AllowEmptyOrigin
+		}
+		// Scheme and host of an origin are case-insensitive (RFC 6454 section 4).
+		for i := range allowedOrigins {
+			if utils.EqualFold(allowedOrigins[i], origin) {
+				return true
+			}
+		}
+		return false
+	}
+
+	var coalescingUpgrader websocket.Upgrader
+	if cfg.CoalesceWrites {
+		coalescingUpgrader = newCoalescingUpgrader(&cfg, originAllowed)
+	}
 
 	var upgrader = websocket.FastHTTPUpgrader{
 		HandshakeTimeout:  cfg.HandshakeTimeout,
@@ -156,20 +191,7 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 			fctx.SetStatusCode(status)
 		},
 		CheckOrigin: func(fctx *fasthttp.RequestCtx) bool {
-			if allowAllOrigins {
-				return true
-			}
-			origin := utils.UnsafeString(fctx.Request.Header.Peek(fiber.HeaderOrigin))
-			if origin == "" {
-				return cfg.AllowEmptyOrigin
-			}
-			// Scheme and host of an origin are case-insensitive (RFC 6454 section 4).
-			for i := range allowedOrigins {
-				if utils.EqualFold(allowedOrigins[i], origin) {
-					return true
-				}
-			}
-			return false
+			return originAllowed(utils.UnsafeString(fctx.Request.Header.Peek(fiber.HeaderOrigin)))
 		},
 	}
 	return func(c fiber.Ctx) error {
@@ -197,32 +219,45 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
 		// callback runs only after it has unwound.
 		conn.capture(fctx)
 
-		if err := upgrader.Upgrade(fctx, func(fconn *websocket.Conn) {
-			conn.Conn = fconn
+		if cfg.CoalesceWrites {
+			return upgradeCoalescing(c, &coalescingUpgrader, conn, &cfg, handler)
+		}
 
-			returned := false
-			// Runs after RecoverHandler. A handler that panicked cannot be trusted with
-			// the socket and nothing else closes a hijacked connection; a normal return
-			// leaves it open.
-			defer func() {
-				if !returned {
-					_ = fconn.Close()
-				}
-			}()
-			defer cfg.RecoverHandler(conn)
-			handler(conn)
-			returned = true
+		if err := upgrader.Upgrade(fctx, func(fconn *websocket.Conn) {
+			runHandler(conn, fconn, cfg.RecoverHandler, handler)
 		}); err != nil { // Handshake rejected
-			// The upgrader chose the RFC 6455 status: 403 for a bad Origin, 400 for a
-			// malformed handshake, 405 for a non-GET; section 4.4 asks for the supported
-			// version on rejection. A *fiber.Error keeps it on the ErrorHandler path.
-			status := fctx.Response.StatusCode()
-			c.Set(fiber.HeaderSecWebSocketVersion, supportedVersion)
-			return fiber.NewError(status, utils.StatusMessage(status))
+			return rejectHandshake(c, fctx.Response.StatusCode())
 		}
 
 		return nil
 	}
+}
+
+// runHandler runs the application handler on the hijacked connection.
+func runHandler(conn *Conn, fconn *websocket.Conn, recoverHandler, handler func(*Conn)) {
+	conn.Conn = fconn
+
+	returned := false
+	// Runs after RecoverHandler. A handler that panicked cannot be trusted with
+	// the socket and nothing else closes a hijacked connection; a normal return
+	// leaves it open.
+	defer func() {
+		if !returned {
+			_ = fconn.Close()
+		}
+	}()
+	defer recoverHandler(conn)
+	handler(conn)
+	returned = true
+}
+
+// rejectHandshake turns a rejected handshake into a *fiber.Error. The
+// upgrader chose the RFC 6455 status: 403 for a bad Origin, 400 for a
+// malformed handshake, 405 for a non-GET; section 4.4 asks for the supported
+// version on rejection. A *fiber.Error keeps it on the ErrorHandler path.
+func rejectHandshake(c fiber.Ctx, status int) error {
+	c.Set(fiber.HeaderSecWebSocketVersion, supportedVersion)
+	return fiber.NewError(status, utils.StatusMessage(status))
 }
 
 // Conn https://godoc.org/github.com/gorilla/websocket#pkg-index


### PR DESCRIPTION
# Description

`fasthttp/websocket` puts every frame on the wire with its own write syscall. When a peer pipelines frames, the server reads them all in one syscall but still answers them one packet at a time. That is why the `fiber-websocket` entry in HttpArena (MDA2AV/HttpArena#1468) sits at 4.7M frames/s and 13 µs of server CPU per frame on the pipelined echo profile, while frameworks that coalesce answer at about 1 µs, and why the plain echo profile could not be improved from inside the middleware: with one frame in flight, 85% of server CPU is kernel time.

The library never batches, but it only ever talks to a `net.Conn`, so this PR makes the middleware own that connection:

- **Write coalescing (always on, no config).** The upgrade runs through the library's `net/http` `Upgrader` on a fasthttp-backed `http.Hijacker`, so the handshake logic stays the library's while the connection underneath is the middleware's. fasthttp still sends the 101: the headers the library composes are mirrored onto the response before the hijack, so `app.Test` and middleware running after `c.Next()` see the same 101 they saw before, and can add headers to it (a session cookie, a request id). A write is held back only while the handler still has unread frames from its last read, and leaves together with the rest of the batch when the handler asks for the next frame, on `Close`, at 64 KiB, or after 1 ms. A fill smaller than 12 bytes cannot hold two masked client frames, so its reply is written directly rather than held, and a write made while nothing is waiting to be read goes out immediately, so push-only handlers are unaffected. Frames are never reordered.
- **Locking that keeps the old `net.Conn` semantics.** One mutex guards the pending buffer; a second lock orders socket writes and is never taken under the first. The reader flushes only when no writer holds the socket, so it never waits behind a stalled write, and `Close` expires a writer stalled on a non-reading peer, sends what is pending within 100 ms, and closes.
- **Reads go straight to the socket.** After the hijack, whatever fasthttp had buffered past the handshake is stashed and served first; every later read bypasses fasthttp's 4 KiB `bufio.Reader`, removing a copy per inbound byte.
- **Pooled `ReadMessage` on the middleware's `Conn`.** The library's `ReadMessage` grows a fresh `io.ReadAll` buffer per message. The middleware's reads into a pooled buffer and returns an exact-size copy the caller owns. The `event` package's private frame reader moved up to back it.
- **Socket.IO heartbeat defaults in `event`.** Ping every 25 s instead of every second, and a new `PingTimeout` (20 s) so a silent peer is dropped after `PingInterval + PingTimeout`, 45 s, matching Socket.IO's `pingInterval`/`pingTimeout` and this repo's `socketio` package. The previous 1 s ping cost 46 µs of CPU per idle connection per second and woke mobile clients every second.

Fixes: no linked issue. Motivated by the third-party benchmark results in MDA2AV/HttpArena#1468.

## Changes introduced

- [x] Benchmarks: see **Performance** below; harness and method described there.
- [x] Documentation Update: `v3/websocket/README.md` (new *Reads and writes* section), `v3/websocket/event/README.md` (heartbeat defaults, `PingTimeout`).
- [x] Changelog/What's New:
  - websocket: replies to pipelined frames are coalesced into one write; 6.8× to 8.3× less server CPU per frame under pipelining, unchanged at one frame in flight.
  - websocket: `(*Conn).ReadMessage` reads through a pooled buffer, +9% throughput at 16 KiB and 64 KiB messages.
  - websocket: `Config.HandshakeTimeout` now bounds sending the 101; the fasthttp upgrader never read it.
  - websocket/event: heartbeat defaults now mirror Socket.IO (`PingInterval` 25 s, new `PingTimeout` 20 s, dead peer dropped after 45 s of silence).
- [x] Migration Guide (behaviour changes, none require code changes for the common handler shapes):
  - A write made while the handler still holds unread frames may wait until the handler's next read, at most 1 ms. A handler that writes and then does slow work before reading again sees that latency.
  - `WriteMessage` can return `nil` for bytes that leave with the next flush; a failed flush surfaces on the next read or write.
  - `Close` sends pending bytes, waiting at most 100 ms for a peer that is not reading, and interrupts a write stalled on that peer.
  - `HandshakeTimeout`, previously unused, now applies: a client that has not taken the 101 within it is dropped before the handler runs. The server's `WriteTimeout`, when set, applies instead.
  - `Sec-WebSocket-Key` is validated as RFC 6455 requires (base64 of 16 bytes); the fasthttp upgrader only checked presence.
  - `c.NetConn()` returns the middleware's connection; its `UnsafeConn()` still exposes the socket, as fasthttp's hijacked conn did.
  - `c.ReadMessage()` on the middleware's `*Conn` returns a `nil` payload on error, where the library's returns partial data; `c.Conn.ReadMessage()` is unchanged.
  - `event`: `PingInterval` default 1 s → 25 s, `ReadIdleTimeout` default `3 * PingInterval` → `PingInterval + PingTimeout`, package var `PongTimeout` 1 s → 25 s. Set `PingInterval`, `PingTimeout` or `ReadIdleTimeout` explicitly to keep the previous cadence.
- [ ] API Alignment with Express: not applicable.
- [x] API Longevity: `ReadMessage` keeps the library's signature and owned-copy contract; `PingTimeout` mirrors Socket.IO's option so the three heartbeat fields compose the same way users already know; coalescing is default behaviour with no knob, so there is nothing to deprecate later.
- [x] Examples: the README echo example is unchanged and benefits as is; zero-copy reads are shown with `NextReader` in the README.

## Type of change

- [x] Enhancement (improvement to existing features and functionality)
- [x] Performance improvement (non-breaking change which improves efficiency)
- [x] Documentation update (changes to documentation)

## Performance

### Where the middleware stood, and where this PR projects it

HttpArena runs three WebSocket profiles with 5-byte frames on 64 logical CPUs, server CPU per frame being `cpu% / rps`. The *after* column is a projection, not a measurement on their hardware: the arena runs CPU-bound, so throughput scales with server CPU per frame, and the ratio of that between `main` and this branch was measured here at the arena's shape of 8 connections per prefork child (64 for the 4096-connection runs).

| profile | fiber on `main` (measured) | fiber with this PR (projected) | best entry | best standard-mode framework |
|---|---|---|---|---|
| `echo-ws`, 1 frame in flight, 512 conns | 3.18M/s, 20.0 µs | unchanged (ratio 1.00) | ringzero-ws 4.35M/s, 14.2 µs | actix 3.34M/s, 19.1 µs |
| `echo-ws-pipeline`, 16 in flight, 512 conns | 4.75M/s, 13.0 µs | ≈ 32M/s, 1.9 µs (ratio 0.15) | ringzero-ws 66.7M/s, 0.9 µs | actix 43.7M/s, 1.5 µs |
| `echo-ws-pipeline`, 16 in flight, 4096 conns | 4.74M/s, 12.8 µs | ≈ 39M/s, 1.5 µs (ratio 0.12) | ringzero-ws 68.4M/s, 0.9 µs | actix 43.1M/s, 1.5 µs |
| `echo-ws-limited`, 10 frames per connection | 1.69M/s, 34.6 µs | unchanged (per-frame and connect cost at parity) | zix 2.25M/s, 23.3 µs | genhttp-ioxide 1.99M/s, 27 µs |

A CPU profile of the middleware server showed the frame codec and the middleware itself at about 4% of server CPU at 1 KiB messages, with syscalls and the Go scheduler at 75%; swapping the frame library (gobwas/ws over the same fasthttp hijack) changed nothing. `strace` on the pipelined shape showed the actual gap: the read side already batched (one `read` per 16 frames thanks to the library's `bufio`), but every reply was its own `write` syscall and TCP packet.

### Method

Scratch harness, not part of the PR: an echo server built once against `main`'s middleware and once against this branch, and a load client, on loopback with the client pinned to separate cores. Both servers run in the same session and are driven alternately, three repeats, medians reported; an earlier draft of this description compared runs from different sessions, which overstated the one-in-flight difference. Two shapes:

- **One prefork child mimic**: server pinned to one core with `GOMAXPROCS=1`, 5-byte binary frames, 8 or 64 connections, bursts of 16 frames written by the client in a single syscall as the arena's generator does. Server CPU per frame from the process's `utime+stime`, which is the arena's metric.
- **Throughput**: 8 connections, default `GOMAXPROCS`, client and server sharing 4 cores. Run-to-run variance is about ±10%, so only differences well above that are called out.

### Results

Server CPU per echoed 5-byte frame, one core, `main` versus this PR:

| workload | `main` | this PR | ratio |
|---|---|---|---|
| 1 frame in flight, 8 connections | 7.51 µs | 7.54 µs | 1.00 |
| 16 frames in flight, 8 connections | 5.22 µs | 0.77 µs | 0.15 |
| 16 frames in flight, 64 connections | 5.24 µs | 0.63 µs | 0.12 |

Syscalls per frame at 16 in flight, from `strace -c` over 3200 frames: `write` 1.000 → 0.065, `read` 0.064 → 0.067, total 1.06 → 0.13.

At one frame in flight the two are at parity by construction: a fill too small to hold two frames is answered directly, so the exchange takes the same path as before. Echo throughput with 8 connections and 4 shared cores is likewise within noise: 1 KiB 95k → 92k round trips/s, 16 KiB 29.7k → 31.9k.

`ReadMessage`, 8 connections, against the library's `ReadMessage` on the same connection (same-session, interleaved):

| payload | middleware `ReadMessage` | `NextReader` into a caller-owned buffer |
|---|---|---|
| 1 KiB | +2.2% | +4.6% |
| 16 KiB | +9.5% | +21.7% |
| 64 KiB | +8.6% | +18.1% |

`event` heartbeat, 2000 idle connections with readers attached, 8 s window of server CPU:

| ping interval | server CPU | per connection |
|---|---|---|
| 1 s (before) | 9.2% of one core | 46 µs/s |
| 25 s (after) | below measurement resolution | under 2 µs/s |

Unchanged: connect rate (14.3k to 14.5k upgrades/s with 8 workers on both, interleaved), and idle memory per connection (about 15.5 KiB for a plain handler; the pending buffer exists only while a batch is being answered).

### What is left

With coalescing in place the single-core profile at one frame in flight is 85% kernel time (read, write, epoll) and 9% for all of user space combined: Go runtime 3.4%, `bufio` 2.4%, frame codec 1.6%, fasthttp 0.8%, this middleware 0.5%. The one remaining syscall-level idea, waiting for readiness before reading to drop the `EAGAIN` read Go issues before parking, was prototyped and deadlocks by design: the runtime's poller resets readiness on every read call, so reads must be read-first. Nothing of coalescing's size remains inside the middleware.

## Checklist

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage. (Not applicable: no new request-handling API.)
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation in the module READMEs (this repository has no `/docs/` directory).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes (`go test -race ./...` in `v3/websocket`, both packages).
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community. (No new dependencies; `go.mod` is unchanged.)
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [x] Provided benchmarks for the new code to analyze and improve upon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqWdVBHdP7GVYYB7o5MHVS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added complete WebSocket message reading with exact-size results.
  - Added configurable ping timeout support for event-based WebSockets.
  - Added zero-copy streaming through the existing reader interface.

- **Improvements**
  - WebSocket replies to pipelined frames are now batched for improved efficiency, while push messages remain immediate.
  - Updated heartbeat defaults to 25-second ping intervals and 20-second ping timeouts.
  - Read-idle timeout now defaults to the combined ping interval and timeout.
  - Improved WebSocket upgrade, handshake validation, and connection shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->