### PR TITLE
🐛 fix(socketio): release sockets on tear-down, finish the closing handshake, cut codec allocations

### DIFF
--- a/v3/socketio/README.md
+++ b/v3/socketio/README.md
@@ -85,7 +85,7 @@ All tunables are package-level variables; override before the first connection i
 | `MaxBatchPackets`      | `256`              | Max EIO packets in a single `0x1E`-batched frame.                             |
 | `MaxEventNameLength`   | `256`              | Max length of an inbound SIO event name.                                      |
 | `MaxEventArgs`         | `256`              | Max elements (event name included) in an inbound SIO EVENT or ACK array.      |
-| `CloseTimeout`         | `5s`               | Bound on the closing handshake: how long the server keeps reading for the peer's Close frame after `Close`, and how long `Close` waits for a saturated send queue. Zero closes the socket as soon as the frames are queued. |
+| `CloseTimeout`         | `5s`               | One budget for the whole tear-down after `Close`: waiting for a slot in a saturated send queue, reading for the peer's Close frame and letting a stalled write finish all share it. Zero closes the socket as soon as the frames are queued. |
 | `WriteTimeout`         | `0` (disabled)     | Deadline for a single WebSocket frame write by the send goroutine; a peer that stops reading is otherwise only detected by the heartbeat. |
 | `OutboundAckTimeout`   | `30s`              | Default ack deadline for `EmitWithAck`.                                       |
 | `SendQueueSize`        | `100`              | Capacity of the per-connection outbound queue.                                |
@@ -96,7 +96,7 @@ All tunables are package-level variables; override before the first connection i
 | `EnablePolling`        | `false`            | If true, the handler returned from `New` also serves Engine.IO HTTP long-polling on `GET`/`POST`. |
 | `PollingMaxBufferSize` | `1_000_000`        | Cap on a single polling HTTP body (request POST or response GET drain).        |
 | `MaxPollWait`          | `30s`              | Maximum time a long-poll GET blocks waiting for outbound frames.                |
-| `PollQueueMaxFrames`   | `1024`             | Cap on buffered outbound frames per polling session; overflow honors `DropFramesOnOverflow`. |
+| `PollQueueMaxFrames`   | `1024`             | Cap on buffered outbound frames per polling session; overflow honors `DropFramesOnOverflow`. The SIO DISCONNECT and EIO CLOSE packets queued by `Close` are exempt, so a queue an `EventClose` listener filled still ends the session cleanly. |
 
 Use `socketio.Shutdown(ctx)` from `fiber.App.ShutdownWithContext` for a deterministic drain.
 
@@ -172,7 +172,7 @@ These package-level variables can be overridden before the first connection is a
 | `PingInterval`      | `25 * time.Second` | Interval between Engine.IO PING frames sent by the server to keep the connection alive.              |
 | `PingTimeout`       | `20 * time.Second` | How long the server waits for the client's PONG before considering the connection dead.              |
 | `HandshakeTimeout`  | `10 * time.Second` | Maximum time allowed for the Engine.IO / Socket.IO handshake (including namespace CONNECT) to complete. |
-| `CloseTimeout`      | `5 * time.Second`  | Bound on the closing handshake after `Close` or a client SIO DISCONNECT; the socket is closed once the peer's Close frame arrives or the timeout elapses. |
+| `CloseTimeout`      | `5 * time.Second`  | Budget for the whole tear-down after `Close` or a client SIO DISCONNECT; the socket is closed once the peer's Close frame arrives or the budget is spent, whatever it was spent on. |
 | `WriteTimeout`      | `0` (disabled)     | Deadline for a single WebSocket frame write; zero relies on the heartbeat to detect a peer that stopped reading. |
 | `MaxPayload`        | `1 << 20` (1 MiB)  | Maximum size in bytes for a single inbound WebSocket frame; oversize messages close the socket.      |
 | `MaxAuthPayload`    | `8 << 10` (8 KiB)  | Maximum size in bytes for the Socket.IO CONNECT auth JSON.                                           |
@@ -186,7 +186,7 @@ These package-level variables can be overridden before the first connection is a
 | `EnablePolling`     | `false`            | If true, the handler also accepts Engine.IO HTTP long-polling on `GET`/`POST` (opt-in fallback).      |
 | `PollingMaxBufferSize` | `1_000_000`     | Cap on a single polling HTTP body (POST request body or GET drain response body), in bytes.           |
 | `MaxPollWait`       | `30 * time.Second` | Maximum time a long-poll GET blocks waiting for outbound frames before returning an empty 200.        |
-| `PollQueueMaxFrames`| `1024`             | Maximum buffered outbound frames per polling session before overflow handling applies.               |
+| `PollQueueMaxFrames`| `1024`             | Maximum buffered outbound frames per polling session before overflow handling applies; the packets `Close` queues are exempt. |
 
 ```go
 func init() {

--- a/v3/socketio/README.md
+++ b/v3/socketio/README.md
@@ -33,7 +33,7 @@ This middleware implements the full Engine.IO v4 / Socket.IO v5 wire protocol. H
 - **Reserved-event-name guard.** User code cannot register or emit names reserved by the protocol (e.g. `connect`, `disconnect`).
 - **EIO version validation.** Handshakes that advertise an unsupported `EIO` version are rejected.
 - **Auth payload validation.** The auth blob must be a JSON object and is bounded by `MaxAuthPayload`; oversize or malformed payloads are answered with CONNECT_ERROR.
-- **DoS hardening.** `MaxPayload`, `MaxBatchPackets`, `MaxEventNameLength`, and `MaxAuthPayload` bound every attacker-controlled length.
+- **DoS hardening.** `MaxPayload`, `MaxBatchPackets`, `MaxEventNameLength`, `MaxEventArgs`, and `MaxAuthPayload` bound every attacker-controlled length and count.
 - **Lock-free listener registry** plus `atomic.Bool isAlive`, removing the per-event mutex from the hot path.
 - **Optional drop-frames-on-overflow.** When `DropFramesOnOverflow` is true, a saturated send queue drops the offending frame and fires `EventError` instead of tearing down the connection.
 - **Graceful drain.** The package-level `Shutdown(ctx)` closes every active socket and waits for each worker to exit (or until `ctx` is cancelled).
@@ -84,6 +84,7 @@ All tunables are package-level variables; override before the first connection i
 | `MaxAuthPayload`       | `8 KiB`            | Max bytes for the SIO CONNECT auth JSON.                                      |
 | `MaxBatchPackets`      | `256`              | Max EIO packets in a single `0x1E`-batched frame.                             |
 | `MaxEventNameLength`   | `256`              | Max length of an inbound SIO event name.                                      |
+| `MaxEventArgs`         | `256`              | Max elements (event name included) in an inbound SIO EVENT or ACK array.      |
 | `CloseTimeout`         | `5s`               | Bound on the closing handshake: how long the server keeps reading for the peer's Close frame after `Close`, and how long `Close` waits for a saturated send queue. Zero closes the socket as soon as the frames are queued. |
 | `WriteTimeout`         | `0` (disabled)     | Deadline for a single WebSocket frame write by the send goroutine; a peer that stops reading is otherwise only detected by the heartbeat. |
 | `OutboundAckTimeout`   | `30s`              | Default ack deadline for `EmitWithAck`.                                       |
@@ -177,6 +178,7 @@ These package-level variables can be overridden before the first connection is a
 | `MaxAuthPayload`    | `8 << 10` (8 KiB)  | Maximum size in bytes for the Socket.IO CONNECT auth JSON.                                           |
 | `MaxBatchPackets`   | `256`              | Maximum number of Engine.IO packets accepted in a single `0x1E`-batched frame.                       |
 | `MaxEventNameLength`| `256`              | Maximum length of an inbound Socket.IO event name.                                                   |
+| `MaxEventArgs`      | `256`              | Maximum number of elements, event name included, in an inbound Socket.IO EVENT or ACK array.         |
 | `OutboundAckTimeout`| `30 * time.Second` | Default timeout used by `EmitWithAck` when no per-call timeout is supplied.                          |
 | `DropFramesOnOverflow` | `false`         | If true, saturated outbound queues drop the offending frame and fire `EventError`.                   |
 | `RetrySendTimeout`  | `20 * time.Millisecond` | Deprecated: no effect; the send goroutine writes each frame exactly once.                       |

--- a/v3/socketio/README.md
+++ b/v3/socketio/README.md
@@ -24,7 +24,11 @@ This middleware implements the full Engine.IO v4 / Socket.IO v5 wire protocol. H
 - **Inbound acks.** Client-initiated callbacks surface as `EventPayload.HasAck` / `AckID`; reply once with `payload.Ack(args...)`.
 - **Outbound acks.** Server-initiated `EmitWithAck`, `EmitWithAckTimeout`, and `EmitWithAckArgs` round-trip a callback id and invoke the supplied callback when the client acks (or on timeout/disconnect).
 - **Multi-arg events.** Inbound events expose every argument tuple as `EventPayload.Args [][]byte`; outbound `EmitArgs` / `EmitWithAckArgs` send pre-encoded JSON tuples.
-- **Deterministic heartbeat.** Server PINGs every `PingInterval`; the connection is torn down if no PONG arrives within `PingTimeout`.
+- **Deterministic heartbeat.** Server PINGs every `PingInterval`; the connection is torn down if no PONG arrives within `PingTimeout`. The heartbeat is a runtime timer, not a goroutine, and an idle read deadline of `PingInterval + PingTimeout` backs it up.
+- **Closing handshake.** `Close` queues the SIO DISCONNECT packet and a Close frame behind the emits already pending, keeps reading until the peer's Close frame arrives (bounded by `CloseTimeout`), then closes the socket, so `socket.io-client` reports `io server disconnect` and does not reconnect. A client SIO DISCONNECT is answered the same way. Every tear-down releases the socket, including when a write is stalled on a peer that stopped reading.
+- **Two goroutines per connection.** The upgrade handler's goroutine runs the read loop and one goroutine serialises writes; polling sessions own no goroutine at all.
+- **Zero-copy inbound, SWAR outbound.** Inbound events are validated once and split into sub-slices of the frame they arrived in; outbound frames are built in a single pre-sized allocation with the SWAR JSON string encoder from `gofiber/utils`, and a broadcast builds each namespace's frame once for all its recipients.
+- **Coalesced writes.** On top of the websocket middleware's write coalescing, replies to a burst of pipelined client frames leave in one write.
 - **EIO 0x1E batched frames.** Multi-packet WebSocket frames separated by ASCII RS (`0x1E`) are parsed correctly, with a hard cap (`MaxBatchPackets`) to prevent slice-header amplification.
 - **Reserved-event-name guard.** User code cannot register or emit names reserved by the protocol (e.g. `connect`, `disconnect`).
 - **EIO version validation.** Handshakes that advertise an unsupported `EIO` version are rejected.
@@ -36,7 +40,7 @@ This middleware implements the full Engine.IO v4 / Socket.IO v5 wire protocol. H
 
 ## Known limitations
 
-- **One namespace per Engine.IO connection.** Each WebSocket binds the namespace negotiated during the SIO CONNECT packet; multiplexing several namespaces over one EIO connection is not supported.
+- **One namespace per Engine.IO connection.** Each WebSocket binds the namespace negotiated during the SIO CONNECT packet; multiplexing several namespaces over one EIO connection is not supported. A CONNECT for another namespace on an established connection is answered with CONNECT_ERROR (`Invalid namespace`) instead of an acknowledgement whose events would never be delivered.
 - **No BINARY_EVENT (5) / BINARY_ACK (6).** Binary Socket.IO frames are passed through as raw `EventMessage` data; attachment reassembly is not implemented.
 - **No connection-state recovery.** Resume-on-reconnect (Socket.IO's `connectionStateRecovery` feature) is not implemented; reconnects always start a fresh session.
 - **No polling-to-WebSocket transport upgrade.** When polling is enabled, sessions that open with `transport=polling` advertise an empty `upgrades` array and stay on polling for the session lifetime. Clients that need WebSocket from the start should configure `transports: ['websocket']`.
@@ -45,10 +49,27 @@ This middleware implements the full Engine.IO v4 / Socket.IO v5 wire protocol. H
 
 #### Production hardening notes
 
-- **Rate limiting**. Each polling open allocates a `*Websocket` plus 2 short-lived goroutines. With `EnablePolling = true` an unauthenticated client can create sessions until `HandshakeTimeout` reaps idle ones (10s default). Mount `github.com/gofiber/fiber/v3/middleware/limiter` upstream of the route to bound concurrent session creation.
+- **Rate limiting**. Each polling open allocates a `*Websocket` and arms a heartbeat timer (no goroutine). With `EnablePolling = true` an unauthenticated client can create sessions until `HandshakeTimeout` reaps idle ones (10s default). Mount `github.com/gofiber/fiber/v3/middleware/limiter` upstream of the route to bound concurrent session creation.
 - **Write timeout**. A long-poll GET response that the client never reads pins a fasthttp worker on TCP backpressure. Configure `fiber.Config{WriteTimeout: ...}` (a few seconds is typically appropriate) so abandoned reads do not strand workers.
 - **Burst sizing**. `PollQueueMaxFrames` (default `1024`) bounds the per-session outbound buffer. With the default `DropFramesOnOverflow = false` a synchronous burst of more than 1024 emits inside a single listener call disconnects the session with `ErrSendQueueClosed`. Either pace large bursts across drains, raise `PollQueueMaxFrames`, or set `DropFramesOnOverflow = true` to tolerate overflow at the cost of dropped frames + `EventError`.
 - **Listener panics**. Both transports recover panics inside the `New()` callback and inside event listeners; the panic value is logged via the package `Logger` hook. Avoid `panic(string(attackerControlledBytes))` to prevent log injection in downstream consumers.
+
+## Performance
+
+The hot paths avoid `encoding/json`'s reflection and copy nothing they do not have to. Inbound frames are handed over by the websocket middleware's pooled `ReadMessage`, validated once, and split into sub-slices; outbound frames are assembled in one pre-sized buffer with `gofiber/utils`' SWAR JSON string encoder; a broadcast builds each namespace's frame once and shares it between recipients. Each WebSocket connection costs two goroutines (the upgrade handler running the read loop, plus the writer) and one runtime timer instead of four goroutines; a polling session costs none.
+
+`benchstat` over `go test -run '^$' -bench . -benchmem -count=6` on a 4 vCPU runner, before and after (in-memory listener, root namespace):
+
+| Benchmark                                         | Before               | After                | Change        |
+|:--------------------------------------------------|:---------------------|:---------------------|:--------------|
+| Parse inbound event (name + 3 args)               | 2.71 µs, 16 allocs   | 0.75 µs, 2 allocs    | -72% time     |
+| Build outbound event, JSON argument               | 716 ns, 5 allocs     | 421 ns, 1 alloc      | -41% time     |
+| Build outbound event, raw-text argument           | 1.13 µs, 12 allocs   | 198 ns, 1 alloc      | -82% time     |
+| Round trip: emit, listener, reply (1 connection)  | 15.9 µs, 24 allocs   | 8.5 µs, 10 allocs    | -47% time     |
+| Broadcast to 1024 subscribers                     | 1.58 ms, 7192 allocs | 0.54 ms, 2009 allocs | -66% time     |
+| Connect: handshake and close                      | 119 µs, 143 allocs   | 140 µs, 155 allocs   | +17% time     |
+
+The connect path is the one that got slower; almost all of it is the websocket middleware's upgrade now running through `net/http`'s upgrader on a fasthttp hijack, which is what makes write coalescing possible, and the same shift appears when the previous socketio code is built against it.
 
 ## Configuration
 
@@ -63,11 +84,13 @@ All tunables are package-level variables; override before the first connection i
 | `MaxAuthPayload`       | `8 KiB`            | Max bytes for the SIO CONNECT auth JSON.                                      |
 | `MaxBatchPackets`      | `256`              | Max EIO packets in a single `0x1E`-batched frame.                             |
 | `MaxEventNameLength`   | `256`              | Max length of an inbound SIO event name.                                      |
+| `CloseTimeout`         | `5s`               | Bound on the closing handshake: how long the server keeps reading for the peer's Close frame after `Close`, and how long `Close` waits for a saturated send queue. Zero closes the socket as soon as the frames are queued. |
+| `WriteTimeout`         | `0` (disabled)     | Deadline for a single WebSocket frame write by the send goroutine; a peer that stops reading is otherwise only detected by the heartbeat. |
 | `OutboundAckTimeout`   | `30s`              | Default ack deadline for `EmitWithAck`.                                       |
 | `SendQueueSize`        | `100`              | Capacity of the per-connection outbound queue.                                |
 | `DropFramesOnOverflow` | `false`            | If true, drop the offending frame on overflow (fires `EventError`).           |
-| `RetrySendTimeout`     | `20ms`             | Back-off between send retries.                                                |
-| `MaxSendRetry`         | `5`                | Max send retries before a frame is dropped.                                   |
+| `RetrySendTimeout`     | `20ms`             | Deprecated: no effect. The websocket middleware allocates a connection per upgrade, so there is no released connection to retry against. |
+| `MaxSendRetry`         | `5`                | Deprecated: no effect; see `RetrySendTimeout`.                                |
 | `ReadTimeout`          | `10ms`             | Deprecated: no longer consulted by the read loop; kept for backward compatibility. |
 | `EnablePolling`        | `false`            | If true, the handler returned from `New` also serves Engine.IO HTTP long-polling on `GET`/`POST`. |
 | `PollingMaxBufferSize` | `1_000_000`        | Cap on a single polling HTTP body (request POST or response GET drain).        |
@@ -148,14 +171,16 @@ These package-level variables can be overridden before the first connection is a
 | `PingInterval`      | `25 * time.Second` | Interval between Engine.IO PING frames sent by the server to keep the connection alive.              |
 | `PingTimeout`       | `20 * time.Second` | How long the server waits for the client's PONG before considering the connection dead.              |
 | `HandshakeTimeout`  | `10 * time.Second` | Maximum time allowed for the Engine.IO / Socket.IO handshake (including namespace CONNECT) to complete. |
+| `CloseTimeout`      | `5 * time.Second`  | Bound on the closing handshake after `Close` or a client SIO DISCONNECT; the socket is closed once the peer's Close frame arrives or the timeout elapses. |
+| `WriteTimeout`      | `0` (disabled)     | Deadline for a single WebSocket frame write; zero relies on the heartbeat to detect a peer that stopped reading. |
 | `MaxPayload`        | `1 << 20` (1 MiB)  | Maximum size in bytes for a single inbound WebSocket frame; oversize messages close the socket.      |
 | `MaxAuthPayload`    | `8 << 10` (8 KiB)  | Maximum size in bytes for the Socket.IO CONNECT auth JSON.                                           |
 | `MaxBatchPackets`   | `256`              | Maximum number of Engine.IO packets accepted in a single `0x1E`-batched frame.                       |
 | `MaxEventNameLength`| `256`              | Maximum length of an inbound Socket.IO event name.                                                   |
 | `OutboundAckTimeout`| `30 * time.Second` | Default timeout used by `EmitWithAck` when no per-call timeout is supplied.                          |
 | `DropFramesOnOverflow` | `false`         | If true, saturated outbound queues drop the offending frame and fire `EventError`.                   |
-| `RetrySendTimeout`  | `20 * time.Millisecond` | Back-off between WebSocket send retries.                                                        |
-| `MaxSendRetry`      | `5`                | Maximum number of WebSocket send retries before a frame is dropped.                                  |
+| `RetrySendTimeout`  | `20 * time.Millisecond` | Deprecated: no effect; the send goroutine writes each frame exactly once.                       |
+| `MaxSendRetry`      | `5`                | Deprecated: no effect; see `RetrySendTimeout`.                                                       |
 | `EnablePolling`     | `false`            | If true, the handler also accepts Engine.IO HTTP long-polling on `GET`/`POST` (opt-in fallback).      |
 | `PollingMaxBufferSize` | `1_000_000`     | Cap on a single polling HTTP body (POST request body or GET drain response body), in bytes.           |
 | `MaxPollWait`       | `30 * time.Second` | Maximum time a long-poll GET blocks waiting for outbound frames before returning an empty 200.        |
@@ -499,11 +524,11 @@ socket.on("disconnect", (reason) => {
 | Const           | Event        | Description                                                                                                                                                |
 |:----------------|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | EventMessage    | `message`    | Fired when a `socket.emit("message", …)` event is received from the client                                                                                |
-| EventPing       | `ping`       | Fired when a WebSocket PING control frame is received (RFC 6455). Engine.IO PING is server-originated and not surfaced via this event.                     |
+| EventPing       | `ping`       | Fired when a WebSocket PING control frame is received (RFC 6455); `Data` carries its payload. Engine.IO PING is server-originated and not surfaced via this event. |
 | EventPong       | `pong`       | Fired when an Engine.IO PONG (`"3"`) replies to the server's heartbeat or when a WebSocket PONG control frame is received.                                 |
-| EventDisconnect | `disconnect` | Fired on disconnection. The error provided in disconnection event as defined in RFC 6455, section 11.7.                                                    |
+| EventDisconnect | `disconnect` | Fired exactly once on disconnection. `Error` is nil for a clean close (`Close`, a client SIO DISCONNECT, or a peer Close frame with code 1000, 1001 or none, RFC 6455 section 11.7) and carries the cause otherwise. |
 | EventConnect    | `connect`    | Fired after the Engine.IO / Socket.IO handshake completes; `ep.HandshakeAuth` is populated with the client's `auth` payload (raw JSON, nil if not provided) |
-| EventClose      | `close`      | Fired when the connection is actively closed from the server. Different from client disconnection                                                          |
+| EventClose      | `close`      | Fired exactly once when the connection is actively closed from the server via `Close`, before the closing frames are queued: frames a listener emits still reach the client. Different from client disconnection |
 | EventError      | `error`      | Fired when some error appears useful also for debugging websockets                                                                                         |
 
 Custom events map directly to the event name used in `socket.emit("myEvent", …)` on the client and `kws.EmitEvent("myEvent", data)` on the server.
@@ -515,9 +540,9 @@ Custom events map directly to the event name used in `socket.emit("myEvent", …
 | Kws              | `*Websocket`        | The connection object                                                                             |
 | Name             | `string`            | The name of the event                                                                             |
 | SocketUUID       | `string`            | Unique connection UUID                                                                            |
-| SocketAttributes | `map[string]any`    | Optional websocket attributes                                                                     |
+| SocketAttributes | `map[string]any`    | Snapshot of the connection's attributes at dispatch time; nil when none were set                  |
 | Error            | `error`             | (optional) Fired from disconnection or error events                                               |
-| Data             | `[]byte`            | Raw JSON of the event payload (first argument of `socket.emit`)                                   |
+| Data             | `[]byte`            | Raw JSON of the event payload (first argument of `socket.emit`); a sub-slice of the frame the event arrived in, safe to retain |
 | Args             | `[][]byte`          | All raw JSON arguments after the event name; useful when the client emits multiple values         |
 | AckID            | `uint64`            | Ack id assigned by the client when it emitted with a callback (0 if `HasAck` is false)            |
 | HasAck           | `bool`              | True when the inbound event expects an ack reply; respond via `EventPayload.Ack(args...)`         |

--- a/v3/socketio/README.md
+++ b/v3/socketio/README.md
@@ -94,7 +94,7 @@ All tunables are package-level variables; override before the first connection i
 | `MaxSendRetry`         | `5`                | Deprecated: no effect; see `RetrySendTimeout`.                                |
 | `ReadTimeout`          | `10ms`             | Deprecated: no longer consulted by the read loop; kept for backward compatibility. |
 | `EnablePolling`        | `false`            | If true, the handler returned from `New` also serves Engine.IO HTTP long-polling on `GET`/`POST`. |
-| `PollingMaxBufferSize` | `1_000_000`        | Cap on a single polling HTTP body (request POST or response GET drain).        |
+| `PollingMaxBufferSize` | `1_000_000`        | Cap on a single polling HTTP body (request POST or response GET drain). The drain that ends a session always carries the SIO DISCONNECT and EIO CLOSE packets; farewell frames that do not fit beside them are dropped. |
 | `MaxPollWait`          | `30s`              | Maximum time a long-poll GET blocks waiting for outbound frames.                |
 | `PollQueueMaxFrames`   | `1024`             | Cap on buffered outbound frames per polling session; overflow honors `DropFramesOnOverflow`. The SIO DISCONNECT and EIO CLOSE packets queued by `Close` are exempt, so a queue an `EventClose` listener filled still ends the session cleanly. |
 
@@ -184,7 +184,7 @@ These package-level variables can be overridden before the first connection is a
 | `RetrySendTimeout`  | `20 * time.Millisecond` | Deprecated: no effect; the send goroutine writes each frame exactly once.                       |
 | `MaxSendRetry`      | `5`                | Deprecated: no effect; see `RetrySendTimeout`.                                                       |
 | `EnablePolling`     | `false`            | If true, the handler also accepts Engine.IO HTTP long-polling on `GET`/`POST` (opt-in fallback).      |
-| `PollingMaxBufferSize` | `1_000_000`     | Cap on a single polling HTTP body (POST request body or GET drain response body), in bytes.           |
+| `PollingMaxBufferSize` | `1_000_000`     | Cap on a single polling HTTP body (POST request body or GET drain response body), in bytes; the packets `Close` queues always fit in the drain that ends the session. |
 | `MaxPollWait`       | `30 * time.Second` | Maximum time a long-poll GET blocks waiting for outbound frames before returning an empty 200.        |
 | `PollQueueMaxFrames`| `1024`             | Maximum buffered outbound frames per polling session before overflow handling applies; the packets `Close` queues are exempt. |
 

--- a/v3/socketio/codec.go
+++ b/v3/socketio/codec.go
@@ -1,0 +1,480 @@
+package socketio
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/gofiber/utils/v2"
+	"github.com/gofiber/utils/v2/simd"
+)
+
+// Wire-format helpers shared by the WebSocket and HTTP long-polling
+// transports. Everything here is allocation-conscious: outbound frames are
+// built into a single pre-sized buffer, JSON strings are encoded with
+// gofiber/utils' SWAR encoder instead of encoding/json's reflection path,
+// and inbound packets are split into sub-slices of the frame they arrived
+// in rather than copied.
+
+var (
+	errNotJSONArray       = errors.New("socketio: payload is not a JSON array")
+	errEventNameNotString = errors.New("socketio: event name is not a JSON string")
+)
+
+// buildEIOOpenFrame returns the full Engine.IO OPEN frame
+// (`0{"sid":...,"upgrades":[],"pingInterval":N,"pingTimeout":N,"maxPayload":N}`)
+// for a freshly opened session. The empty "upgrades" array signals "no
+// transport upgrade available" per Engine.IO v4. The frame is assembled in
+// one allocation; the error return is kept for API stability and is always
+// nil.
+func buildEIOOpenFrame(sid string) ([]byte, error) {
+	maxPayload := MaxPayload
+	if maxPayload <= 0 {
+		maxPayload = defaultMaxPayload
+	}
+	buf := make([]byte, 0, 96+len(sid))
+	buf = append(buf, eioOpen)
+	buf = append(buf, `{"sid":`...)
+	buf = utils.AppendJSONString(buf, sid)
+	buf = append(buf, `,"upgrades":[],"pingInterval":`...)
+	buf = strconv.AppendInt(buf, PingInterval.Milliseconds(), 10)
+	buf = append(buf, `,"pingTimeout":`...)
+	buf = strconv.AppendInt(buf, PingTimeout.Milliseconds(), 10)
+	buf = append(buf, `,"maxPayload":`...)
+	buf = strconv.AppendInt(buf, maxPayload, 10)
+	buf = append(buf, '}')
+	return buf, nil
+}
+
+// appendSIOPrefix appends the "4<type>[/<ns>,]" head shared by every
+// Socket.IO packet.
+func appendSIOPrefix(buf []byte, sioType byte, namespace []byte) []byte {
+	buf = append(buf, eioMessage, sioType)
+	if len(namespace) > 0 {
+		buf = append(buf, namespace...)
+		buf = append(buf, ',')
+	}
+	return buf
+}
+
+// buildSIOConnectAckSID encodes the CONNECT ack the server sends once the
+// namespace/auth handshake succeeded: `40[/ns,]{"sid":"<sid>"}`.
+func buildSIOConnectAckSID(namespace []byte, sid string) []byte {
+	buf := make([]byte, 0, 13+len(namespace)+len(sid))
+	buf = appendSIOPrefix(buf, sioConnect, namespace)
+	buf = append(buf, `{"sid":`...)
+	buf = utils.AppendJSONString(buf, sid)
+	return append(buf, '}')
+}
+
+// buildSIOConnectError encodes a SIO CONNECT_ERROR frame
+// ("44[/ns,]<json>"). jsonMessage must already be a JSON object such as
+// `{"message":"Not authorized"}` (socket.io-protocol v5).
+func buildSIOConnectError(namespace []byte, jsonMessage string) []byte {
+	buf := make([]byte, 0, 3+len(namespace)+len(jsonMessage))
+	buf = appendSIOPrefix(buf, sioConnectError, namespace)
+	return append(buf, jsonMessage...)
+}
+
+// buildSIODisconnect encodes a SIO DISCONNECT frame. Per socket.io-protocol
+// v5 a namespaced packet is "41/<ns>," with a trailing comma separating the
+// namespace from the (empty) payload.
+func buildSIODisconnect(namespace []byte) []byte {
+	buf := make([]byte, 0, 3+len(namespace))
+	return appendSIOPrefix(buf, sioDisconnect, namespace)
+}
+
+// buildSIOEvent encodes a Socket.IO EVENT packet ready to send over the wire.
+// Format: 4 2 [/<namespace>,] [ "<event>" , <data> ]
+//
+// data may be valid JSON (object, array, string, number, etc.) or raw text.
+// Raw text is encoded as a JSON string for compatibility with earlier
+// versions that accepted arbitrary bytes in Emit.
+// namespace may be nil for the root namespace.
+func buildSIOEvent(namespace []byte, event string, data []byte) []byte {
+	if len(data) == 0 {
+		return buildSIOEventWithAck(namespace, 0, false, event, nil)
+	}
+	return buildSIOEventWithAck(namespace, 0, false, event, [][]byte{data})
+}
+
+// buildSIOEventWithAck is the ack-id aware multi-arg variant of buildSIOEvent.
+//
+// args is the slice of arguments to encode after the event name (matches the
+// JS-side socket.emit("event", a, b, c) shape). Entries that are valid JSON are
+// passed through unchanged; raw text entries are encoded as JSON strings.
+// Nil/empty entries are skipped.
+//
+// The buffer is sized up front so a typical event costs exactly one
+// allocation; only an event name or raw-text argument that needs escaping
+// can push it past the estimate.
+func buildSIOEventWithAck(namespace []byte, ackID uint64, hasAck bool, event string, args [][]byte) []byte {
+	size := 2 + len(namespace) + 1 + 20 + 1 + len(event) + 2 + 1
+	for _, a := range args {
+		size += len(a) + 1
+	}
+	buf := make([]byte, 0, size)
+	buf = appendSIOPrefix(buf, sioEvent, namespace)
+	if hasAck {
+		buf = strconv.AppendUint(buf, ackID, 10)
+	}
+	buf = append(buf, '[')
+	buf = utils.AppendJSONString(buf, event)
+	for _, a := range args {
+		if len(a) == 0 {
+			continue
+		}
+		buf = append(buf, ',')
+		buf = appendJSONArg(buf, a)
+	}
+	return append(buf, ']')
+}
+
+// buildSIOAck encodes a Socket.IO ACK ("43") packet.
+//
+// Format: 4 3 [/<namespace>,] <ackID> [ <args> ]
+// args may be nil/empty to send `43<id>[]`. Valid JSON args are passed
+// through; raw text args are encoded as JSON strings.
+func buildSIOAck(namespace []byte, ackID uint64, args [][]byte) []byte {
+	size := 2 + len(namespace) + 1 + 20 + 2
+	for _, a := range args {
+		size += len(a) + 1
+	}
+	buf := make([]byte, 0, size)
+	buf = appendSIOPrefix(buf, sioAck, namespace)
+	buf = strconv.AppendUint(buf, ackID, 10)
+	buf = append(buf, '[')
+	first := true
+	for _, a := range args {
+		if len(a) == 0 {
+			continue
+		}
+		if !first {
+			buf = append(buf, ',')
+		}
+		buf = appendJSONArg(buf, a)
+		first = false
+	}
+	return append(buf, ']')
+}
+
+// appendJSONArg appends one emit argument: valid JSON is copied verbatim,
+// anything else is encoded as a JSON string (byte-identical to
+// encoding/json.Marshal of the same text, HTML escaping included) using the
+// SWAR encoder from gofiber/utils. Plain text is recognised by its first
+// byte before json.Valid runs, which would otherwise allocate a syntax
+// error for every raw-text argument.
+func appendJSONArg(buf, data []byte) []byte {
+	if mayBeJSON(data) && json.Valid(data) {
+		return append(buf, data...)
+	}
+	return utils.AppendJSONString(buf, data)
+}
+
+// mayBeJSON reports whether data starts, after optional whitespace, with a
+// byte that can begin a JSON value. Anything else is raw text for sure.
+func mayBeJSON(data []byte) bool {
+	for _, c := range data {
+		switch c {
+		case ' ', '\t', '\n', '\r':
+			continue
+		case '{', '[', '"', '-', 't', 'f', 'n', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// splitSIOAckID extracts the optional leading numeric ack ID from a SIO
+// EVENT or ACK payload (the bytes after any namespace stripping). It
+// returns the ID, a flag whether one was present, and the remaining bytes.
+//
+// Hand-rolled digit accumulation avoids the string allocation that
+// strconv.ParseUint(string(data[:i])) would force on the hot inbound path.
+func splitSIOAckID(data []byte) (id uint64, has bool, rest []byte, err error) {
+	var v uint64
+	i := 0
+	for i < len(data) && data[i] >= '0' && data[i] <= '9' {
+		d := uint64(data[i] - '0')
+		if v > (math.MaxUint64-d)/10 {
+			return 0, false, data, ErrAckIDOverflow
+		}
+		v = v*10 + d
+		i++
+	}
+	if i == 0 {
+		return 0, false, data, nil
+	}
+	return v, true, data[i:], nil
+}
+
+// parseSIOEvent parses the JSON-array payload of a Socket.IO EVENT packet.
+//
+// payload is the bytes after the "42" prefix, e.g. `["message",{"key":"val"}]`.
+// It returns the event name and a slice of raw-JSON arguments (one entry
+// per element after the event name). args is nil for events without
+// arguments.
+//
+// The arguments are sub-slices of payload, not copies: both transports hand
+// the parser a buffer that belongs to the connection (the WebSocket
+// ReadMessage returns a fresh buffer per message and the polling handler
+// copies the request body once), so listeners may retain them freely.
+func parseSIOEvent(payload []byte) (string, [][]byte, error) {
+	// Name plus up to three arguments fit the first allocation.
+	elems, err := splitJSONArray(payload, make([][]byte, 0, 4))
+	if err != nil {
+		return "", nil, fmt.Errorf("socketio: failed to parse event payload: %w", err)
+	}
+	if len(elems) == 0 {
+		return "", nil, ErrEmptyEventArray
+	}
+	name, err := unquoteJSONString(elems[0])
+	if err != nil {
+		return "", nil, fmt.Errorf("socketio: failed to parse event name: %w", err)
+	}
+	if MaxEventNameLength > 0 && len(name) > MaxEventNameLength {
+		return "", nil, fmt.Errorf("socketio: event name exceeds MaxEventNameLength (%d)", MaxEventNameLength)
+	}
+	if len(elems) == 1 {
+		return name, nil, nil
+	}
+	return name, elems[1:], nil
+}
+
+// parseSIOAckArgs parses the JSON-array payload of a Socket.IO ACK packet
+// (the bytes after the ack id). Returns nil for an empty array.
+func parseSIOAckArgs(payload []byte) ([][]byte, error) {
+	elems, err := splitJSONArray(payload, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(elems) == 0 {
+		return nil, nil
+	}
+	return elems, nil
+}
+
+// splitJSONArray appends the top-level elements of the JSON array payload
+// to dst as sub-slices of payload and returns the extended slice. Leading
+// and trailing whitespace around the array and around each element is
+// dropped. It returns an error when payload is not a syntactically valid
+// JSON array.
+//
+// The payload is validated once with encoding/json's allocation-free
+// scanner, after which only structure matters: nesting depth and string
+// bodies. String bodies, which dominate typical payloads, are skipped with
+// utils.IndexAny2 (SIMD on amd64 for 32+ byte runs, SWAR otherwise) rather
+// than byte by byte.
+func splitJSONArray(payload []byte, dst [][]byte) ([][]byte, error) {
+	p := trimJSONSpace(payload)
+	if len(p) < 2 || p[0] != '[' || p[len(p)-1] != ']' || !json.Valid(p) {
+		return nil, errNotJSONArray
+	}
+	body := p[1 : len(p)-1]
+	i := 0
+	for i < len(body) {
+		for i < len(body) && isJSONSpace(body[i]) {
+			i++
+		}
+		if i >= len(body) {
+			break
+		}
+		start := i
+		depth := 0
+	scan:
+		for i < len(body) {
+			switch body[i] {
+			case '"':
+				i = skipJSONString(body, i+1)
+				continue
+			case '[', '{':
+				depth++
+			case ']', '}':
+				depth--
+			case ',':
+				if depth == 0 {
+					break scan
+				}
+			}
+			i++
+		}
+		end := i
+		for end > start && isJSONSpace(body[end-1]) {
+			end--
+		}
+		dst = append(dst, body[start:end:end])
+		i++ // past the separating comma, or past the end
+	}
+	return dst, nil
+}
+
+// skipJSONString returns the index just past the closing quote of the JSON
+// string whose body starts at i (the opening quote already consumed). A
+// backslash escapes the byte after it, so a scan for either byte never
+// stops inside an escape sequence.
+func skipJSONString(b []byte, i int) int {
+	for i < len(b) {
+		j := utils.IndexAny2(b[i:], '"', '\\')
+		if j < 0 {
+			return len(b)
+		}
+		if b[i+j] == '\\' {
+			i += j + 2
+			continue
+		}
+		return i + j + 1
+	}
+	return i
+}
+
+// unquoteJSONString decodes a JSON string literal. Literals without escape
+// sequences, the overwhelmingly common case for event names, are converted
+// with a single string allocation; the rest go through encoding/json.
+func unquoteJSONString(elem []byte) (string, error) {
+	if len(elem) < 2 || elem[0] != '"' || elem[len(elem)-1] != '"' {
+		return "", errEventNameNotString
+	}
+	body := elem[1 : len(elem)-1]
+	if bytes.IndexByte(body, '\\') < 0 {
+		return string(body), nil
+	}
+	var s string
+	if err := json.Unmarshal(elem, &s); err != nil {
+		return "", err
+	}
+	return s, nil
+}
+
+// isJSONSpace reports whether c is insignificant whitespace per RFC 8259.
+func isJSONSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+// trimJSONSpace strips RFC 8259 whitespace from both ends of b.
+func trimJSONSpace(b []byte) []byte {
+	for len(b) > 0 && isJSONSpace(b[0]) {
+		b = b[1:]
+	}
+	for len(b) > 0 && isJSONSpace(b[len(b)-1]) {
+		b = b[:len(b)-1]
+	}
+	return b
+}
+
+// extractSIOConnect parses the bytes after the "40" type prefix of a SIO
+// CONNECT packet and returns both the optional namespace (including the
+// leading "/", or nil for root) AND the optional JSON auth payload.
+//
+// Wire format: [ "/" namespace "," ] [ <json> ]
+//
+// Examples:
+//
+//	""                   -> (nil, nil)
+//	"{"token":"x"}"      -> (nil, `{"token":"x"}`)
+//	"/admin,"            -> ("/admin", nil)
+//	"/admin,{"k":1}"     -> ("/admin", `{"k":1}`)
+//	"/admin"             -> ("/admin", nil)   // no comma, no auth
+func extractSIOConnect(data []byte) (namespace, auth []byte) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	if data[0] != '/' {
+		return nil, data
+	}
+	ns, rest, found := utils.CutByte(data, ',')
+	if !found {
+		// Namespace without trailing comma (no auth payload).
+		return data, nil
+	}
+	if len(rest) == 0 {
+		return ns, nil
+	}
+	return ns, rest
+}
+
+// splitSIONamespace separates an optional "/<ns>," prefix from a packet
+// payload. Returns nil and data unchanged when no prefix is present.
+func splitSIONamespace(data []byte) (namespace, rest []byte) {
+	if len(data) == 0 || data[0] != '/' {
+		return nil, data
+	}
+	ns, rest, found := utils.CutByte(data, ',')
+	if !found {
+		return data, nil
+	}
+	return ns, rest
+}
+
+// isValidNamespace returns true when ns matches the conservative subset of
+// the socket.io namespace grammar: empty (root), or "/<segment>" with at
+// least one byte and only [A-Za-z0-9._\-/] characters. We deliberately
+// reject characters that would change framing if echoed verbatim into a
+// "42<ns>,..." event packet.
+//
+// Runs of word characters are skipped with simd.MemchrNotWord (AVX2 on
+// amd64 for 32+ byte inputs, SWAR otherwise); only the three extra
+// punctuation bytes are checked one at a time.
+func isValidNamespace(ns []byte) bool {
+	if len(ns) == 0 {
+		return true
+	}
+	if ns[0] != '/' {
+		return false
+	}
+	// A lone "/" is treated as the root namespace by socket.io and is
+	// accepted here.
+	rest := ns[1:]
+	for len(rest) > 0 {
+		i := simd.MemchrNotWord(rest)
+		if i < 0 {
+			return true
+		}
+		switch rest[i] {
+		case '_', '-', '.', '/':
+			rest = rest[i+1:]
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isValidAuthPayload returns true when the auth payload extracted from a
+// SIO CONNECT packet conforms to socket.io-protocol v5: either absent (nil
+// / empty), or a syntactically valid JSON object (i.e. first non-whitespace
+// byte is '{'). Arrays, scalars, strings, and malformed JSON are rejected.
+//
+// Also enforces the global MaxAuthPayload cap so an oversized auth payload
+// can never reach kws.handshakeAuth or user-visible state.
+func isValidAuthPayload(auth []byte) bool {
+	if len(auth) == 0 {
+		return true
+	}
+	if MaxAuthPayload > 0 && len(auth) > MaxAuthPayload {
+		return false
+	}
+	trimmed := trimJSONSpace(auth)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return false
+	}
+	return json.Valid(trimmed)
+}
+
+// isReservedEventName reports whether name is a reserved socket.io
+// lifecycle event name that must not be used as a custom event name.
+//
+// Only wire-level reserved names are blocked. Node EventEmitter internals
+// (disconnecting, newListener, removeListener) never appear on the wire and
+// must not constrain user event names.
+func isReservedEventName(name string) bool {
+	switch name {
+	case "connect", "connect_error", "disconnect":
+		return true
+	}
+	return false
+}

--- a/v3/socketio/codec.go
+++ b/v3/socketio/codec.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"unicode/utf8"
 
 	"github.com/gofiber/utils/v2"
 	"github.com/gofiber/utils/v2/simd"
@@ -340,14 +341,19 @@ func skipJSONString(b []byte, i int) int {
 }
 
 // unquoteJSONString decodes a JSON string literal. Literals without escape
-// sequences, the overwhelmingly common case for event names, are converted
-// with a single string allocation; the rest go through encoding/json.
+// sequences and with valid UTF-8, the overwhelmingly common case for event
+// names, are converted with a single string allocation; the rest go
+// through encoding/json.
 func unquoteJSONString(elem []byte) (string, error) {
 	if len(elem) < 2 || elem[0] != '"' || elem[len(elem)-1] != '"' {
 		return "", errEventNameNotString
 	}
 	body := elem[1 : len(elem)-1]
-	if bytes.IndexByte(body, '\\') < 0 {
+	// Without escapes the bytes are the string, provided they are valid
+	// UTF-8: json.Valid does not check UTF-8 inside strings, and
+	// encoding/json decodes each invalid byte as U+FFFD, so such names take
+	// the decoder path below and come out as the escaped path decodes them.
+	if bytes.IndexByte(body, '\\') < 0 && utf8.Valid(body) {
 		return string(body), nil
 	}
 	var s string

--- a/v3/socketio/codec.go
+++ b/v3/socketio/codec.go
@@ -263,7 +263,8 @@ func parseSIOAckArgs(payload []byte) ([][]byte, error) {
 // to dst as sub-slices of payload and returns the extended slice. Leading
 // and trailing whitespace around the array and around each element is
 // dropped. It returns an error when payload is not a syntactically valid
-// JSON array.
+// JSON array, or ErrTooManyArgs once more than MaxEventArgs elements would
+// be appended.
 //
 // The payload is validated once with encoding/json's allocation-free
 // scanner, after which only structure matters: nesting depth and string
@@ -276,6 +277,8 @@ func splitJSONArray(payload []byte, dst [][]byte) ([][]byte, error) {
 		return nil, errNotJSONArray
 	}
 	body := p[1 : len(p)-1]
+	limit := MaxEventArgs
+	appended := 0
 	i := 0
 	for i < len(body) {
 		for i < len(body) && isJSONSpace(body[i]) {
@@ -283,6 +286,9 @@ func splitJSONArray(payload []byte, dst [][]byte) ([][]byte, error) {
 		}
 		if i >= len(body) {
 			break
+		}
+		if limit > 0 && appended >= limit {
+			return nil, ErrTooManyArgs
 		}
 		start := i
 		depth := 0
@@ -308,6 +314,7 @@ func splitJSONArray(payload []byte, dst [][]byte) ([][]byte, error) {
 			end--
 		}
 		dst = append(dst, body[start:end:end])
+		appended++
 		i++ // past the separating comma, or past the end
 	}
 	return dst, nil

--- a/v3/socketio/go.mod
+++ b/v3/socketio/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/fasthttp/websocket v1.5.12
-	github.com/gofiber/contrib/v3/websocket v1.2.6-0.20260909131928-91add0513cdc
+	github.com/gofiber/contrib/v3/websocket v1.2.6
 	github.com/gofiber/fiber/v3 v3.5.0
 	github.com/gofiber/utils/v2 v2.5.1
 	github.com/google/uuid v1.6.0

--- a/v3/socketio/go.mod
+++ b/v3/socketio/go.mod
@@ -4,8 +4,9 @@ go 1.26.0
 
 require (
 	github.com/fasthttp/websocket v1.5.12
-	github.com/gofiber/contrib/v3/websocket v1.2.5
+	github.com/gofiber/contrib/v3/websocket v1.2.6-0.20260909131928-91add0513cdc
 	github.com/gofiber/fiber/v3 v3.5.0
+	github.com/gofiber/utils/v2 v2.5.1
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.12.1
 	github.com/valyala/fasthttp v1.74.0
@@ -13,7 +14,6 @@ require (
 
 require (
 	github.com/gofiber/schema v1.8.6 // indirect
-	github.com/gofiber/utils/v2 v2.5.1 // indirect
 	github.com/klauspost/compress v1.20.0 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect

--- a/v3/socketio/go.sum
+++ b/v3/socketio/go.sum
@@ -2,8 +2,8 @@ github.com/fasthttp/websocket v1.5.12 h1:e4RGPpWW2HTbL3zV0Y/t7g0ub294LkiuXXUuTOU
 github.com/fasthttp/websocket v1.5.12/go.mod h1:I+liyL7/4moHojiOgUOIKEWm9EIxHqxZChS+aMFltyg=
 github.com/fxamacker/cbor/v2 v2.9.3 h1:oQBnFATpNdY8gJHTndDDv5Xl4QqNaz51G5LLEPhng3Q=
 github.com/fxamacker/cbor/v2 v2.9.3/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/gofiber/contrib/v3/websocket v1.2.6-0.20260909131928-91add0513cdc h1:/VRaYQ0PyCqlPbXKVgY29L/EJpCdStuKeNvOz/K49v8=
-github.com/gofiber/contrib/v3/websocket v1.2.6-0.20260909131928-91add0513cdc/go.mod h1:QHnpSvNDsoVHrfSvnMl9ptx6x4l83moCtiT+4XM++nw=
+github.com/gofiber/contrib/v3/websocket v1.2.6 h1:5XcHejNCq460uLSdDAAp11RIrDGMHax07d0zWUZXgYc=
+github.com/gofiber/contrib/v3/websocket v1.2.6/go.mod h1:QHnpSvNDsoVHrfSvnMl9ptx6x4l83moCtiT+4XM++nw=
 github.com/gofiber/fiber/v3 v3.5.0 h1:dk7TOUH6DXJGtOLsN2XEG+0ZML7cznzHILTVozbNEK8=
 github.com/gofiber/fiber/v3 v3.5.0/go.mod h1:GOVDTW+gjJvfe0iJyVujbQ1Lnx+JUjFySJRI/9/xX/w=
 github.com/gofiber/schema v1.8.6 h1:xVlbSg3vsyKVlfzRBps2tJ7pHx1d8mSgiaJye6Lb3xs=

--- a/v3/socketio/go.sum
+++ b/v3/socketio/go.sum
@@ -2,8 +2,8 @@ github.com/fasthttp/websocket v1.5.12 h1:e4RGPpWW2HTbL3zV0Y/t7g0ub294LkiuXXUuTOU
 github.com/fasthttp/websocket v1.5.12/go.mod h1:I+liyL7/4moHojiOgUOIKEWm9EIxHqxZChS+aMFltyg=
 github.com/fxamacker/cbor/v2 v2.9.3 h1:oQBnFATpNdY8gJHTndDDv5Xl4QqNaz51G5LLEPhng3Q=
 github.com/fxamacker/cbor/v2 v2.9.3/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/gofiber/contrib/v3/websocket v1.2.5 h1:Db/nNlzfy1q2lbEpmylmXR/hgbTz1BPqMauH0ZQ2ch4=
-github.com/gofiber/contrib/v3/websocket v1.2.5/go.mod h1:bgkSqR8MuGdz9R6CCa1Cex4uuawZ9ixH6D7aNF4TKXU=
+github.com/gofiber/contrib/v3/websocket v1.2.6-0.20260909131928-91add0513cdc h1:/VRaYQ0PyCqlPbXKVgY29L/EJpCdStuKeNvOz/K49v8=
+github.com/gofiber/contrib/v3/websocket v1.2.6-0.20260909131928-91add0513cdc/go.mod h1:QHnpSvNDsoVHrfSvnMl9ptx6x4l83moCtiT+4XM++nw=
 github.com/gofiber/fiber/v3 v3.5.0 h1:dk7TOUH6DXJGtOLsN2XEG+0ZML7cznzHILTVozbNEK8=
 github.com/gofiber/fiber/v3 v3.5.0/go.mod h1:GOVDTW+gjJvfe0iJyVujbQ1Lnx+JUjFySJRI/9/xX/w=
 github.com/gofiber/schema v1.8.6 h1:xVlbSg3vsyKVlfzRBps2tJ7pHx1d8mSgiaJye6Lb3xs=

--- a/v3/socketio/polling.go
+++ b/v3/socketio/polling.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/utils/v2"
 )
 
 // EnablePolling toggles HTTP long-polling fallback support. When true, the
@@ -310,14 +311,8 @@ func handlePolling(c fiber.Ctx, callback func(kws *Websocket)) (handled bool, er
 // first SIO CONNECT POST so polling preserves the same callback ordering as
 // the WebSocket path: EIO OPEN -> SIO CONNECT -> SIO CONNECT ACK -> callback.
 func openPollingSession(c fiber.Ctx, callback func(kws *Websocket)) error {
-	kws := &Websocket{
-		queue: make(chan message, SendQueueSize),
-		done:  make(chan struct{}, 1),
-		pollQ: newPollQueue(),
-	}
-	kws.UUID = kws.createUUID()
-	kws.isAlive.Store(true)
-	kws.lastPongNanos.Store(time.Now().UnixNano())
+	kws := newWebsocket()
+	kws.pollQ = newPollQueue()
 
 	// Snapshot per-request state into immutable lookup maps. fasthttp
 	// recycles its RequestCtx after the handler returns, so capturing
@@ -326,17 +321,19 @@ func openPollingSession(c fiber.Ctx, callback func(kws *Websocket)) error {
 	// Locals, Params, Query and Cookies from the OPEN request once;
 	// listener callbacks on later transports see those frozen values.
 	// Users needing per-connection mutable state should use
-	// SetAttribute, which is transport-agnostic.
+	// SetAttribute, which is transport-agnostic. Unless the app runs with
+	// Immutable set, Fiber hands out strings that alias the request
+	// buffers, so every value is copied.
 	queries := c.Queries()
 	queriesSnap := make(map[string]string, len(queries))
 	for k, v := range queries {
-		queriesSnap[k] = v
+		queriesSnap[k] = utils.CopyString(v)
 	}
 	var paramsSnap map[string]string
 	if route := c.Route(); route != nil && len(route.Params) > 0 {
 		paramsSnap = make(map[string]string, len(route.Params))
 		for _, k := range route.Params {
-			paramsSnap[k] = c.Params(k)
+			paramsSnap[k] = utils.CopyString(c.Params(k))
 		}
 	}
 	// Locals and Cookies are usually empty for socket.io routes; lazy-
@@ -381,19 +378,12 @@ func openPollingSession(c fiber.Ctx, callback func(kws *Websocket)) error {
 		return writePollingError(c, 3)
 	}
 
-	// Heartbeat goroutine. Polling has no send goroutine (the long-poll
-	// GET handler is the sender) and no read goroutine (POST handlers
-	// are the readers). pong() emits PINGs via kws.write, which routes
-	// to pollQ.enqueue for polling sessions.
-	ctx, cancel := context.WithCancel(context.Background())
-	kws.ctx = ctx
-	kws.cancelCtx = cancel
-	kws.workersWg.Add(1)
-	go func() { defer kws.workersWg.Done(); kws.pong(ctx) }()
-	// Lifecycle goroutine: blocks until disconnected fires, then runs
-	// finishRun to cancel the ctx and join the heartbeat goroutine. This
-	// substitutes for the run() loop used by the WebSocket path.
-	go func() { <-kws.done; kws.finishRun() }()
+	// Heartbeat: a runtime timer, like the WebSocket path. Polling has
+	// no send goroutine (the long-poll GET handler is the sender) and no
+	// read goroutine (POST handlers are the readers), so a session owns
+	// no goroutine at all; the heartbeat emits PINGs via kws.write,
+	// which routes to pollQ.enqueue for polling sessions.
+	kws.startHeartbeat()
 
 	// Handshake budget: enforce parity with the WebSocket path
 	// (handshake() uses HandshakeTimeout via SetReadDeadline). Without
@@ -544,8 +534,7 @@ func ingestPolling(c fiber.Ctx, kws *Websocket) error {
 	copy(body, src)
 
 	// Any inbound HTTP body counts as proof of life for the heartbeat
-	// enforcer, mirroring the WebSocket read-loop behaviour at
-	// socketio.go:1960.
+	// enforcer, mirroring the WebSocket read loop.
 	kws.lastPongNanos.Store(time.Now().UnixNano())
 
 	rest := body

--- a/v3/socketio/polling.go
+++ b/v3/socketio/polling.go
@@ -68,6 +68,11 @@ type pollQueue struct {
 	mu     sync.Mutex
 	frames [][]byte
 	closed bool
+	// terminal counts the trailing frames that end the session (SIO
+	// DISCONNECT and EIO CLOSE, queued by Close). They stay at the tail:
+	// enqueue drops ordinary frames once they are queued, and drain
+	// carries them whatever the byte cap.
+	terminal int
 	// notify is closed by the next signalLocked call after a successful
 	// enqueue or close, waking every blocked drain. It is recreated by
 	// drain after consuming frames so the next enqueue starts a fresh
@@ -96,8 +101,9 @@ type enqueueResult int
 
 const (
 	// enqueueOK indicates the frame was buffered (or silently dropped
-	// because the queue was already closed, to match post-disconnect
-	// best-effort semantics).
+	// because the queue was already closed or the packets that end the
+	// session were already queued, to match post-disconnect best-effort
+	// semantics).
 	enqueueOK enqueueResult = iota
 	// enqueueDroppedQueueFull indicates the queue is full and
 	// DropFramesOnOverflow is true: the offending frame was discarded
@@ -115,7 +121,7 @@ const (
 func (q *pollQueue) enqueue(frame []byte) enqueueResult {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	if q.closed {
+	if q.closed || q.terminal > 0 {
 		return enqueueOK
 	}
 	if PollQueueMaxFrames > 0 && len(q.frames) >= PollQueueMaxFrames {
@@ -133,15 +139,17 @@ func (q *pollQueue) enqueue(frame []byte) enqueueResult {
 // and EIO CLOSE, past PollQueueMaxFrames: they are two small fixed frames,
 // and a peer that drained a queue an EventClose listener filled must still
 // learn the session is over rather than meet an unknown sid on its next
-// poll. Both land together, so one drain delivers both. A no-op once the
-// queue is closed.
+// poll. Both land together, so one drain delivers both, and drain keeps
+// them inside its byte cap. A no-op once the queue is closed or they are
+// already queued.
 func (q *pollQueue) enqueueTerminal(frames ...[]byte) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	if q.closed {
+	if q.closed || q.terminal > 0 {
 		return
 	}
 	q.frames = append(q.frames, frames...)
+	q.terminal = len(frames)
 	q.signalLocked()
 }
 
@@ -164,26 +172,49 @@ func (q *pollQueue) close() {
 // frame larger than maxBytes is emitted alone rather than blocking
 // forever. The closed flag indicates the session has terminated.
 //
+// Once the packets that end the session are queued, the drain that finds
+// them carries them whatever else is buffered: the sid is released right
+// after Close, so a second drain never comes. They are reserved out of
+// the byte cap first and the ordinary prefix that still fits goes ahead
+// of them; the rest is dropped.
+//
 // On ctx expiry returns (nil, false). On close with empty buffer returns
 // (nil, true).
 func (q *pollQueue) drain(ctx context.Context, maxBytes int) ([][]byte, bool) {
 	for {
 		q.mu.Lock()
 		if len(q.frames) > 0 {
+			ordinary, budget := q.frames, maxBytes
+			var terminal [][]byte
+			if q.terminal > 0 {
+				ordinary = q.frames[:len(q.frames)-q.terminal]
+				terminal = q.frames[len(q.frames)-q.terminal:]
+				for _, f := range terminal {
+					budget -= len(f) + 1
+				}
+			}
 			taken := make([][]byte, 0, len(q.frames))
 			var size int
 			i := 0
-			for ; i < len(q.frames); i++ {
-				f := q.frames[i]
+			for ; i < len(ordinary); i++ {
+				f := ordinary[i]
 				add := len(f)
 				if i > 0 {
 					add++
 				}
-				if maxBytes > 0 && size+add > maxBytes && len(taken) > 0 {
+				if maxBytes > 0 && size+add > budget && (len(taken) > 0 || terminal != nil) {
 					break
 				}
 				taken = append(taken, f)
 				size += add
+			}
+			if terminal != nil {
+				if dropped := len(ordinary) - i; dropped > 0 {
+					logf("warn", "poll_close_drop", "dropped", dropped, "cap", maxBytes)
+				}
+				taken = append(taken, terminal...)
+				i = len(q.frames)
+				q.terminal = 0
 			}
 			// Truncate in place to retain the backing array across
 			// drain cycles. nil out the slots we are dropping so the

--- a/v3/socketio/polling.go
+++ b/v3/socketio/polling.go
@@ -129,6 +129,22 @@ func (q *pollQueue) enqueue(frame []byte) enqueueResult {
 	return enqueueOK
 }
 
+// enqueueTerminal appends the packets that end a session, SIO DISCONNECT
+// and EIO CLOSE, past PollQueueMaxFrames: they are two small fixed frames,
+// and a peer that drained a queue an EventClose listener filled must still
+// learn the session is over rather than meet an unknown sid on its next
+// poll. Both land together, so one drain delivers both. A no-op once the
+// queue is closed.
+func (q *pollQueue) enqueueTerminal(frames ...[]byte) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return
+	}
+	q.frames = append(q.frames, frames...)
+	q.signalLocked()
+}
+
 // close releases any blocked drain and marks the queue terminal: future
 // enqueue calls become no-ops, and a drain that finds an empty buffer
 // returns the closed flag. Idempotent.

--- a/v3/socketio/polling.go
+++ b/v3/socketio/polling.go
@@ -327,7 +327,7 @@ func openPollingSession(c fiber.Ctx, callback func(kws *Websocket)) error {
 	queries := c.Queries()
 	queriesSnap := make(map[string]string, len(queries))
 	for k, v := range queries {
-		queriesSnap[k] = utils.CopyString(v)
+		queriesSnap[utils.CopyString(k)] = utils.CopyString(v)
 	}
 	var paramsSnap map[string]string
 	if route := c.Route(); route != nil && len(route.Params) > 0 {

--- a/v3/socketio/polling_test.go
+++ b/v3/socketio/polling_test.go
@@ -544,6 +544,86 @@ func TestPollingCloseTerminalPacketsSurviveFullQueue(t *testing.T) {
 	require.Equal(t, "1", frames[PollQueueMaxFrames+1])
 }
 
+// TestPollQueueDrainReservesTerminalPackets pins the byte-cap rule once
+// the packets that end a session are queued: the drain that carries them
+// takes the ordinary prefix that fits beside them and drops the rest,
+// because the sid is released right after and a second drain never comes.
+func TestPollQueueDrainReservesTerminalPackets(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	q := newPollQueue()
+	q.enqueue(bytes.Repeat([]byte("a"), 100))
+	q.enqueue(bytes.Repeat([]byte("b"), 100))
+	q.enqueue(bytes.Repeat([]byte("c"), 100))
+	q.enqueueTerminal([]byte("41"), []byte("1"))
+	require.Equal(t, enqueueOK, q.enqueue([]byte("late")), "frames after the terminal packets are dropped")
+	q.close()
+
+	// 150 bytes hold one 100-byte frame plus the terminal packets and
+	// their separators; the second frame no longer fits and is dropped
+	// together with the third.
+	frames, closed := q.drain(ctx, 150)
+	require.True(t, closed)
+	require.Len(t, frames, 3)
+	require.Len(t, frames[0], 100)
+	require.Equal(t, "41", string(frames[1]))
+	require.Equal(t, "1", string(frames[2]))
+	frames, closed = q.drain(ctx, 150)
+	require.True(t, closed)
+	require.Nil(t, frames)
+
+	// A cap smaller than the first ordinary frame delivers the terminal
+	// packets alone instead of the oversized frame alone.
+	q = newPollQueue()
+	q.enqueue(bytes.Repeat([]byte("a"), 100))
+	q.enqueueTerminal([]byte("41"), []byte("1"))
+	frames, _ = q.drain(ctx, 10)
+	require.Equal(t, [][]byte{[]byte("41"), []byte("1")}, frames)
+
+	// Without a cap everything goes, in order.
+	q = newPollQueue()
+	q.enqueue([]byte("x"))
+	q.enqueueTerminal([]byte("41"), []byte("1"))
+	frames, _ = q.drain(ctx, 0)
+	require.Equal(t, [][]byte{[]byte("x"), []byte("41"), []byte("1")}, frames)
+}
+
+// TestPollingCloseTerminalPacketsWithinBufferCap verifies that after Close
+// on a polling session whose EventClose listener queued more than a
+// long-poll can carry, the drain that ends the session still delivers
+// SIO DISCONNECT and EIO CLOSE within the cap.
+func TestPollingCloseTerminalPacketsWithinBufferCap(t *testing.T) {
+	resetSIOGlobals(t)
+
+	var captured atomic.Pointer[Websocket]
+	On(EventConnect, func(p *EventPayload) { captured.Store(p.Kws) })
+	farewell := []byte(`"` + strings.Repeat("a", 280) + `"`)
+	On(EventClose, func(p *EventPayload) {
+		for i := 0; i < 3; i++ {
+			p.Kws.Emit(farewell)
+		}
+	})
+
+	_, c, td := newPollingTestServer(t, func(_ *Websocket) {})
+	defer td()
+
+	sid, _, _ := pollOpen(t, c)
+	_, _ = pollPost(t, c, sid, []byte(`40`))
+	require.Eventually(t, func() bool { return captured.Load() != nil }, 2*time.Second, 10*time.Millisecond)
+	_, _ = pollGet(t, c, sid) // drain the CONNECT ack so the queue starts empty
+
+	kws := captured.Load()
+	kws.Close()
+
+	// The drain a long-poll performs, with a cap no farewell frame fits in.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	frames, closed := kws.pollQ.drain(ctx, 256)
+	require.True(t, closed)
+	require.Equal(t, [][]byte{[]byte("41"), []byte("1")}, frames)
+}
+
 // TestPollQueueDrainSemantics covers the pollQueue primitive directly:
 // FIFO order, batching, byte cap, blocking, close.
 func TestPollQueueDrainSemantics(t *testing.T) {

--- a/v3/socketio/polling_test.go
+++ b/v3/socketio/polling_test.go
@@ -457,6 +457,93 @@ func TestPollingCloseDeliversDisconnect(t *testing.T) {
 	require.Contains(t, string(body), `"code":1`)
 }
 
+// TestPollQueueEnqueueTerminalBypassesCap pins the pollQueue contract for
+// the packets that end a session: they are appended past
+// PollQueueMaxFrames, together, and are a no-op once the queue is closed.
+func TestPollQueueEnqueueTerminalBypassesCap(t *testing.T) {
+	prevCap := PollQueueMaxFrames
+	PollQueueMaxFrames = 2
+	t.Cleanup(func() { PollQueueMaxFrames = prevCap })
+
+	q := newPollQueue()
+	require.Equal(t, enqueueOK, q.enqueue([]byte("a")))
+	require.Equal(t, enqueueOK, q.enqueue([]byte("b")))
+	require.Equal(t, enqueueRejectedDisconnect, q.enqueue([]byte("c")))
+	q.enqueueTerminal([]byte("41"), []byte("1"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	frames, closed := q.drain(ctx, 0)
+	require.False(t, closed)
+	require.Equal(t, [][]byte{[]byte("a"), []byte("b"), []byte("41"), []byte("1")}, frames)
+
+	q.close()
+	q.enqueueTerminal([]byte("41"), []byte("1"))
+	frames, closed = q.drain(ctx, 0)
+	require.True(t, closed)
+	require.Nil(t, frames)
+}
+
+// TestPollingCloseTerminalPacketsSurviveFullQueue verifies that Close on a
+// polling session still queues SIO DISCONNECT and EIO CLOSE when an
+// EventClose listener filled the queue to PollQueueMaxFrames: before, both
+// enqueues were rejected and their result ignored, so the peer drained the
+// farewell frames and then met an unknown sid instead of a disconnect.
+func TestPollingCloseTerminalPacketsSurviveFullQueue(t *testing.T) {
+	resetSIOGlobals(t)
+	prevCap := PollQueueMaxFrames
+	PollQueueMaxFrames = 2
+	t.Cleanup(func() { PollQueueMaxFrames = prevCap })
+
+	var captured atomic.Pointer[Websocket]
+	On(EventConnect, func(p *EventPayload) { captured.Store(p.Kws) })
+	On(EventClose, func(p *EventPayload) {
+		for i := 0; i < PollQueueMaxFrames; i++ {
+			p.Kws.Emit([]byte(`"bye"`))
+		}
+	})
+	disc := make(chan error, 1)
+	On(EventDisconnect, func(p *EventPayload) {
+		select {
+		case disc <- p.Error:
+		default:
+		}
+	})
+
+	_, c, td := newPollingTestServer(t, func(_ *Websocket) {})
+	defer td()
+
+	sid, _, _ := pollOpen(t, c)
+	_, _ = pollPost(t, c, sid, []byte(`40`))
+	require.Eventually(t, func() bool { return captured.Load() != nil }, 2*time.Second, 10*time.Millisecond)
+	_, _ = pollGet(t, c, sid) // drain the CONNECT ack so the queue starts empty
+
+	kws := captured.Load()
+	kws.Close()
+	select {
+	case err := <-disc:
+		require.NoError(t, err, "the farewell frames must not overflow the queue")
+	case <-time.After(2 * time.Second):
+		t.Fatal("EventDisconnect did not fire")
+	}
+
+	// No long-poll was in flight, so everything is still buffered: the
+	// listener's frames up to the cap, then the two terminal packets.
+	q := kws.pollQ
+	q.mu.Lock()
+	frames := make([]string, 0, len(q.frames))
+	for _, f := range q.frames {
+		frames = append(frames, string(f))
+	}
+	q.mu.Unlock()
+	require.Len(t, frames, PollQueueMaxFrames+2)
+	for _, f := range frames[:PollQueueMaxFrames] {
+		require.True(t, strings.HasPrefix(f, "42"), "farewell frame %q is not an event", f)
+	}
+	require.Equal(t, "41", frames[PollQueueMaxFrames])
+	require.Equal(t, "1", frames[PollQueueMaxFrames+1])
+}
+
 // TestPollQueueDrainSemantics covers the pollQueue primitive directly:
 // FIFO order, batching, byte cap, blocking, close.
 func TestPollQueueDrainSemantics(t *testing.T) {

--- a/v3/socketio/polling_test.go
+++ b/v3/socketio/polling_test.go
@@ -35,7 +35,17 @@ func newPollingTestServer(t *testing.T, callback func(*Websocket)) (*fasthttputi
 	// to wait the default 30s.
 	MaxPollWait = 2 * time.Second
 
-	app := fiber.New()
+	// fasthttp's Shutdown waits for every open connection, and it counts a
+	// keep-alive connection that has not yet sent its first request as
+	// active, not idle. net/http's Transport produces exactly that when
+	// two requests race for a connection: the dial that loses the race is
+	// parked in the idle pool without ever being used. A bounded read
+	// timeout on the server side lets such a connection expire on its
+	// own, and the teardown below closes the client side first anyway.
+	app := fiber.New(fiber.Config{
+		ReadTimeout: 5 * time.Second,
+		IdleTimeout: 5 * time.Second,
+	})
 	ln := fasthttputil.NewInmemoryListener()
 
 	h := New(callback)
@@ -45,17 +55,24 @@ func newPollingTestServer(t *testing.T, callback func(*Websocket)) (*fasthttputi
 
 	go func() { _ = app.Listener(ln) }()
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return ln.Dial()
-			},
+	transport := &http.Transport{
+		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+			return ln.Dial()
 		},
-		Timeout: 10 * time.Second,
+	}
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   10 * time.Second,
 	}
 
 	return ln, client, func() {
-		_ = app.Shutdown()
+		// Close the client side first: an idle keep-alive connection,
+		// including one that never carried a request, would otherwise
+		// keep app.Shutdown waiting until its read timeout. Then bound
+		// the shutdown so a session still draining a long-poll cannot
+		// stall the whole suite.
+		transport.CloseIdleConnections()
+		_ = app.ShutdownWithTimeout(5 * time.Second)
 		_ = ln.Close()
 		EnablePolling = prevEnable
 		MaxPollWait = prevWait
@@ -353,11 +370,16 @@ func TestPollingOptionsPreflight(t *testing.T) {
 // while another is in flight is rejected with engine.io code 3.
 func TestPollingConcurrentGetsRejected(t *testing.T) {
 	resetSIOGlobals(t)
+	var captured atomic.Pointer[Websocket]
+	On(EventConnect, func(p *EventPayload) {
+		captured.Store(p.Kws)
+	})
 	_, c, td := newPollingTestServer(t, func(_ *Websocket) {})
 	defer td()
 
 	sid, _, _ := pollOpen(t, c)
 	_, _ = pollPost(t, c, sid, []byte(`40`))
+	require.Eventually(t, func() bool { return captured.Load() != nil }, 2*time.Second, 10*time.Millisecond)
 	// Drain the connect ack so the next GET will block.
 	_, _ = pollGet(t, c, sid)
 
@@ -369,8 +391,10 @@ func TestPollingConcurrentGetsRejected(t *testing.T) {
 		close(firstDone)
 	}()
 
-	// Give the first poll time to enter drain.
-	time.Sleep(50 * time.Millisecond)
+	// Wait until the first poll actually holds the gate rather than
+	// guessing with a sleep, which lost the race on a loaded CI runner.
+	require.Eventually(t, func() bool { return captured.Load().pollGate.Load() },
+		2*time.Second, 5*time.Millisecond, "first long-poll never took the gate")
 
 	body, status := pollGet(t, c, sid)
 	require.Equal(t, http.StatusBadRequest, status,
@@ -1169,8 +1193,8 @@ func TestPollingHandshakeTimeoutEnforced(t *testing.T) {
 }
 
 // TestPollingHeartbeatTimeoutTearsDown verifies that a polling session
-// torn down with ErrHeartbeatTimeout (as the pong goroutine would call
-// when the client stops responding) cleans up the session, drains any
+// torn down with ErrHeartbeatTimeout (as the heartbeat timer does when
+// the client stops responding) cleans up the session, drains any
 // in-flight long-poll, and rejects subsequent GETs with engine.io code
 // 1.
 //
@@ -1213,8 +1237,8 @@ func TestPollingHeartbeatTimeoutTearsDown(t *testing.T) {
 	_, _ = pollGet(t, c, sid)
 
 	// Start an in-flight long-poll, then simulate a heartbeat timeout
-	// from another goroutine (the production pong goroutine would do
-	// the same on PingInterval+PingTimeout expiry).
+	// from another goroutine (the production heartbeat timer does the
+	// same on PingInterval+PingTimeout expiry).
 	pollResp := make(chan int, 1)
 	go func() {
 		_, st := pollGet(t, c, sid)
@@ -1370,10 +1394,10 @@ func TestPollingQueueOverflowDrop(t *testing.T) {
 	resetSIOGlobals(t)
 
 	// Restore via t.Cleanup (runs AFTER all defers, so AFTER td()
-	// shuts down the test server and AFTER resetSIOGlobals' workersWg
-	// wait). Plain defer here would restore globals BEFORE the pong
-	// goroutine has actually exited, racing it on PollQueueMaxFrames
-	// / DropFramesOnOverflow.
+	// shuts down the test server and AFTER resetSIOGlobals waited for
+	// every session to release). Plain defer here would restore globals
+	// BEFORE a heartbeat tick has actually finished, racing it on
+	// PollQueueMaxFrames / DropFramesOnOverflow.
 	prevCap, prevDrop := PollQueueMaxFrames, DropFramesOnOverflow
 	PollQueueMaxFrames = 4
 	DropFramesOnOverflow = true
@@ -1539,8 +1563,8 @@ func TestPollingHandshakeTimerStoppedAfterConnect(t *testing.T) {
 }
 
 // TestPollingCallbackPanicCleansUp verifies that a panic in the user callback
-// during the first SIO CONNECT runs disconnected() so the lifecycle goroutine,
-// pong goroutine, and pool entry do not leak.
+// during the first SIO CONNECT runs disconnected() so the heartbeat timer
+// and pool entry do not leak.
 func TestPollingCallbackPanicCleansUp(t *testing.T) {
 	resetSIOGlobals(t)
 

--- a/v3/socketio/socketio.go
+++ b/v3/socketio/socketio.go
@@ -6,15 +6,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
-	"strconv"
+	"maps"
+	"net"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/gofiber/contrib/v3/websocket"
 	"github.com/gofiber/fiber/v3"
-	"github.com/google/uuid"
+	"github.com/gofiber/utils/v2"
 )
 
 // Engine.IO v4 packet type bytes
@@ -37,7 +37,7 @@ const (
 	// defaultMaxPayload is the fallback advertised in the EIO OPEN
 	// packet when MaxPayload is unset or non-positive. Matches the
 	// engine.io reference server default (1 MB).
-	defaultMaxPayload = 1_000_000
+	defaultMaxPayload int64 = 1_000_000
 )
 
 // Socket.IO v5 packet type bytes (carried inside an eioMessage payload)
@@ -71,6 +71,17 @@ const (
 	PongMessage = 10
 )
 
+// closeFrameMarker is the internal queue entry that asks the send goroutine
+// to perform the closing handshake once every frame queued before it is on
+// the wire: the optional SIO DISCONNECT packet carried in message.data,
+// then a Close control frame.
+const closeFrameMarker = -1
+
+// controlWriteTimeout bounds the Pong reply to a peer Ping and the Close
+// frame written by the send goroutine, so a peer that stopped reading
+// cannot park either goroutine.
+const controlWriteTimeout = 5 * time.Second
+
 // Supported event list
 const (
 	// EventMessage is fired when a text or binary message is received that is
@@ -78,7 +89,7 @@ const (
 	// or raw binary frames).
 	EventMessage = "message"
 	// EventPing is fired when a WebSocket PING control frame is received
-	// from the peer. See
+	// from the peer. EventPayload.Data carries the ping payload. See
 	// https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#Pings_and_Pongs_The_Heartbeat_of_WebSockets
 	EventPing = "ping"
 	// EventPong is fired when a WebSocket PONG control frame, or an
@@ -86,15 +97,19 @@ const (
 	EventPong = "pong"
 	// EventDisconnect is fired exactly once when the connection is torn
 	// down, regardless of which side initiated the close. The
-	// EventPayload.Error field carries the close reason (RFC 6455 section
-	// 11.7) when available, or nil for a clean shutdown.
+	// EventPayload.Error field carries the cause when the teardown was
+	// not a clean close: nil for Websocket.Close, for a client that sent
+	// SIO DISCONNECT, and for a peer Close frame with code 1000, 1001 or
+	// no code (RFC 6455 section 11.7).
 	EventDisconnect = "disconnect"
 	// EventConnect is fired exactly once after the Engine.IO and Socket.IO
 	// handshake completes, before the read loop starts dispatching events.
 	// EventPayload.HandshakeAuth carries the client's auth payload, if any.
 	EventConnect = "connect"
 	// EventClose is fired exactly once when the connection is closed from
-	// the server side via Websocket.Close.
+	// the server side via Websocket.Close, before the SIO DISCONNECT and
+	// Close frames are queued: frames a listener emits still reach the
+	// peer ahead of them.
 	EventClose = "close"
 	// EventError is fired when an error occurs on the connection (read,
 	// write, parse, or listener panic). EventPayload.Error carries the
@@ -174,27 +189,6 @@ var (
 	ErrUnknownEIOPacket = errors.New("socketio: unknown EIO packet type")
 )
 
-// reservedEventNames is the set of outbound event names the JS socket.io
-// client treats as built-in lifecycle events. Emitting any of these by
-// name from the server would either be silently swallowed or trigger
-// spurious lifecycle handlers on the client.
-//
-// Only wire-level reserved names are blocked here. Node EventEmitter
-// internals (disconnecting, newListener, removeListener) never appear
-// on the wire and must not constrain user event names.
-var reservedEventNames = map[string]struct{}{
-	"connect":       {},
-	"connect_error": {},
-	"disconnect":    {},
-}
-
-// isReservedEventName reports whether name is a reserved socket.io
-// lifecycle event name that must not be used as a custom event name.
-func isReservedEventName(name string) bool {
-	_, ok := reservedEventNames[name]
-	return ok
-}
-
 // Tunable package-level knobs. Mutate them before calling New so each new
 // connection captures the desired value; in-flight connections retain the
 // values in effect at handshake time and are not affected by later changes.
@@ -205,16 +199,20 @@ var (
 	// Deprecated: PongTimeout is no longer consulted by the heartbeat
 	// implementation. Use PingTimeout instead.
 	PongTimeout = 20 * time.Second
-	// RetrySendTimeout is the back-off delay the send goroutine waits
-	// before retrying a failed write to a temporarily unavailable
-	// connection.
+	// RetrySendTimeout was the back-off between retries of a write against
+	// a connection the websocket middleware had already released.
+	//
+	// Deprecated: the middleware allocates a connection per upgrade and
+	// never releases it while the handler runs, so there is nothing to
+	// retry; the send goroutine writes each frame exactly once. Setting
+	// it has no effect.
 	RetrySendTimeout = 20 * time.Millisecond
-	// MaxSendRetry is the maximum number of times the send goroutine
-	// retries a frame against a missing connection before dropping it.
+	// MaxSendRetry was the retry budget paired with RetrySendTimeout.
+	//
+	// Deprecated: see RetrySendTimeout; setting it has no effect.
 	MaxSendRetry = 5
-	// ReadTimeout is no longer consulted by the read loop, which now
-	// blocks in a single ReadMessage call gated by SetReadDeadline rather
-	// than busy-polling with a sleep.
+	// ReadTimeout is no longer consulted by the read loop, which blocks in
+	// a single ReadMessage call rather than busy-polling with a sleep.
 	//
 	// Deprecated: kept only for backward compatibility with code that
 	// still references the variable; setting it has no effect.
@@ -233,6 +231,20 @@ var (
 	// CONNECT packet ("40") after sending the EIO OPEN packet. Set to
 	// zero to disable.
 	HandshakeTimeout = 10 * time.Second
+	// CloseTimeout bounds the closing handshake. After Websocket.Close
+	// (or a client SIO DISCONNECT) the server sends its Close frame and
+	// keeps reading, discarding frames, until the peer's Close frame or
+	// EOF arrives, so the SIO DISCONNECT packet is never lost to a TCP
+	// reset; the socket is closed regardless once CloseTimeout elapses.
+	// It also bounds how long Close waits for a saturated send queue to
+	// accept the closing frames. Set to zero to close the socket as soon
+	// as the frames are queued. Read once per Close call.
+	CloseTimeout = 5 * time.Second
+	// WriteTimeout bounds a single WebSocket frame write by the send
+	// goroutine. A peer that stops reading is otherwise only detected by
+	// the heartbeat (PingInterval + PingTimeout). Zero disables the
+	// deadline. Read once per frame.
+	WriteTimeout time.Duration
 	// MaxPayload is the maximum size in bytes of an inbound WebSocket
 	// frame. It is advertised to the client in the EIO OPEN packet and
 	// enforced via SetReadLimit on the underlying connection: frames
@@ -349,10 +361,14 @@ type pendingAck struct {
 }
 
 // eioPingFrame is the cached single-byte EIO PING packet that the
-// heartbeat goroutine puts on the wire. Sharing one slice across every
-// emit avoids a per-tick allocation; the underlying bytes are never
-// mutated by Conn.WriteMessage.
+// heartbeat puts on the wire. Sharing one slice across every emit avoids
+// a per-tick allocation; the underlying bytes are never mutated by
+// Conn.WriteMessage.
 var eioPingFrame = []byte{eioPing}
+
+// closeFramePayload is the Close control frame payload the server sends
+// when it initiates the closing handshake.
+var closeFramePayload = websocket.FormatCloseMessage(websocket.CloseNormalClosure, "Connection closed")
 
 // Raw form of websocket message
 type message struct {
@@ -360,8 +376,6 @@ type message struct {
 	mType int
 	// Message data
 	data []byte
-	// Message send retries when error
-	retries int
 }
 
 // EventPayload is the read-only value passed to every event listener. It
@@ -370,11 +384,12 @@ type message struct {
 // and the handshake auth payload (HandshakeAuth, populated for EventConnect
 // listeners only).
 //
-// Byte-slice fields (Args, Data, HandshakeAuth) carry their own backing
-// storage independent of the read buffer: parseSIOEvent copies inbound
-// args, the read goroutine copies binary frames before dispatch, and
-// HandshakeAuth is captured during the handshake. Listeners may safely
-// retain these slices across goroutine boundaries.
+// Byte-slice fields (Args, Data, HandshakeAuth) are backed by memory that
+// belongs to the connection, never by a buffer the transport reuses: the
+// WebSocket transport hands over a fresh buffer per message, the polling
+// transport copies each request body once, and HandshakeAuth is captured
+// during the handshake. Listeners may safely retain these slices across
+// goroutine boundaries.
 type EventPayload struct {
 	// Kws is the connection that fired the event. Use it to call
 	// Emit/EmitEvent/Close from inside the listener.
@@ -388,7 +403,8 @@ type EventPayload struct {
 	SocketUUID string
 	// SocketAttributes is a defensive snapshot of the connection's
 	// attribute map taken at dispatch time. Mutating it does not affect
-	// the live connection; use Kws.SetAttribute for that.
+	// the live connection; use Kws.SetAttribute for that. It is nil when
+	// the connection has no attributes.
 	SocketAttributes map[string]any
 	// Error is the cause associated with lifecycle events such as
 	// EventDisconnect and EventError; nil for ordinary user events.
@@ -454,15 +470,6 @@ func (ep *EventPayload) Ack(args ...[]byte) error {
 	return nil
 }
 
-// eioOpenPacket holds the JSON payload sent in the Engine.IO OPEN packet.
-type eioOpenPacket struct {
-	SID          string   `json:"sid"`
-	Upgrades     []string `json:"upgrades"`
-	PingInterval int      `json:"pingInterval"`
-	PingTimeout  int      `json:"pingTimeout"`
-	MaxPayload   int      `json:"maxPayload"`
-}
-
 // runUserCallback invokes the user's New() callback inside a recover
 // block so a panicking callback cannot leak the session. Returns the
 // recovered panic value (nil on clean return). Used by both the
@@ -474,184 +481,9 @@ func runUserCallback(callback func(*Websocket), kws *Websocket) (recovered inter
 	return nil
 }
 
-// buildEIOOpenFrame returns the full Engine.IO OPEN frame bytes
-// (`0{"sid":...,"upgrades":[],"pingInterval":N,"pingTimeout":N,"maxPayload":N}`)
-// for a freshly opened session. Used by both the WebSocket handshake
-// path and the polling open handler. The empty "upgrades" array
-// signals "no transport upgrade available" per Engine.IO v4.
-func buildEIOOpenFrame(sid string) ([]byte, error) {
-	maxPayload := int(MaxPayload)
-	if maxPayload <= 0 {
-		maxPayload = defaultMaxPayload
-	}
-	data, err := json.Marshal(eioOpenPacket{
-		SID:          sid,
-		Upgrades:     []string{},
-		PingInterval: int(PingInterval.Milliseconds()),
-		PingTimeout:  int(PingTimeout.Milliseconds()),
-		MaxPayload:   maxPayload,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return append([]byte{eioOpen}, data...), nil
-}
-
-// buildSIOEvent encodes a Socket.IO EVENT packet ready to send over the wire.
-// Format: 4 2 [/<namespace>,] [ "<event>" , <data> ]
-//
-// data may be valid JSON (object, array, string, number, etc.) or raw text.
-// Raw text is encoded as a JSON string for compatibility with earlier
-// versions that accepted arbitrary bytes in Emit.
-// namespace may be nil for the root namespace.
-func buildSIOEvent(namespace []byte, event string, data []byte) []byte {
-	if len(data) == 0 {
-		return buildSIOEventWithAck(namespace, 0, false, event, nil)
-	}
-	return buildSIOEventWithAck(namespace, 0, false, event, [][]byte{data})
-}
-
-// buildSIOEventWithAck is the ack-id aware multi-arg variant of buildSIOEvent.
-//
-// args is the slice of arguments to encode after the event name (matches the
-// JS-side socket.emit("event", a, b, c) shape). Entries that are valid JSON are
-// passed through unchanged; raw text entries are encoded as JSON strings.
-// Nil/empty entries are skipped.
-//
-// The output buffer is pre-sized so a typical event allocates exactly
-// once instead of growing through 8/16/32/... append boundaries.
-func buildSIOEventWithAck(namespace []byte, ackID uint64, hasAck bool, event string, args [][]byte) []byte {
-	name, _ := json.Marshal(event)
-	var buf []byte
-	buf = append(buf, eioMessage, sioEvent)
-	if len(namespace) > 0 {
-		buf = append(buf, namespace...)
-		buf = append(buf, ',')
-	}
-	if hasAck {
-		buf = strconv.AppendUint(buf, ackID, 10)
-	}
-	buf = append(buf, '[')
-	buf = append(buf, name...)
-	for _, a := range args {
-		if len(a) == 0 {
-			continue
-		}
-		buf = append(buf, ',')
-		buf = append(buf, normalizeJSONArg(a)...)
-	}
-	buf = append(buf, ']')
-	return buf
-}
-
-func normalizeJSONArg(data []byte) []byte {
-	if len(data) == 0 || json.Valid(data) {
-		return data
-	}
-	encoded, err := json.Marshal(string(data))
-	if err != nil {
-		return []byte("null")
-	}
-	return encoded
-}
-
-// buildSIOAck encodes a Socket.IO ACK ("43") packet.
-//
-// Format: 4 3 [/<namespace>,] <ackID> [ <args> ]
-// args may be nil/empty to send `43<id>[]`. Valid JSON args are passed
-// through; raw text args are encoded as JSON strings.
-func buildSIOAck(namespace []byte, ackID uint64, args [][]byte) []byte {
-	var buf []byte
-	buf = append(buf, eioMessage, sioAck)
-	if len(namespace) > 0 {
-		buf = append(buf, namespace...)
-		buf = append(buf, ',')
-	}
-	buf = strconv.AppendUint(buf, ackID, 10)
-	buf = append(buf, '[')
-	first := true
-	for _, a := range args {
-		if len(a) == 0 {
-			continue
-		}
-		if !first {
-			buf = append(buf, ',')
-		}
-		buf = append(buf, normalizeJSONArg(a)...)
-		first = false
-	}
-	buf = append(buf, ']')
-	return buf
-}
-
-// splitSIOAckID extracts the optional leading numeric ack ID from a SIO
-// EVENT or ACK payload (the bytes after any namespace stripping). It
-// returns the ID, a flag whether one was present, and the remaining bytes.
-//
-// Hand-rolled digit accumulation avoids the string allocation that
-// strconv.ParseUint(string(data[:i])) would force on the hot inbound path.
-func splitSIOAckID(data []byte) (id uint64, has bool, rest []byte, err error) {
-	var v uint64
-	i := 0
-	for i < len(data) && data[i] >= '0' && data[i] <= '9' {
-		d := uint64(data[i] - '0')
-		if v > (math.MaxUint64-d)/10 {
-			return 0, false, data, ErrAckIDOverflow
-		}
-		v = v*10 + d
-		i++
-	}
-	if i == 0 {
-		return 0, false, data, nil
-	}
-	return v, true, data[i:], nil
-}
-
-// parseSIOEvent parses the JSON-array payload of a Socket.IO EVENT packet.
-//
-// payload is the bytes after the "42" prefix, e.g. `["message",{"key":"val"}]`.
-// It returns the event name and a slice of raw-JSON arguments (one entry
-// per element after the event name). args is nil for events without
-// arguments.
-//
-// Argument bytes are copied so callers may safely retain them past the
-// next ReadMessage() (the underlying read buffer in github.com/fasthttp/websocket
-// is reused on the next read). One pooled allocation amortises the copy.
-func parseSIOEvent(payload []byte) (string, [][]byte, error) {
-	var arr []json.RawMessage
-	if err := json.Unmarshal(payload, &arr); err != nil {
-		return "", nil, fmt.Errorf("socketio: failed to parse event payload: %w", err)
-	}
-	if len(arr) == 0 {
-		return "", nil, ErrEmptyEventArray
-	}
-	var eventName string
-	if err := json.Unmarshal(arr[0], &eventName); err != nil {
-		return "", nil, fmt.Errorf("socketio: failed to parse event name: %w", err)
-	}
-	if MaxEventNameLength > 0 && len(eventName) > MaxEventNameLength {
-		return "", nil, fmt.Errorf("socketio: event name exceeds MaxEventNameLength (%d)", MaxEventNameLength)
-	}
-	if len(arr) == 1 {
-		return eventName, nil, nil
-	}
-	// Allocate one contiguous backing buffer for all args and slice into it
-	// so we never alias the read buffer. One alloc total instead of N.
-	total := 0
-	for _, raw := range arr[1:] {
-		total += len(raw)
-	}
-	buf := make([]byte, total)
-	args := make([][]byte, 0, len(arr)-1)
-	off := 0
-	for _, raw := range arr[1:] {
-		n := copy(buf[off:], raw)
-		args = append(args, buf[off:off+n:off+n])
-		off += n
-	}
-	return eventName, args, nil
-}
-
+// ws is the connection surface the pool stores. Everything except
+// fireEvent is public API; fireEvent lets package-level Fire reach every
+// connection.
 type ws interface {
 	IsAlive() bool
 	GetUUID() string
@@ -671,13 +503,6 @@ type ws interface {
 	EmitWithAckTimeout(event string, data []byte, timeout time.Duration, cb AckCallback)
 	EmitWithAckArgs(event string, args [][]byte, cb func([][]byte, error))
 	Close()
-	pong(ctx context.Context)
-	write(messageType int, messageBytes []byte)
-	run()
-	read(ctx context.Context)
-	disconnected(err error)
-	createUUID() string
-	randomUUID() string
 	fireEvent(event string, data []byte, error error)
 }
 
@@ -685,51 +510,80 @@ type ws interface {
 // Fiber WebSocket. It carries the per-connection state (UUID, namespace,
 // attributes, ack bookkeeping) and exposes the Emit/Broadcast/Close API that
 // user code interacts with from inside listener callbacks.
+//
+// Goroutines per WebSocket connection: the upgrade handler goroutine runs
+// the read loop and one send goroutine serialises writes; the heartbeat is
+// a runtime timer. Polling sessions own no goroutine at all.
 type Websocket struct {
+	// once guards disconnected: the tear-down runs exactly once.
 	once sync.Once
-	// closeOnce guards the synchronous DISCONNECT + Close-frame write block
-	// in Close() so that exactly one goroutine ever performs those writes,
-	// regardless of how many concurrent Close() callers race in. Without
-	// this, a second Close() racing in could acquire kws.mu after the first
-	// released it but before disconnected() flipped isAlive=false, double-
-	// writing the close frames and (worse) racing the upgrade handler's
-	// deferred releaseConn() that nils the embedded *fasthttp.Conn.
-	closeOnce sync.Once
-	mu        sync.RWMutex
+	// finishOnce guards finishRun: the final cleanup (socket close,
+	// send goroutine join, closed channel) runs exactly once.
+	finishOnce sync.Once
+	// closeStarted flips on the first Close call; concurrent or re-entrant
+	// callers return immediately.
+	closeStarted atomic.Bool
+	// closeRequested reports that the closing handshake has been queued:
+	// disconnected then keeps the socket open, bounded by closeGrace, so
+	// the read loop can consume the peer's Close frame.
+	closeRequested atomic.Bool
+	// closeGrace is CloseTimeout as captured when the session was created
+	// and again when Close was called, in nanoseconds, so the tear-down
+	// never reads the global while another goroutine may set it.
+	closeGrace atomic.Int64
+	// writeTimeout is WriteTimeout as captured when the session was
+	// created; only the send goroutine reads it.
+	writeTimeout time.Duration
+	// teardownDeadline is the read deadline (unix nanoseconds) the
+	// tear-down armed to return the read loop, so a concurrent idle
+	// refresh that lost the race can reinstate it.
+	teardownDeadline atomic.Int64
+	// mu guards UUID, attributes and handshakeAuth.
+	mu sync.RWMutex
 	// Conn is the underlying Fiber WebSocket connection. Treat it as
 	// read-only from listener callbacks; writes must go through the
 	// Emit/EmitEvent/Broadcast methods so the send goroutine remains
-	// the sole writer.
+	// the sole writer. nil for polling sessions.
 	Conn *websocket.Conn
 	// isAlive reports whether the connection is alive. Accessed lock-free
-	// from every emit path (write/EmitTo/etc.) and the read goroutine.
+	// from every emit path (write/EmitTo/etc.) and the read loop.
 	isAlive atomic.Bool
-	// handlerDone flips just before run returns to the websocket upgrader.
-	// After that point the vendored websocket package may release and nil the
-	// embedded fasthttp connection, so external Close callers must not touch
-	// Conn anymore.
-	handlerDone atomic.Bool
 	// Queue of messages sent from the socket
 	queue chan message
-	// Channel to signal when this websocket is closed
-	// so go routines will stop gracefully
+	// done is closed by disconnected once the connection is torn down.
 	done chan struct{}
-	// ctx is the lifetime context for read/send/pong goroutines.
+	// closed is closed by finishRun once the socket is closed and the
+	// send goroutine has exited; Shutdown waits on it.
+	closed chan struct{}
+	// sendDone is closed when the send goroutine exits. finishRun waits
+	// on it, bounded by CloseTimeout, so the closing frames reach the
+	// wire before the socket is closed.
+	sendDone chan struct{}
+	// ctx is the lifetime context of the send goroutine.
 	ctx context.Context
 	// cancelCtx cancels ctx when the connection is torn down.
 	cancelCtx context.CancelFunc
-	// namespace is the Socket.IO namespace this connection belongs to. Empty
-	// means the root namespace. Captured during the handshake from the
-	// client's CONNECT packet so outbound events can mirror it.
-	namespace []byte
+	// namespace is the Socket.IO namespace this connection belongs to.
+	// nil means the root namespace. Captured during the handshake from
+	// the client's CONNECT packet so outbound events can mirror it;
+	// read lock-free on every emit.
+	namespace atomic.Pointer[[]byte]
 	// handshakeAuth is the raw JSON auth payload supplied by the client in
 	// its SIO CONNECT packet (e.g. `{"token":"..."}`). nil for clients that
 	// connect without an auth payload.
 	handshakeAuth json.RawMessage
 	// lastPongNanos is the unix-nano timestamp of the last frame received
-	// from the client. The pong ticker uses it to enforce the heartbeat
-	// timeout (PingInterval + PingTimeout) and disconnect dead peers.
+	// from the client. The heartbeat uses it to enforce the timeout
+	// (PingInterval + PingTimeout) and disconnect dead peers.
 	lastPongNanos atomic.Int64
+	// lastPingNanos is when the heartbeat last put a PING on the wire.
+	lastPingNanos atomic.Int64
+	// heartbeat is the runtime timer driving the heartbeat; the settings
+	// are captured once when it starts.
+	heartbeat  atomic.Pointer[time.Timer]
+	hbInterval time.Duration
+	hbDeadline time.Duration
+	hbTick     time.Duration
 	// outboundAckSeq is the monotonic counter for ack ids on emits issued
 	// via EmitWithAck. It is incremented under outboundAcksMu.
 	outboundAckSeq uint64
@@ -738,10 +592,6 @@ type Websocket struct {
 	// holds a callback plus an optional timeout timer.
 	outboundAcks   map[uint64]*pendingAck
 	outboundAcksMu sync.Mutex
-	// workersWg tracks the send/pong/read goroutines so the upgrade handler
-	// does not return (and the framework does not release Conn) until every
-	// goroutine that touches kws.Conn has exited.
-	workersWg sync.WaitGroup
 	// Attributes map collection for the connection
 	attributes map[string]interface{}
 	// UUID is the unique identifier assigned to this connection and used as
@@ -798,10 +648,36 @@ type Websocket struct {
 	handshakeTimer atomic.Pointer[time.Timer]
 }
 
+// newWebsocket allocates the transport-independent part of a session: the
+// send queue, the lifecycle channels, the UUID and the liveness flags.
+// attributes and outboundAcks are lazy-initialised on first SetAttribute /
+// EmitWithAck* call; most idle connections never touch them.
+func newWebsocket() *Websocket {
+	queueSize := SendQueueSize
+	if queueSize < 1 {
+		queueSize = 1
+	}
+	kws := &Websocket{
+		queue:        make(chan message, queueSize),
+		done:         make(chan struct{}),
+		closed:       make(chan struct{}),
+		sendDone:     make(chan struct{}),
+		writeTimeout: WriteTimeout,
+	}
+	kws.closeGrace.Store(int64(CloseTimeout))
+	kws.isAlive.Store(true)
+	kws.lastPongNanos.Store(time.Now().UnixNano())
+	kws.UUID = kws.createUUID()
+	return kws
+}
+
 type safePool struct {
 	sync.RWMutex
 	// List of the connections alive
 	conn map[string]ws
+	// snap caches the last snapshot until membership changes, so a
+	// broadcast storm on a stable pool never copies the map.
+	snap []ws
 }
 
 // Pool with the active connections
@@ -812,15 +688,40 @@ var pool = safePool{
 func (p *safePool) set(ws ws) {
 	p.Lock()
 	p.conn[ws.GetUUID()] = ws
+	p.snap = nil
 	p.Unlock()
 }
 
+// snapshot returns the live connections. The slice is shared until
+// membership changes and must not be modified.
+func (p *safePool) snapshot() []ws {
+	p.RLock()
+	s := p.snap
+	p.RUnlock()
+	if s != nil {
+		return s
+	}
+	p.Lock()
+	if p.snap == nil {
+		s = make([]ws, 0, len(p.conn))
+		for _, kws := range p.conn {
+			s = append(s, kws)
+		}
+		p.snap = s
+	}
+	s = p.snap
+	p.Unlock()
+	return s
+}
+
+// all returns a copy of the pool map. Only tests use it; production paths
+// iterate snapshot.
+//
+//nolint:unused // test helper
 func (p *safePool) all() map[string]ws {
 	p.RLock()
-	ret := make(map[string]ws, 0)
-	for wsUUID, kws := range p.conn {
-		ret[wsUUID] = kws
-	}
+	ret := make(map[string]ws, len(p.conn))
+	maps.Copy(ret, p.conn)
 	p.RUnlock()
 	return ret
 }
@@ -838,6 +739,7 @@ func (p *safePool) get(key string) (ws, error) {
 func (p *safePool) delete(key string) {
 	p.Lock()
 	delete(p.conn, key)
+	p.snap = nil
 	p.Unlock()
 }
 
@@ -845,6 +747,7 @@ func (p *safePool) delete(key string) {
 func (p *safePool) reset() {
 	p.Lock()
 	p.conn = make(map[string]ws)
+	p.snap = nil
 	p.Unlock()
 }
 
@@ -871,9 +774,7 @@ func (l *safeListeners) set(event string, callback eventCallback) {
 
 	cur := l.m.Load()
 	next := make(map[string][]eventCallback, len(*cur)+1)
-	for k, v := range *cur {
-		next[k] = v
-	}
+	maps.Copy(next, *cur)
 	old := next[event]
 	cp := make([]eventCallback, len(old), len(old)+1)
 	copy(cp, old)
@@ -911,7 +812,7 @@ const unsupportedEIOVersionBody = `{"code":5,"message":"Unsupported protocol ver
 // New returns a Fiber handler that upgrades the request to a Socket.IO-
 // compatible WebSocket, performs the Engine.IO / Socket.IO handshake, and
 // invokes callback with the established Websocket so user code can register
-// per-connection state before the read and heartbeat goroutines start.
+// per-connection state before the read loop and heartbeat start.
 //
 // Before delegating to the WebSocket upgrader, the handler validates the
 // Engine.IO protocol version supplied via the "EIO" query parameter. Only
@@ -922,32 +823,22 @@ const unsupportedEIOVersionBody = `{"code":5,"message":"Unsupported protocol ver
 // upgraded into an incompatible session.
 func New(callback func(kws *Websocket), config ...websocket.Config) func(fiber.Ctx) error {
 	wsHandler := websocket.New(func(c *websocket.Conn) {
-		kws := &Websocket{
-			Conn: c,
-			Locals: func(key string) interface{} {
-				return c.Locals(key)
-			},
-			Params: func(key string, defaultValue ...string) string {
-				return c.Params(key, defaultValue...)
-			},
-			Query: func(key string, defaultValue ...string) string {
-				return c.Query(key, defaultValue...)
-			},
-			Cookies: func(key string, defaultValue ...string) string {
-				return c.Cookies(key, defaultValue...)
-			},
-			queue: make(chan message, SendQueueSize),
-			done:  make(chan struct{}, 1),
-			// attributes and outboundAcks are lazy-initialised on first
-			// SetAttribute / EmitWithAck* call. Most idle connections never
-			// touch them; deferring the allocation saves ~560 B per conn at
-			// scale (1k idle conns => ~560 KB).
+		kws := newWebsocket()
+		kws.Conn = c
+		// The middleware allocates c per upgrade and never reuses it, so
+		// closures over it stay valid for the life of the session.
+		kws.Locals = func(key string) interface{} {
+			return c.Locals(key)
 		}
-		kws.isAlive.Store(true)
-		kws.lastPongNanos.Store(time.Now().UnixNano())
-
-		// Generate uuid
-		kws.UUID = kws.createUUID()
+		kws.Params = func(key string, defaultValue ...string) string {
+			return c.Params(key, defaultValue...)
+		}
+		kws.Query = func(key string, defaultValue ...string) string {
+			return c.Query(key, defaultValue...)
+		}
+		kws.Cookies = func(key string, defaultValue ...string) string {
+			return c.Cookies(key, defaultValue...)
+		}
 
 		// register the connection into the pool
 		pool.set(kws)
@@ -965,6 +856,7 @@ func New(callback func(kws *Websocket), config ...websocket.Config) func(fiber.C
 			// rejected handshakes in production.
 			logf("error", "handshake_failure", "uuid", kws.UUID, "err", err.Error())
 			kws.disconnected(err)
+			kws.finishRun()
 			return
 		}
 
@@ -973,8 +865,7 @@ func New(callback func(kws *Websocket), config ...websocket.Config) func(fiber.C
 		ctx, cancelCtx := context.WithCancel(context.Background())
 		kws.ctx = ctx
 		kws.cancelCtx = cancelCtx
-		kws.workersWg.Add(1)
-		go func() { defer kws.workersWg.Done(); kws.send(ctx) }()
+		go kws.send(ctx)
 
 		// 3. Execute the user callback on a fully established socket.
 		//    Recover panics so the framework's worker pool stays
@@ -998,7 +889,7 @@ func New(callback func(kws *Websocket), config ...websocket.Config) func(fiber.C
 		// 4. Notify listeners that the socket is ready.
 		kws.fireEvent(EventConnect, nil, nil)
 
-		// 5. Read / heartbeat goroutines and block until the connection closes.
+		// 5. Heartbeat and read loop; blocks until the connection closes.
 		kws.run()
 	}, config...)
 
@@ -1058,11 +949,16 @@ func (kws *Websocket) GetUUID() string {
 //  1. Server -> Client: 0{...sid,pingInterval,pingTimeout,maxPayload}
 //  2. Client -> Server: 40 (optionally with namespace, e.g. "40/admin,")
 //  3. Server -> Client: 40{"sid":"..."}
+//
+// A rejected CONNECT is answered with CONNECT_ERROR followed by the closing
+// handshake (see rejectHandshake) so the client learns why before the
+// socket goes away.
 func (kws *Websocket) handshake() error {
+	conn := kws.Conn
 	// Enforce the advertised payload size: prevent malicious clients from
 	// streaming arbitrarily large frames into our memory.
 	if MaxPayload > 0 {
-		kws.Conn.SetReadLimit(MaxPayload)
+		conn.SetReadLimit(MaxPayload)
 	}
 
 	// 1. Send EIO OPEN
@@ -1070,7 +966,7 @@ func (kws *Websocket) handshake() error {
 	if err != nil {
 		return fmt.Errorf("socketio: marshal EIO OPEN: %w", err)
 	}
-	if err := kws.Conn.WriteMessage(TextMessage, frame); err != nil {
+	if err := conn.WriteMessage(TextMessage, frame); err != nil {
 		return fmt.Errorf("socketio: write EIO OPEN: %w", err)
 	}
 
@@ -1080,17 +976,16 @@ func (kws *Websocket) handshake() error {
 	if HandshakeTimeout > 0 {
 		deadline = time.Now().Add(HandshakeTimeout)
 	}
-	_ = kws.Conn.SetReadDeadline(deadline)
-	defer func() { _ = kws.Conn.SetReadDeadline(time.Time{}) }()
-
-	mType, msg, err := kws.Conn.ReadMessage()
+	_ = conn.SetReadDeadline(deadline)
+	mType, msg, err := conn.ReadMessage()
 	if err != nil {
+		if websocket.IsUnexpectedCloseError(err) {
+			return fmt.Errorf("%w: %w", ErrHandshakeClosed, err)
+		}
 		return fmt.Errorf("socketio: read SIO CONNECT: %w", err)
 	}
-	if mType == CloseMessage {
-		return ErrHandshakeClosed
-	}
 	if mType != TextMessage || len(msg) < 2 || msg[0] != eioMessage || msg[1] != sioConnect {
+		kws.rejectHandshake(nil, `{"message":"Expected SIO CONNECT"}`)
 		return fmt.Errorf("socketio: expected SIO CONNECT (40), got type=%d payload=%q", mType, msg)
 	}
 
@@ -1102,7 +997,7 @@ func (kws *Websocket) handshake() error {
 	// otherwise be echoed back verbatim into every outbound emit.
 	if !isValidNamespace(namespace) {
 		logf("warn", "invalid_namespace", "uuid", kws.UUID, "namespace", string(namespace))
-		_ = kws.writeConnectError(namespace, `{"message":"invalid namespace"}`)
+		kws.rejectHandshake(namespace, `{"message":"invalid namespace"}`)
 		return ErrInvalidNamespace
 	}
 
@@ -1114,147 +1009,55 @@ func (kws *Websocket) handshake() error {
 	// any user code runs.
 	if !isValidAuthPayload(authPayload) {
 		logf("warn", "invalid_auth_payload", "uuid", kws.UUID, "namespace", string(namespace), "size", len(authPayload))
-		_ = kws.writeConnectError(namespace, `{"message":"Invalid auth payload"}`)
+		kws.rejectHandshake(namespace, `{"message":"Invalid auth payload"}`)
 		return ErrInvalidAuthPayload
 	}
 
-	// Store as a fresh slice (msg's backing buffer is owned by the read
-	// loop and may be reused) so concurrent readers via getNamespace see
-	// stable bytes.
-	nsCopy := make([]byte, len(namespace))
-	copy(nsCopy, namespace)
-	kws.mu.Lock()
-	kws.namespace = nsCopy
-	if len(authPayload) > 0 {
-		kws.handshakeAuth = make(json.RawMessage, len(authPayload))
-		copy(kws.handshakeAuth, authPayload)
-	}
-	kws.mu.Unlock()
+	kws.bindNamespace(namespace, authPayload)
 
 	// 3. Send SIO CONNECT confirmation, mirroring the namespace.
-	payload, err := json.Marshal(struct {
-		SID string `json:"sid"`
-	}{SID: kws.UUID})
-	if err != nil {
-		return fmt.Errorf("socketio: marshal SIO CONNECT: %w", err)
-	}
-	ack := buildSIOConnectAck(namespace, payload)
-	if err := kws.Conn.WriteMessage(TextMessage, ack); err != nil {
+	if err := conn.WriteMessage(TextMessage, buildSIOConnectAckSID(kws.getNamespace(), kws.UUID)); err != nil {
 		return fmt.Errorf("socketio: write SIO CONNECT: %w", err)
 	}
 	return nil
 }
 
-// extractSIONamespace returns the namespace bytes (including the leading "/")
-// from a Socket.IO CONNECT or DISCONNECT payload (the bytes after the "40"/"41"
-// type prefix). Returns nil for the root namespace.
-func extractSIONamespace(data []byte) []byte {
-	ns, _ := extractSIOConnect(data)
-	return ns
-}
-
-// extractSIOConnect parses the bytes after the "40" type prefix of a SIO
-// CONNECT packet and returns both the optional namespace (including the
-// leading "/", or nil for root) AND the optional JSON auth payload.
-//
-// Wire format: [ "/" namespace "," ] [ <json> ]
-//
-// Examples:
-//
-//	""                   -> (nil, nil)
-//	"{"token":"x"}"      -> (nil, `{"token":"x"}`)
-//	"/admin,"            -> ("/admin", nil)
-//	"/admin,{"k":1}"     -> ("/admin", `{"k":1}`)
-//	"/admin"             -> ("/admin", nil)   // no comma, no auth
-func extractSIOConnect(data []byte) (namespace, auth []byte) {
-	if len(data) == 0 {
-		return nil, nil
+// rejectHandshake answers a rejected SIO CONNECT: CONNECT_ERROR, then the
+// closing handshake. Reading on until the peer's Close frame, bounded by
+// CloseTimeout, keeps the error packet from being lost to a TCP reset that
+// closing with unread inbound data would provoke. Runs before the send
+// goroutine exists, so it writes directly.
+func (kws *Websocket) rejectHandshake(namespace []byte, jsonMessage string) {
+	conn := kws.Conn
+	_ = conn.WriteMessage(TextMessage, buildSIOConnectError(namespace, jsonMessage))
+	grace := time.Duration(kws.closeGrace.Load())
+	if grace <= 0 {
+		return
 	}
-	if data[0] != '/' {
-		return nil, data
+	if err := conn.WriteControl(CloseMessage, websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "handshake rejected"), time.Now().Add(grace)); err != nil {
+		return
 	}
-	if idx := bytes.IndexByte(data, ','); idx >= 0 {
-		ns := data[:idx]
-		rest := data[idx+1:]
-		if len(rest) == 0 {
-			return ns, nil
-		}
-		return ns, rest
-	}
-	// Namespace without trailing comma (no auth payload).
-	return data, nil
-}
-
-// isValidNamespace returns true when ns matches the conservative subset of
-// the socket.io namespace grammar: empty (root), or "/<segment>" with at
-// least one byte and only [A-Za-z0-9._\-/] characters. We deliberately
-// reject characters that would change framing if echoed verbatim into a
-// "42<ns>,..." event packet.
-func isValidNamespace(ns []byte) bool {
-	if len(ns) == 0 {
-		return true
-	}
-	if ns[0] != '/' {
-		return false
-	}
-	if len(ns) == 1 {
-		// Lone "/" is treated as the root namespace by socket.io and is
-		// accepted here.
-		return true
-	}
-	for i := 1; i < len(ns); i++ {
-		c := ns[i]
-		switch {
-		case c >= 'a' && c <= 'z':
-		case c >= 'A' && c <= 'Z':
-		case c >= '0' && c <= '9':
-		case c == '_' || c == '-' || c == '.' || c == '/':
-		default:
-			return false
+	_ = conn.SetReadDeadline(time.Now().Add(grace))
+	for {
+		if _, _, err := conn.ReadMessage(); err != nil {
+			return
 		}
 	}
-	return true
 }
 
-// isValidAuthPayload returns true when the auth payload extracted from a
-// SIO CONNECT packet conforms to socket.io-protocol v5: either absent (nil
-// / empty), or a syntactically valid JSON object (i.e. first non-whitespace
-// byte is '{'). Arrays, scalars, strings, and malformed JSON are rejected.
-//
-// Also enforces the global MaxAuthPayload cap so an oversized auth payload
-// can never reach kws.handshakeAuth or user-visible state.
-func isValidAuthPayload(auth []byte) bool {
-	if len(auth) == 0 {
-		return true
-	}
-	if MaxAuthPayload > 0 && len(auth) > MaxAuthPayload {
-		return false
-	}
-	// First non-whitespace byte must be '{' (JSON object). RFC 8259
-	// whitespace: SP / HT / LF / CR.
-	first := byte(0)
-	for i := 0; i < len(auth); i++ {
-		c := auth[i]
-		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
-			continue
-		}
-		first = c
-		break
-	}
-	if first != '{' {
-		return false
-	}
-	return json.Valid(auth)
-}
-
-// buildSIOConnectAck encodes a SIO CONNECT ack frame ("40[/ns,]<json>").
-func buildSIOConnectAck(namespace, payload []byte) []byte {
-	out := []byte{eioMessage, sioConnect}
+// bindNamespace records the namespace and auth payload negotiated in the
+// SIO CONNECT packet. Both are copied: the frame they arrived in belongs
+// to the transport.
+func (kws *Websocket) bindNamespace(namespace, auth []byte) {
 	if len(namespace) > 0 {
-		out = append(out, namespace...)
-		out = append(out, ',')
+		ns := utils.CopyBytes(namespace)
+		kws.namespace.Store(&ns)
 	}
-	return append(out, payload...)
+	if len(auth) > 0 {
+		kws.mu.Lock()
+		kws.handshakeAuth = json.RawMessage(utils.CopyBytes(auth))
+		kws.mu.Unlock()
+	}
 }
 
 // SetUUID replaces this connection's UUID, updating the active connections
@@ -1270,12 +1073,11 @@ func (kws *Websocket) SetUUID(uuid string) error {
 	if prevUUID == uuid {
 		return nil
 	}
-	kws.UUID = uuid
 
 	if existing, ok := pool.conn[uuid]; ok && existing != kws {
-		kws.UUID = prevUUID
 		return ErrorUUIDDuplication
 	}
+	kws.UUID = uuid
 
 	if prevUUID != "" {
 		delete(pool.conn, prevUUID)
@@ -1361,9 +1163,6 @@ func (kws *Websocket) EmitTo(uuid string, message []byte, mType ...int) error {
 		kws.fireEvent(EventError, []byte(uuid), err)
 		return err
 	}
-	// pool.get already returned a hit; we only need to verify the conn is
-	// still alive. Dropping the redundant pool.contains saves one RWMutex
-	// RLock per call - meaningful in Broadcast/EmitToList fanout paths.
 	if !conn.IsAlive() {
 		kws.fireEvent(EventError, []byte(uuid), ErrorInvalidConnection)
 		return ErrorInvalidConnection
@@ -1390,19 +1189,79 @@ func EmitTo(uuid string, message []byte, mType ...int) error {
 	return nil
 }
 
+// frameType resolves the optional mType argument of the emit APIs.
+func frameType(mType []int) int {
+	if len(mType) > 0 {
+		return mType[0]
+	}
+	return TextMessage
+}
+
+// broadcastFrames caches the encoded "message" event of one broadcast per
+// namespace, so a fan-out to N connections builds each frame once rather
+// than N times. The root namespace, by far the most common, has its own
+// slot so a root-only pool costs a single allocation: the frame itself.
+type broadcastFrames struct {
+	root   []byte
+	ns     [][]byte
+	frames [][]byte
+}
+
+func (b *broadcastFrames) frame(namespace, message []byte) []byte {
+	if len(namespace) == 0 {
+		if b.root == nil {
+			b.root = buildSIOEvent(nil, EventMessage, message)
+		}
+		return b.root
+	}
+	for i := range b.ns {
+		if bytes.Equal(b.ns[i], namespace) {
+			return b.frames[i]
+		}
+	}
+	f := buildSIOEvent(namespace, EventMessage, message)
+	b.ns = append(b.ns, namespace)
+	b.frames = append(b.frames, f)
+	return f
+}
+
+// emitShared is Emit for a fan-out: text messages reuse the per-namespace
+// frame from cache. The frame is shared read-only between the send queues
+// of every recipient; nothing on the write path mutates queued bytes.
+func (kws *Websocket) emitShared(cache *broadcastFrames, message []byte, mType int) {
+	if mType != TextMessage {
+		kws.write(mType, message)
+		return
+	}
+	kws.write(TextMessage, cache.frame(kws.getNamespace(), message))
+}
+
 // Broadcast sends message to every active connection in the pool. When except
 // is true the originating connection is skipped. The optional mType selects
 // the WebSocket frame type: omit it (or pass TextMessage) to wrap message as
 // a Socket.IO "message" event; pass BinaryMessage to send the bytes verbatim
 // as a binary frame.
+//
+// A target that has gone away between the pool snapshot and the emit is
+// reported with EventError (ErrorInvalidConnection) on kws, as EmitTo does.
 func (kws *Websocket) Broadcast(message []byte, except bool, mType ...int) {
 	selfUUID := kws.GetUUID()
-	for wsUUID := range pool.all() {
-		if except && selfUUID == wsUUID {
+	t := frameType(mType)
+	var cache broadcastFrames
+	for _, target := range pool.snapshot() {
+		uuid := target.GetUUID()
+		if except && uuid == selfUUID {
 			continue
 		}
-		// EmitTo fires EventError on failure; no need to re-fire here.
-		_ = kws.EmitTo(wsUUID, message, mType...)
+		if !target.IsAlive() {
+			kws.fireEvent(EventError, []byte(uuid), ErrorInvalidConnection)
+			continue
+		}
+		if w, ok := target.(*Websocket); ok {
+			w.emitShared(&cache, message, t)
+			continue
+		}
+		target.Emit(message, mType...)
 	}
 }
 
@@ -1411,8 +1270,14 @@ func (kws *Websocket) Broadcast(message []byte, except bool, mType ...int) {
 // (use the method form to skip the originator). See Websocket.Emit for the
 // meaning of mType.
 func Broadcast(message []byte, mType ...int) {
-	for _, kws := range pool.all() {
-		kws.Emit(message, mType...)
+	t := frameType(mType)
+	var cache broadcastFrames
+	for _, target := range pool.snapshot() {
+		if w, ok := target.(*Websocket); ok {
+			w.emitShared(&cache, message, t)
+			continue
+		}
+		target.Emit(message, mType...)
 	}
 }
 
@@ -1445,10 +1310,7 @@ func Fire(event string, data []byte) {
 // already-disconnected sockets are a no-op. Behavior on a full queue is
 // governed by DropFramesOnOverflow.
 func (kws *Websocket) Emit(message []byte, mType ...int) {
-	t := TextMessage
-	if len(mType) > 0 {
-		t = mType[0]
-	}
+	t := frameType(mType)
 	if t == TextMessage {
 		kws.write(TextMessage, buildSIOEvent(kws.getNamespace(), EventMessage, message))
 	} else {
@@ -1468,11 +1330,7 @@ func (kws *Websocket) EmitEvent(event string, data []byte) {
 		kws.fireEvent(EventError, []byte(event), ErrReservedEventName)
 		return
 	}
-	var args [][]byte
-	if len(data) > 0 {
-		args = [][]byte{data}
-	}
-	kws.write(TextMessage, buildSIOEventWithAck(kws.getNamespace(), 0, false, event, args))
+	kws.write(TextMessage, buildSIOEvent(kws.getNamespace(), event, data))
 }
 
 // EmitArgs sends a named socket.io event with multiple arguments, matching the
@@ -1541,37 +1399,11 @@ func (kws *Websocket) EmitWithAckTimeout(event string, data []byte, timeout time
 		kws.EmitEvent(event, data)
 		return
 	}
-	kws.outboundAcksMu.Lock()
-	// Re-check IsAlive while holding the ack mutex: disconnected() takes the
-	// same mutex when it swaps the pending map. Without this re-check, a
-	// disconnect that started after the IsAlive() probe but before us
-	// acquiring the mutex would land our entry in the post-swap (empty) map,
-	// where it could leak (timeout = 0) or fire with ErrAckTimeout instead of
-	// the correct ErrAckDisconnected (timeout > 0).
-	if !kws.isAlive.Load() {
-		kws.outboundAcksMu.Unlock()
+	id, ok := kws.registerAck(adaptSingleArgAck(cb), timeout)
+	if !ok {
 		cb(nil, ErrAckDisconnected)
 		return
 	}
-	kws.outboundAckSeq++
-	id := kws.outboundAckSeq
-	p := &pendingAck{cb: adaptSingleArgAck(cb)}
-	// Arm the timeout while still holding the lock so p.timer is published
-	// to every reader (deliverOutboundAck, fireAckTimeout, disconnected
-	// drain) under the same mutex that guards the map. Without this the
-	// race detector flags the timer-field write against the pre-fire read
-	// in the deliver path. fireAckTimeout itself acquires the lock
-	// asynchronously inside the AfterFunc closure, so this cannot deadlock
-	// even if the timer fires immediately on a stalled scheduler.
-	if timeout > 0 {
-		p.timer = time.AfterFunc(timeout, func() { kws.fireAckTimeout(id) })
-	}
-	if kws.outboundAcks == nil {
-		kws.outboundAcks = make(map[uint64]*pendingAck)
-	}
-	kws.outboundAcks[id] = p
-	kws.outboundAcksMu.Unlock()
-
 	var args [][]byte
 	if len(data) > 0 {
 		args = [][]byte{data}
@@ -1600,36 +1432,51 @@ func (kws *Websocket) EmitWithAckArgs(event string, args [][]byte, cb func([][]b
 		kws.write(TextMessage, buildSIOEventWithAck(kws.getNamespace(), 0, false, event, args))
 		return
 	}
-	kws.outboundAcksMu.Lock()
-	// Re-check IsAlive while holding the ack mutex: see the matching comment
-	// in EmitWithAckTimeout. Closes the disconnect-vs-insert race that would
-	// otherwise either leak the entry (OutboundAckTimeout = 0) or surface as
-	// ErrAckTimeout instead of ErrAckDisconnected.
-	if !kws.isAlive.Load() {
-		kws.outboundAcksMu.Unlock()
-		cb(nil, ErrAckDisconnected)
-		return
-	}
-	kws.outboundAckSeq++
-	id := kws.outboundAckSeq
 	// The internal pendingAck callback already takes [][]byte, matching the
 	// user signature exactly, so no lossy adapter is needed here. Wire-level
 	// "43<id>[a,b]" arrives as args=[a,b]; "43<id>[[a,b]]" arrives as
-	// args=[[a,b]]. The two cases are now distinguishable for callers.
+	// args=[[a,b]]. The two cases are distinguishable for callers.
+	id, ok := kws.registerAck(cb, OutboundAckTimeout)
+	if !ok {
+		cb(nil, ErrAckDisconnected)
+		return
+	}
+	kws.write(TextMessage, buildSIOEventWithAck(kws.getNamespace(), id, true, event, args))
+}
+
+// registerAck allocates the next ack id and records cb under it, arming the
+// timeout when positive. It reports false when the connection is already
+// torn down, in which case nothing was registered.
+//
+// IsAlive is re-checked while holding the ack mutex: disconnected() takes
+// the same mutex when it swaps the pending map. Without this re-check, a
+// disconnect that started after the caller's IsAlive() probe but before us
+// acquiring the mutex would land our entry in the post-swap (empty) map,
+// where it could leak (timeout = 0) or fire with ErrAckTimeout instead of
+// the correct ErrAckDisconnected (timeout > 0).
+//
+// The timeout is armed while still holding the lock so p.timer is published
+// to every reader (deliverOutboundAck, fireAckTimeout, disconnected drain)
+// under the same mutex that guards the map. fireAckTimeout itself acquires
+// the lock asynchronously inside the AfterFunc closure, so this cannot
+// deadlock even if the timer fires immediately on a stalled scheduler.
+func (kws *Websocket) registerAck(cb func(args [][]byte, err error), timeout time.Duration) (uint64, bool) {
+	kws.outboundAcksMu.Lock()
+	defer kws.outboundAcksMu.Unlock()
+	if !kws.isAlive.Load() {
+		return 0, false
+	}
+	kws.outboundAckSeq++
+	id := kws.outboundAckSeq
 	p := &pendingAck{cb: cb}
-	// Arm the timeout under the same lock that guards the map (see the
-	// matching note in EmitWithAckTimeout) so p.timer is safely published
-	// to deliverOutboundAck / fireAckTimeout / the disconnected drain.
-	if OutboundAckTimeout > 0 {
-		p.timer = time.AfterFunc(OutboundAckTimeout, func() { kws.fireAckTimeout(id) })
+	if timeout > 0 {
+		p.timer = time.AfterFunc(timeout, func() { kws.fireAckTimeout(id) })
 	}
 	if kws.outboundAcks == nil {
 		kws.outboundAcks = make(map[uint64]*pendingAck)
 	}
 	kws.outboundAcks[id] = p
-	kws.outboundAcksMu.Unlock()
-
-	kws.write(TextMessage, buildSIOEventWithAck(kws.getNamespace(), id, true, event, args))
+	return id, true
 }
 
 // deliverOutboundAck dispatches an incoming ACK to the registered callback,
@@ -1707,87 +1554,90 @@ func adaptSingleArgAck(cb AckCallback) func(args [][]byte, err error) {
 
 // Close actively closes the connection from the server side.
 //
-// It is idempotent: the synchronous DISCONNECT plus close-frame write block
-// runs at most once even when called concurrently. EventClose fires exactly
-// once before the regular disconnected tear-down (which fires EventDisconnect).
-// Callers may invoke Close from inside an event listener; it does not block
-// on the listener's own goroutine.
-//
-// Synchronous writes (bypassing kws.queue) are required so the frames
-// reach the wire BEFORE disconnected() closes done and the send goroutine
-// shuts down. The kws.mu write lock serialises with the send goroutine
-// (which writes under kws.mu.RLock) so the Conn is never written
-// concurrently.
-//
-// closeOnce gates the actual write block so concurrent Close() callers
-// do not double-write the disconnect frames and, more importantly, do
-// not race the upgrade handler's deferred releaseConn() that nils the
-// embedded *fasthttp.Conn the moment run() returns. The companion
-// kws.mu.Lock()/Unlock() fence at the tail of run() guarantees an
-// in-flight Close() write has completed before the handler returns
-// and releaseConn() fires.
+// It is idempotent: concurrent or re-entrant callers return immediately
+// while the first call proceeds. EventClose fires exactly once, before the
+// SIO DISCONNECT packet and the Close control frame are queued behind
+// every frame emitted so far, so a listener may still send a final message
+// that reaches the peer ahead of them. The regular disconnected tear-down
+// (which fires EventDisconnect) follows synchronously; the socket itself
+// is closed once the peer answers the Close frame or CloseTimeout elapses.
+// Callers may invoke Close from inside an event listener; it does not
+// block on the listener's own goroutine.
 func (kws *Websocket) Close() {
 	if !kws.IsAlive() {
 		return
 	}
+	if !kws.closeStarted.CompareAndSwap(false, true) {
+		return
+	}
 
-	kws.closeOnce.Do(func() {
-		// Build the SIO DISCONNECT frame. Per socket.io-protocol v5,
-		// namespaced packets are "41/<ns>," with a trailing comma
-		// separating the namespace from the (empty) payload.
-		disconnect := []byte{eioMessage, sioDisconnect}
-		if ns := kws.getNamespace(); len(ns) > 0 {
-			disconnect = append(disconnect, ns...)
-			disconnect = append(disconnect, ',')
-		}
+	kws.fireEvent(EventClose, nil, nil)
 
-		if kws.pollQ != nil {
-			// Polling: enqueue SIO DISCONNECT and EIO CLOSE so the next
-			// drain (or any in-flight long-poll) delivers them; the
-			// queue is closed by disconnected() below, after which
-			// further enqueues are silent no-ops. There is no
-			// equivalent of the WebSocket Close control frame on
-			// polling - the EIO "1" packet is the protocol-level
-			// disconnect signal.
-			kws.pollQ.enqueue(disconnect)
-			kws.pollQ.enqueue([]byte{eioClose})
-		} else {
-			kws.mu.Lock()
-			// Do not read kws.Conn.Conn here. The vendored websocket
-			// package nils that embedded pointer in releaseConn() after the
-			// upgrade handler returns, without taking our mutex. handlerDone
-			// is our race-free guard for that lifecycle boundary.
-			if kws.Conn != nil && !kws.handlerDone.Load() {
-				_ = kws.Conn.WriteMessage(TextMessage, disconnect)
-				// Per RFC 6455 a Close control frame's payload must start with
-				// a 2-byte big-endian status code optionally followed by a UTF-8
-				// reason. Writing the raw string would produce an invalid frame
-				// that strict clients (including socket.io-client's underlying
-				// engine.io transport) close with a protocol error.
-				_ = kws.Conn.WriteMessage(CloseMessage,
-					websocket.FormatCloseMessage(websocket.CloseNormalClosure, "Connection closed"))
-			}
-			kws.mu.Unlock()
-		}
+	// Re-capture the grace period at call time so a caller that lowered
+	// CloseTimeout right before closing (a test cleanup, a shutdown hook)
+	// is honoured.
+	kws.closeGrace.Store(int64(CloseTimeout))
 
-		kws.fireEvent(EventClose, nil, nil)
-	})
+	disconnect := buildSIODisconnect(kws.getNamespace())
+	if kws.pollQ != nil {
+		// Polling: enqueue SIO DISCONNECT and EIO CLOSE so the next
+		// drain (or any in-flight long-poll) delivers them; the
+		// queue is closed by disconnected() below, after which
+		// further enqueues are silent no-ops. There is no
+		// equivalent of the WebSocket Close control frame on
+		// polling - the EIO "1" packet is the protocol-level
+		// disconnect signal.
+		kws.pollQ.enqueue(disconnect)
+		kws.pollQ.enqueue([]byte{eioClose})
+	} else {
+		kws.beginClose(disconnect)
+	}
 
 	kws.disconnected(nil)
+}
+
+// beginClose queues the closing handshake behind everything already in the
+// send queue: the optional SIO DISCONNECT frame, then a Close control
+// frame, both written by the send goroutine. It sets closeRequested so the
+// tear-down leaves the socket open, bounded by CloseTimeout, for the read
+// loop to consume the peer's Close frame. A queue that stays saturated for
+// CloseTimeout means the peer stopped reading; the marker is then dropped
+// and disconnected closes the socket outright.
+func (kws *Websocket) beginClose(disconnect []byte) {
+	msg := message{mType: closeFrameMarker, data: disconnect}
+	select {
+	case kws.queue <- msg:
+		kws.closeRequested.Store(true)
+		return
+	default:
+	}
+	wait := time.Duration(kws.closeGrace.Load())
+	if wait <= 0 {
+		return
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case kws.queue <- msg:
+		kws.closeRequested.Store(true)
+	case <-timer.C:
+		logf("warn", "close_queue_stalled", "uuid", kws.UUID, "queue_cap", cap(kws.queue))
+	case <-kws.done:
+	}
 }
 
 // getNamespace returns the Socket.IO namespace this connection is bound to,
 // or nil for the root namespace.
 //
 // The returned slice MUST NOT be mutated by callers. namespace is written
-// exactly once during handshake (under kws.mu.Lock) and never reassigned;
-// readers can therefore alias the underlying bytes safely. All internal
-// callers feed it into append() which never mutates the source.
+// exactly once during the handshake and never reassigned; readers can
+// therefore alias the underlying bytes safely. All internal callers feed
+// it into append() which never mutates the source.
 func (kws *Websocket) getNamespace() []byte {
-	kws.mu.RLock()
-	ns := kws.namespace
-	kws.mu.RUnlock()
-	return ns
+	if ns := kws.namespace.Load(); ns != nil {
+		return *ns
+	}
+	return nil
 }
 
 // HandshakeAuth returns the raw JSON auth payload supplied by the client in
@@ -1802,43 +1652,15 @@ func (kws *Websocket) HandshakeAuth() json.RawMessage {
 	if len(kws.handshakeAuth) == 0 {
 		return nil
 	}
-	out := make(json.RawMessage, len(kws.handshakeAuth))
-	copy(out, kws.handshakeAuth)
-	return out
+	return json.RawMessage(utils.CopyBytes(kws.handshakeAuth))
 }
 
-// writeConnectError sends a Socket.IO CONNECT_ERROR ("44") frame directly on
-// the WebSocket conn (not via the queue, since this can run before the send
-// goroutine starts during the handshake).
-//
-// Acquires kws.mu.Lock around the WriteMessage so post-handshake callers (the
-// late-CONNECT path in the read goroutine) cannot race the send goroutine,
-// which writes under kws.mu.RLock. Same pattern Close() uses for its
-// synchronous DISCONNECT/CLOSE frames.
-//
-// Returns ErrorInvalidConnection if the underlying conn is nil or the upgrade
-// handler has already returned.
-func (kws *Websocket) writeConnectError(namespace []byte, jsonMessage string) error {
-	out := []byte{eioMessage, sioConnectError}
-	if len(namespace) > 0 {
-		out = append(out, namespace...)
-		out = append(out, ',')
-	}
-	out = append(out, jsonMessage...)
-	if kws.pollQ != nil {
-		// Polling: enqueue the CONNECT_ERROR frame for the next drain.
-		kws.pollQ.enqueue(out)
-		return nil
-	}
-	kws.mu.Lock()
-	defer kws.mu.Unlock()
-	// Do not inspect kws.Conn.Conn; releaseConn() mutates that embedded
-	// pointer without taking our mutex. handlerDone is the race-free
-	// lifecycle guard.
-	if kws.Conn == nil || kws.handlerDone.Load() {
-		return ErrorInvalidConnection
-	}
-	return kws.Conn.WriteMessage(TextMessage, out)
+// writeConnectError queues a Socket.IO CONNECT_ERROR ("44") frame for a
+// session whose handshake already completed (a late CONNECT the server
+// cannot honour). The handshake itself answers rejections directly through
+// rejectHandshake, before the send goroutine exists.
+func (kws *Websocket) writeConnectError(namespace []byte, jsonMessage string) {
+	kws.write(TextMessage, buildSIOConnectError(namespace, jsonMessage))
 }
 
 // IsAlive reports whether the connection is still considered active and able
@@ -1856,12 +1678,6 @@ func (kws *Websocket) IsPolling() bool {
 	return kws.pollQ != nil
 }
 
-func (kws *Websocket) hasConn() bool {
-	kws.mu.RLock()
-	defer kws.mu.RUnlock()
-	return kws.Conn.Conn != nil
-}
-
 func (kws *Websocket) setAlive(alive bool) {
 	kws.isAlive.Store(alive)
 }
@@ -1873,21 +1689,17 @@ func (kws *Websocket) queueLength() int {
 	return len(kws.queue)
 }
 
-// pong sends Engine.IO PING packets to the client at PingInterval and
-// enforces the heartbeat timeout: if no frame has been received from the
-// peer within PingInterval + PingTimeout the connection is dropped.
+// startHeartbeat arms the Engine.IO heartbeat: a PING every PingInterval
+// and a tear-down when no frame arrived within PingInterval + PingTimeout.
 //
-// The interval is read once at goroutine start (handshake-completed time);
-// later mutations to the global PingInterval do not affect a live
-// connection, which keeps tests race-free.
-//
-// To bound dead-peer detection latency, the ticker fires at
-// min(PingInterval, PingTimeout) so the deadline check runs at least once
-// per PingTimeout. PINGs are still emitted only every PingInterval.
-// Worst-case detection latency is therefore at most
-// PingInterval + PingTimeout + tick (vs. up to 2*PingInterval+PingTimeout
-// when the tick equalled PingInterval).
-func (kws *Websocket) pong(ctx context.Context) {
+// The settings are read once here; later mutations of the globals do not
+// affect a live connection, which keeps tests race-free. The timer fires
+// every min(PingInterval, PingTimeout) so the deadline check runs at least
+// once per PingTimeout while PINGs still go out only every PingInterval;
+// worst-case dead-peer detection latency is PingInterval + PingTimeout +
+// tick. A runtime timer replaces the goroutine the heartbeat used to own:
+// a thousand idle connections no longer pin a thousand goroutine stacks.
+func (kws *Websocket) startHeartbeat() {
 	interval := PingInterval
 	if interval <= 0 {
 		interval = 25 * time.Second
@@ -1896,34 +1708,41 @@ func (kws *Websocket) pong(ctx context.Context) {
 	if timeout <= 0 {
 		timeout = 20 * time.Second
 	}
-	deadline := interval + timeout
+	kws.hbInterval = interval
+	kws.hbDeadline = interval + timeout
+	kws.hbTick = min(interval, timeout)
+	kws.lastPingNanos.Store(time.Now().UnixNano())
+	// Published before it is armed, so a tick can never observe a nil
+	// timer and lose the chain.
+	t := time.AfterFunc(time.Hour, kws.heartbeatTick)
+	kws.heartbeat.Store(t)
+	t.Reset(kws.hbTick)
+}
 
-	tick := interval
-	if timeout < tick {
-		tick = timeout
+// heartbeatTick runs on the runtime timer goroutine.
+func (kws *Websocket) heartbeatTick() {
+	if !kws.IsAlive() {
+		return
 	}
+	now := time.Now()
+	if last := kws.lastPongNanos.Load(); last > 0 && now.Sub(time.Unix(0, last)) > kws.hbDeadline {
+		logf("warn", "heartbeat_timeout", "uuid", kws.UUID, "deadline_ms", kws.hbDeadline.Milliseconds())
+		kws.disconnected(ErrHeartbeatTimeout)
+		return
+	}
+	// Emit a PING only every PingInterval, regardless of tick rate.
+	if now.Sub(time.Unix(0, kws.lastPingNanos.Load())) >= kws.hbInterval {
+		kws.write(TextMessage, eioPingFrame)
+		kws.lastPingNanos.Store(now.UnixNano())
+	}
+	if t := kws.heartbeat.Load(); t != nil && kws.IsAlive() {
+		t.Reset(kws.hbTick)
+	}
+}
 
-	ticker := time.NewTicker(tick)
-	defer ticker.Stop()
-
-	lastPing := time.Now()
-	for {
-		select {
-		case <-ticker.C:
-			last := kws.lastPongNanos.Load()
-			if last > 0 && time.Since(time.Unix(0, last)) > deadline {
-				logf("warn", "heartbeat_timeout", "uuid", kws.UUID, "deadline_ms", deadline.Milliseconds())
-				kws.disconnected(ErrHeartbeatTimeout)
-				return
-			}
-			// Emit a PING only every PingInterval, regardless of tick rate.
-			if time.Since(lastPing) >= interval {
-				kws.write(TextMessage, eioPingFrame)
-				lastPing = time.Now()
-			}
-		case <-ctx.Done():
-			return
-		}
+func (kws *Websocket) stopHeartbeat() {
+	if t := kws.heartbeat.Load(); t != nil {
+		t.Stop()
 	}
 }
 
@@ -1958,12 +1777,12 @@ func (kws *Websocket) write(messageType int, messageBytes []byte) {
 		case enqueueRejectedDisconnect:
 			logf("error", "poll_queue_overflow_disconnect", "uuid", kws.UUID, "cap", PollQueueMaxFrames)
 			kws.disconnected(ErrSendQueueClosed)
+		case enqueueOK:
 		}
 		return
 	}
-	msg := message{mType: messageType, data: messageBytes}
 	select {
-	case kws.queue <- msg:
+	case kws.queue <- message{mType: messageType, data: messageBytes}:
 	default:
 		if DropFramesOnOverflow {
 			// Backpressure: drop the frame and surface an error event,
@@ -1979,45 +1798,28 @@ func (kws *Websocket) write(messageType int, messageBytes []byte) {
 	}
 }
 
-// Send out message queue
-// send drains the outbound message queue and writes frames to the wire.
-//
-// On a missing Conn it sleeps RetrySendTimeout (synchronously, ctx-aware)
-// up to MaxSendRetry times. The previous implementation spawned a fresh
-// goroutine per retry that pushed back into the buffered queue; under
-// sustained network slowness that fanned out into thousands of goroutines
-// and could deadlock the queue.
+// send drains the outbound message queue and writes frames to the wire. It
+// is the only goroutine that writes data frames, so no lock guards the
+// connection; the closing frames are written here too, in queue order,
+// after which it exits. The middleware coalesces writes made while the
+// peer still has frames queued for the read loop, so a burst of replies
+// leaves in one syscall.
 func (kws *Websocket) send(ctx context.Context) {
+	defer close(kws.sendDone)
+	conn := kws.Conn
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case msg := <-kws.queue:
-			for !kws.hasConn() {
-				if msg.retries >= MaxSendRetry {
-					// Give up; nothing more we can do for this frame.
-					msg.retries = -1
-					break
-				}
-				msg.retries++
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(RetrySendTimeout):
-				}
+			if msg.mType == closeFrameMarker {
+				kws.writeCloseFrames(msg.data)
+				return
 			}
-			if msg.retries < 0 {
-				continue
+			if kws.writeTimeout > 0 {
+				_ = conn.SetWriteDeadline(time.Now().Add(kws.writeTimeout))
 			}
-
-			// Hold the kws.mu read-lock across the write so we serialise
-			// against Close()'s Lock(), which writes the SIO DISCONNECT +
-			// close frame directly. Multiple send goroutines do not exist
-			// (only this one), so RLock here only blocks Close().
-			kws.mu.RLock()
-			err := kws.Conn.WriteMessage(msg.mType, msg.data)
-			kws.mu.RUnlock()
-			if err != nil {
+			if err := conn.WriteMessage(msg.mType, msg.data); err != nil {
 				kws.disconnected(err)
 				return
 			}
@@ -2025,164 +1827,265 @@ func (kws *Websocket) send(ctx context.Context) {
 	}
 }
 
-// run starts the heartbeat and read goroutines and blocks until the
-// connection is torn down. The handshake, send goroutine and EventConnect
-// notification are intentionally performed in New() before run() is called,
-// so that any Emit/EmitEvent calls inside the user callback are flushed onto
-// an already established connection and are not interleaved with handshake
-// frames.
-//
-// run blocks the caller (the WebSocket upgrade handler) until ALL child
-// goroutines that touch kws.Conn have exited. This is required for race
-// safety: once the upgrade handler returns, the underlying gofiber/contrib
-// websocket package releases the *websocket.Conn back to its pool. Any
-// goroutine still running and reading kws.Conn would race the release.
-func (kws *Websocket) run() {
-	ctx := kws.ctx
-	if ctx == nil {
-		// Defensive: should always be set by New() but allow standalone use.
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithCancel(context.Background())
-		kws.ctx = ctx
-		kws.cancelCtx = cancel
-		kws.workersWg.Add(1)
-		go func() { defer kws.workersWg.Done(); kws.send(ctx) }()
+// writeCloseFrames puts the closing handshake on the wire: the SIO
+// DISCONNECT packet, when the server initiated the close, then a Close
+// control frame. After the Close frame the library refuses further data
+// frames (ErrCloseSent), which is what ends the send goroutine's job.
+func (kws *Websocket) writeCloseFrames(disconnect []byte) {
+	conn := kws.Conn
+	grace := kws.writeTimeout
+	if grace <= 0 {
+		grace = controlWriteTimeout
 	}
+	if len(disconnect) > 0 {
+		_ = conn.SetWriteDeadline(time.Now().Add(grace))
+		if err := conn.WriteMessage(TextMessage, disconnect); err != nil {
+			return
+		}
+	}
+	_ = conn.WriteControl(CloseMessage, closeFramePayload, time.Now().Add(grace))
+}
 
-	kws.workersWg.Add(2)
-	go func() { defer kws.workersWg.Done(); kws.pong(ctx) }()
-	go func() { defer kws.workersWg.Done(); kws.read(ctx) }()
-
-	<-kws.done // block until disconnected closes the channel
-
+// run arms the heartbeat, installs the control-frame handlers and runs
+// the read loop on the calling goroutine (the WebSocket upgrade handler)
+// until the connection is torn down; then finishRun releases everything.
+// The handshake, send goroutine and EventConnect notification are
+// intentionally performed in New() before run() is called, so that any
+// Emit/EmitEvent calls inside the user callback are flushed onto an
+// already established connection and are not interleaved with handshake
+// frames.
+func (kws *Websocket) run() {
+	kws.installControlHandlers()
+	kws.startHeartbeat()
+	kws.read()
 	kws.finishRun()
 }
 
-func (kws *Websocket) finishRun() {
-	if kws.cancelCtx != nil {
-		kws.cancelCtx()
-	}
-
-	// Wait for send / pong / read to actually exit before letting the
-	// upgrade handler return and the websocket framework release Conn.
-	kws.workersWg.Wait()
-
-	// Mark the upgrade handler as finished before the final barrier. A Close
-	// caller that starts after this point will skip direct Conn writes; a
-	// Close caller already inside its write block still holds kws.mu and is
-	// waited on by the barrier below.
-	kws.handlerDone.Store(true)
-
-	// Fence against any in-flight Close() that is still inside its
-	// kws.mu-protected write block. Close() is invoked from caller
-	// goroutines that are NOT tracked by workersWg, so workersWg.Wait()
-	// alone cannot guarantee they have finished writing to kws.Conn.
-	// Acquiring and immediately releasing kws.mu here blocks until
-	// every concurrent Close() writer has exited the critical section,
-	// ensuring no goroutine is still touching the embedded *fasthttp.Conn
-	// when this function returns and the vendored websocket package's
-	// deferred releaseConn() nils that pointer.
-	kws.mu.Lock()
-	//nolint:staticcheck // intentional empty-locked region; this is a barrier.
-	kws.mu.Unlock()
+// installControlHandlers routes RFC 6455 Ping/Pong control frames, which
+// the library consumes inside ReadMessage and never surfaces as messages,
+// to EventPing / EventPong. A Ping is still answered with a Pong, as the
+// library's default handler would. Control frames do not count as
+// Engine.IO liveness: a stack that answers pings while the application is
+// wedged must not mask its own death.
+func (kws *Websocket) installControlHandlers() {
+	conn := kws.Conn
+	conn.SetPingHandler(func(data string) error {
+		if kws.IsAlive() {
+			kws.fireEvent(EventPing, []byte(data), nil)
+		}
+		err := conn.WriteControl(PongMessage, []byte(data), time.Now().Add(controlWriteTimeout))
+		if errors.Is(err, websocket.ErrCloseSent) {
+			return nil
+		}
+		var ne net.Error
+		if errors.As(err, &ne) && ne.Timeout() {
+			return nil
+		}
+		return err
+	})
+	conn.SetPongHandler(func(string) error {
+		if kws.IsAlive() {
+			kws.fireEvent(EventPong, nil, nil)
+		}
+		return nil
+	})
 }
 
-// Listen for incoming messages
-// and filter by message type
-func (kws *Websocket) read(ctx context.Context) {
-	// Single-reader contract: only this goroutine ever calls ReadMessage on
-	// kws.Conn. We do NOT hold kws.mu around it because ReadMessage blocks
-	// indefinitely until a peer frame arrives, which would deadlock any
-	// goroutine that subsequently takes kws.mu.Lock (e.g. Close(),
-	// disconnected()). SetReadDeadline (called by disconnected to break
-	// us out of ReadMessage) is delegated to net.Conn.SetReadDeadline,
-	// which is safe to call concurrently with an in-flight Read per
-	// the net.Conn contract.
-	for {
-		if !kws.hasConn() {
-			return
+// finishRun is the final cleanup of a session, run exactly once: it lets a
+// queued closing handshake reach the wire, closes the socket, joins the
+// send goroutine and signals closed. It is the point at which a connection
+// stops holding any resource - the upgrade handler returns right after,
+// and the middleware leaves the hijacked socket to us.
+func (kws *Websocket) finishRun() {
+	kws.finishOnce.Do(func() {
+		kws.disconnected(nil)
+		kws.stopHeartbeat()
+		graceful := kws.closeRequested.Load()
+		// A queued closing handshake must reach the wire before the
+		// send goroutine is told to stop; anything else is stopped
+		// first so no more frames go to a peer that is already gone.
+		if kws.cancelCtx != nil && !graceful {
+			kws.cancelCtx()
 		}
-
-		mType, msg, err := kws.Conn.ReadMessage()
-
-		// Any successful application-layer frame counts as proof of life
-		// for the heartbeat enforcer. RFC 6455 control frames (Ping/Pong)
-		// are answered by the underlying websocket library at the OS/TCP
-		// boundary even when the EIO peer is stuck, so excluding them
-		// prevents a wedged client from masking its own death.
-		if err == nil && mType != PingMessage && mType != PongMessage {
-			kws.lastPongNanos.Store(time.Now().UnixNano())
-		}
-
-		// Cancellation while reading.
-		if ctx.Err() != nil {
-			return
-		}
-
-		// WebSocket-level control frames.
-		if mType == PingMessage {
-			kws.fireEvent(EventPing, nil, nil)
-			continue
-		}
-		if mType == PongMessage {
-			kws.fireEvent(EventPong, nil, nil)
-			continue
-		}
-		if mType == CloseMessage {
-			kws.disconnected(nil)
-			return
-		}
-
-		if err != nil {
-			kws.disconnected(err)
-			return
-		}
-
-		// Binary messages (socket.io binary events / raw binary data).
-		// Copy the bytes off the read buffer; listeners may spawn goroutines
-		// that observe payload.Data after the next ReadMessage() reuses msg.
-		if mType == BinaryMessage {
-			data := make([]byte, len(msg))
-			copy(data, msg)
-			kws.fireEvent(EventMessage, data, nil)
-			continue
-		}
-
-		// Text messages: parse Engine.IO packet.
-		if mType != TextMessage || len(msg) == 0 {
-			continue
-		}
-
-		// EIO v4 supports batching multiple packets in one WebSocket
-		// frame, separated by ASCII RS (0x1E). Single-packet frames
-		// (no separator) take the zero-alloc fast path; the rare batched
-		// form is parsed with a hand-rolled scanner that walks msg with
-		// bytes.IndexByte so we never materialise a [][]byte for a
-		// frame that an attacker could fill with separators (which
-		// bytes.Split would amplify into millions of slice headers).
-		if bytes.IndexByte(msg, eioPacketSeparator) < 0 {
-			kws.dispatchEIOPacket(msg)
-		} else {
-			rest, count := msg, 0
-			for len(rest) > 0 {
-				if count >= MaxBatchPackets {
-					logf("warn", "batched_frame_overflow", "uuid", kws.UUID, "limit", MaxBatchPackets)
-					kws.fireEvent(EventError, nil, ErrBatchPacketsExceeded)
-					break
-				}
-				idx := bytes.IndexByte(rest, eioPacketSeparator)
-				var packet []byte
-				if idx < 0 {
-					packet, rest = rest, nil
-				} else {
-					packet, rest = rest[:idx], rest[idx+1:]
-				}
-				if len(packet) == 0 {
-					continue
-				}
-				kws.dispatchEIOPacket(packet)
-				count++
+		if kws.Conn != nil {
+			// Let an in-flight write finish before closing under it:
+			// closing is what returns a write stalled on a peer that
+			// stopped reading, so the wait is bounded.
+			grace := time.Duration(kws.closeGrace.Load())
+			if grace <= 0 {
+				grace = controlWriteTimeout
 			}
+			kws.waitSendDone(grace)
+			if kws.cancelCtx != nil {
+				kws.cancelCtx()
+			}
+			kws.closeConn()
+			kws.waitSendDone(0)
+		} else if kws.cancelCtx != nil {
+			kws.cancelCtx()
+		}
+		close(kws.closed)
+	})
+}
+
+// waitSendDone blocks until the send goroutine has exited, or for at most
+// d when d is positive. With d <= 0 it waits without bound, which is only
+// safe once the socket is closed: a write can no longer stall.
+func (kws *Websocket) waitSendDone(d time.Duration) {
+	if kws.ctx == nil {
+		return // never started
+	}
+	if d <= 0 {
+		<-kws.sendDone
+		return
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-kws.sendDone:
+	case <-timer.C:
+	}
+}
+
+// armTeardownDeadline sets the read deadline that returns the read loop:
+// CloseTimeout from now when the closing handshake is queued, so the loop
+// drains until the peer's Close frame; as good as immediately otherwise.
+// The socket itself is closed by finishRun once the send goroutine is out
+// of any write: SetReadDeadline is safe to call concurrently with a read,
+// closing under a write is not on every net.Conn. The immediate deadline
+// is a moment ahead rather than in the past because a conn that
+// implements deadlines with a timer fires a deadline that was reset, not
+// one that was stopped.
+func (kws *Websocket) armTeardownDeadline(graceful bool) {
+	grace := time.Millisecond
+	if graceful {
+		if g := time.Duration(kws.closeGrace.Load()); g > 0 {
+			grace = g
+		}
+	}
+	deadline := time.Now().Add(grace)
+	kws.teardownDeadline.Store(deadline.UnixNano())
+	_ = kws.Conn.SetReadDeadline(deadline)
+}
+
+// closeConn closes the underlying socket, which returns a blocked
+// ReadMessage or WriteMessage; closing twice is harmless. The middleware
+// flushes what it still holds before closing. Only finishRun (and the
+// Shutdown deadline) call it, once the send goroutine is out of its write
+// or its grace period has elapsed.
+func (kws *Websocket) closeConn() {
+	if c := kws.Conn; c != nil {
+		_ = c.Close()
+	}
+}
+
+// read is the single reader of kws.Conn. It runs on the upgrade handler's
+// goroutine and returns once ReadMessage fails, which is how every
+// tear-down ends: the peer closes, the socket errors, disconnected closes
+// it, or the closing-handshake deadline expires.
+func (kws *Websocket) read() {
+	conn := kws.Conn
+	// An idle deadline stays armed on the socket, refreshed at most every
+	// quarter of its length: it backs up the heartbeat (a peer that sends
+	// nothing for PingInterval + PingTimeout is gone either way) and, more
+	// importantly, it is what lets the tear-down's own deadline wake a
+	// parked read on every net.Conn - one that implements deadlines with a
+	// timer only fires a deadline set while a timer is already running.
+	idle := kws.hbDeadline + kws.hbTick
+	refreshEvery := idle / 4
+	var nextRefresh time.Time
+	for {
+		if now := time.Now(); kws.IsAlive() && now.After(nextRefresh) {
+			_ = conn.SetReadDeadline(now.Add(idle))
+			nextRefresh = now.Add(refreshEvery)
+			if !kws.IsAlive() {
+				// Lost a race with the tear-down: its deadline stands.
+				if d := kws.teardownDeadline.Load(); d != 0 {
+					_ = conn.SetReadDeadline(time.Unix(0, d))
+				}
+			}
+		}
+		mType, msg, err := conn.ReadMessage()
+		if err != nil {
+			kws.disconnected(kws.readCause(err))
+			return
+		}
+
+		// Closing handshake in progress: keep consuming frames so the
+		// peer's Close frame (or EOF) ends the session cleanly, but
+		// dispatch nothing after EventDisconnect.
+		if !kws.IsAlive() {
+			continue
+		}
+
+		// Any application-layer frame counts as proof of life for the
+		// heartbeat enforcer.
+		kws.lastPongNanos.Store(time.Now().UnixNano())
+
+		switch mType {
+		case BinaryMessage:
+			// ReadMessage hands over a buffer the caller owns, so the
+			// bytes go to listeners without a copy.
+			kws.fireEvent(EventMessage, msg, nil)
+		case TextMessage:
+			if len(msg) > 0 {
+				kws.dispatchEIOFrame(msg)
+			}
+		default:
+			// Control frames never reach here: the library handles
+			// them inside ReadMessage.
+		}
+	}
+}
+
+// readCause maps a read error to the EventDisconnect cause: nil for a
+// clean close (a Close frame with code 1000, 1001 or no code),
+// ErrHeartbeatTimeout when the idle deadline expired on a live session
+// (the peer sent nothing for PingInterval + PingTimeout, which is what the
+// heartbeat timer would have reported a moment later), the error itself
+// otherwise.
+func (kws *Websocket) readCause(err error) error {
+	if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseNoStatusReceived) {
+		return nil
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() && kws.IsAlive() {
+		return ErrHeartbeatTimeout
+	}
+	return err
+}
+
+// dispatchEIOFrame splits an inbound text frame into Engine.IO packets and
+// routes each. EIO v4 batches multiple packets in one WebSocket frame,
+// separated by ASCII RS (0x1E). Single-packet frames (no separator) take
+// the fast path; a batched frame is walked with bytes.IndexByte so a frame
+// an attacker fills with separators never materialises a [][]byte (which
+// bytes.Split would amplify into millions of slice headers).
+func (kws *Websocket) dispatchEIOFrame(msg []byte) {
+	if bytes.IndexByte(msg, eioPacketSeparator) < 0 {
+		kws.dispatchEIOPacket(msg)
+		return
+	}
+	rest, count := msg, 0
+	for len(rest) > 0 {
+		if count >= MaxBatchPackets {
+			logf("warn", "batched_frame_overflow", "uuid", kws.UUID, "limit", MaxBatchPackets)
+			kws.fireEvent(EventError, nil, ErrBatchPacketsExceeded)
+			return
+		}
+		var packet []byte
+		if idx := bytes.IndexByte(rest, eioPacketSeparator); idx < 0 {
+			packet, rest = rest, nil
+		} else {
+			packet, rest = rest[:idx], rest[idx+1:]
+		}
+		if len(packet) == 0 {
+			continue
+		}
+		kws.dispatchEIOPacket(packet)
+		count++
+		if !kws.IsAlive() {
+			return
 		}
 	}
 }
@@ -2237,24 +2140,14 @@ func (kws *Websocket) handleSIOPacket(payload []byte) {
 		kws.disconnected(ErrPollingBeforeConnect)
 		return
 	}
-	data := payload[1:]
 
-	// Capture optional namespace prefix (e.g., "/admin,") BEFORE stripping
-	// so we can verify it matches the namespace bound to this connection.
-	// ACK ids are per-namespace per the socket.io v5 spec, so a frame whose
-	// namespace does not match the connection's bound namespace must NOT be
-	// allowed to fire a pending callback (or event listener) registered on a
-	// different namespace.
-	var packetNS []byte
-	if len(data) > 0 && data[0] == '/' {
-		if idx := bytes.IndexByte(data, ','); idx >= 0 {
-			packetNS = data[:idx]
-			data = data[idx+1:]
-		} else {
-			packetNS = data
-			data = nil
-		}
-	}
+	// Capture the optional namespace prefix (e.g., "/admin,") BEFORE
+	// stripping so we can verify it matches the namespace bound to this
+	// connection. ACK ids are per-namespace per the socket.io v5 spec, so
+	// a frame whose namespace does not match the connection's bound
+	// namespace must NOT be allowed to fire a pending callback (or event
+	// listener) registered on a different namespace.
+	packetNS, data := splitSIONamespace(payload[1:])
 
 	switch sioType {
 	case sioEvent:
@@ -2262,8 +2155,8 @@ func (kws *Websocket) handleSIOPacket(payload []byte) {
 		// not match the namespace bound to this connection. Otherwise a
 		// frame "42/admin,..." arriving on a "/" connection would fire
 		// listeners registered on the root namespace.
-		if !bytes.Equal(packetNS, kws.getNamespace()) {
-			kws.fireEvent(EventError, payload, fmt.Errorf("socketio: cross-namespace event dropped: packet=%q conn=%q", packetNS, kws.getNamespace()))
+		if bound := kws.getNamespace(); !bytes.Equal(packetNS, bound) {
+			kws.fireEvent(EventError, payload, fmt.Errorf("socketio: cross-namespace event dropped: packet=%q conn=%q", packetNS, bound))
 			return
 		}
 		ackID, hasAck, rest, err := splitSIOAckID(data)
@@ -2287,92 +2180,52 @@ func (kws *Websocket) handleSIOPacket(payload []byte) {
 		kws.fireEventWithAck(eventName, eventArgs, nil, ackID, hasAck)
 
 	case sioDisconnect:
-		// Per socket.io-protocol v5, "41/<ns>," targets a single namespace and
-		// must NOT tear down sibling namespaces sharing the same EIO
-		// connection. This implementation is single-namespace-per-conn
-		// (kws.namespace is one slice), so we cannot detach a namespace
-		// without ending the conn. Compromise (iter 9): if the inbound
-		// namespace matches the bound one, treat as a real disconnect; if it
-		// does not match, ignore the frame so a malicious or buggy client
-		// cannot kill the conn by addressing a foreign namespace. A full
-		// per-conn namespaces map is deferred to a later iteration.
-		ns := extractSIONamespace(payload[1:])
-		if !bytes.Equal(ns, kws.getNamespace()) {
+		// Per socket.io-protocol v5, "41/<ns>," targets a single namespace
+		// and must NOT tear down sibling namespaces sharing the same EIO
+		// connection. This implementation is single-namespace-per-conn,
+		// so a matching namespace ends the connection and a foreign one
+		// is ignored: a malicious or buggy client cannot kill the conn by
+		// addressing a namespace it never joined.
+		if !bytes.Equal(packetNS, kws.getNamespace()) {
 			return
+		}
+		if kws.pollQ == nil {
+			// Answer with the closing handshake so a peer that keeps
+			// the transport open still ends the session promptly.
+			kws.beginClose(nil)
 		}
 		kws.disconnected(nil)
 
 	case sioConnect:
-		// CONNECT path. For polling sessions the SIO CONNECT packet
-		// arrives via the first POST after the OPEN handshake response;
-		// the WebSocket path performs CONNECT synchronously inside
-		// handshake() and never reaches this case for the initial
-		// CONNECT. The polling first-CONNECT branch below mirrors the
-		// validation, namespace/auth capture, and EventConnect dispatch
-		// that handshake() does for WebSocket sessions.
+		// For polling sessions the SIO CONNECT packet arrives via the
+		// first POST after the OPEN handshake response; the WebSocket
+		// path performs CONNECT synchronously inside handshake() and
+		// never reaches this case for the initial CONNECT. The polling
+		// first-CONNECT branch below mirrors the validation,
+		// namespace/auth capture, and EventConnect dispatch that
+		// handshake() does for WebSocket sessions.
 		ns, auth := extractSIOConnect(payload[1:])
 		if !isValidNamespace(ns) {
-			_ = kws.writeConnectError(ns, `{"message":"Invalid namespace"}`)
+			kws.writeConnectError(ns, `{"message":"Invalid namespace"}`)
 			if kws.pollQ != nil {
 				kws.disconnected(ErrInvalidNamespace)
 			}
 			return
 		}
 		if kws.pollQ != nil && !kws.connectFired.Load() {
-			// Polling first-CONNECT: validate auth, persist namespace +
-			// auth, send the CONNECT ack, run the user callback, then fire
-			// EventConnect once. The callback intentionally runs after the
-			// CONNECT ack is queued, matching the WebSocket handshake order:
-			// Emit calls inside the callback cannot overtake the namespace
-			// connect confirmation.
-			if !isValidAuthPayload(auth) {
-				logf("warn", "invalid_auth_payload", "uuid", kws.UUID, "namespace", string(ns), "size", len(auth))
-				_ = kws.writeConnectError(ns, `{"message":"Invalid auth payload"}`)
-				kws.disconnected(ErrInvalidAuthPayload)
-				return
-			}
-			if t := kws.handshakeTimer.Load(); t != nil {
-				t.Stop()
-			}
-			nsCopy := append([]byte(nil), ns...)
-			kws.mu.Lock()
-			kws.namespace = nsCopy
-			if len(auth) > 0 {
-				kws.handshakeAuth = make(json.RawMessage, len(auth))
-				copy(kws.handshakeAuth, auth)
-			}
-			kws.mu.Unlock()
-			ackPayload, err := json.Marshal(struct {
-				SID string `json:"sid"`
-			}{SID: kws.UUID})
-			if err == nil {
-				kws.write(TextMessage, buildSIOConnectAck(nsCopy, ackPayload))
-			}
-			pollCallback := kws.pollCallback
-			kws.pollCallback = nil
-			if r := runUserCallback(pollCallback, kws); r != nil {
-				logf("error", "polling_callback_panic", "uuid", kws.UUID, "panic", fmt.Sprintf("%v", r))
-				kws.disconnected(fmt.Errorf("socketio: polling callback panic: %v", r))
-				return
-			}
-			if !kws.IsAlive() {
-				kws.disconnected(nil)
-				return
-			}
-			if kws.connectFired.CompareAndSwap(false, true) {
-				kws.fireEvent(EventConnect, nil, nil)
-			}
+			kws.connectPolling(ns, auth)
 			return
 		}
-		// Late namespace CONNECT (after the initial handshake): confirm
-		// via the send queue, mirroring the namespace, so we do not race
-		// the read loop.
-		ackPayload, err := json.Marshal(struct {
-			SID string `json:"sid"`
-		}{SID: kws.GetUUID()})
-		if err == nil {
-			kws.write(TextMessage, buildSIOConnectAck(ns, ackPayload))
+		// A CONNECT on an established connection. The same namespace is
+		// acknowledged again; a different one cannot be served, because
+		// a connection binds exactly one namespace and every event for
+		// another would be dropped by the cross-namespace guard, so the
+		// client is told instead of being acknowledged into silence.
+		if bytes.Equal(ns, kws.getNamespace()) {
+			kws.write(TextMessage, buildSIOConnectAckSID(ns, kws.GetUUID()))
+			return
 		}
+		kws.writeConnectError(ns, `{"message":"Invalid namespace"}`)
 
 	case sioAck:
 		// 43[/ns,]<id>[<data>] - response to a server-initiated EmitWithAck.
@@ -2388,25 +2241,51 @@ func (kws *Websocket) handleSIOPacket(payload []byte) {
 		if err != nil || !has {
 			return
 		}
-		var arr []json.RawMessage
-		if err := json.Unmarshal(rest, &arr); err != nil {
+		args, err := parseSIOAckArgs(rest)
+		if err != nil {
 			return
-		}
-		var args [][]byte
-		if len(arr) > 0 {
-			args = make([][]byte, len(arr))
-			for i, raw := range arr {
-				// Copy each raw JSON value off the read buffer so callers may
-				// retain it past the next ReadMessage (the underlying
-				// websocket library reuses the read buffer between frames).
-				args[i] = append([]byte(nil), raw...)
-			}
 		}
 		kws.deliverOutboundAck(ackID, args)
 
 	default:
-		// Unknown SIO packet type: surface payload as a raw message.
+		// Unknown SIO packet type (including BINARY_EVENT / BINARY_ACK,
+		// whose attachments are not reassembled): surface the payload
+		// as a raw message.
 		kws.fireEvent(EventMessage, payload, nil)
+	}
+}
+
+// connectPolling completes the Socket.IO handshake of a polling session on
+// its first CONNECT packet: validate auth, persist namespace and auth,
+// queue the CONNECT ack, run the user callback, then fire EventConnect
+// once. The callback intentionally runs after the CONNECT ack is queued,
+// matching the WebSocket handshake order: Emit calls inside the callback
+// cannot overtake the namespace connect confirmation.
+func (kws *Websocket) connectPolling(ns, auth []byte) {
+	if !isValidAuthPayload(auth) {
+		logf("warn", "invalid_auth_payload", "uuid", kws.UUID, "namespace", string(ns), "size", len(auth))
+		kws.writeConnectError(ns, `{"message":"Invalid auth payload"}`)
+		kws.disconnected(ErrInvalidAuthPayload)
+		return
+	}
+	if t := kws.handshakeTimer.Load(); t != nil {
+		t.Stop()
+	}
+	kws.bindNamespace(ns, auth)
+	kws.write(TextMessage, buildSIOConnectAckSID(kws.getNamespace(), kws.UUID))
+	pollCallback := kws.pollCallback
+	kws.pollCallback = nil
+	if r := runUserCallback(pollCallback, kws); r != nil {
+		logf("error", "polling_callback_panic", "uuid", kws.UUID, "panic", fmt.Sprintf("%v", r))
+		kws.disconnected(fmt.Errorf("socketio: polling callback panic: %v", r))
+		return
+	}
+	if !kws.IsAlive() {
+		kws.disconnected(nil)
+		return
+	}
+	if kws.connectFired.CompareAndSwap(false, true) {
+		kws.fireEvent(EventConnect, nil, nil)
 	}
 }
 
@@ -2416,36 +2295,21 @@ func (kws *Websocket) handleSIOPacket(payload []byte) {
 // EventError, removes the connection from the pool, drains pending ack
 // callbacks and closes the done channel. Subsequent calls are no-ops.
 // This guarantees "EventDisconnect fires exactly once" even when read,
-// send, pong and handshake all hit an error simultaneously.
+// send, heartbeat and handshake all hit an error simultaneously.
+//
+// The socket is closed here unless the closing handshake was queued with
+// no error (Websocket.Close, or a client SIO DISCONNECT): then the read
+// loop keeps draining, bounded by CloseTimeout through the read deadline,
+// so the peer's Close frame is consumed and the SIO DISCONNECT packet
+// cannot be lost to a reset. Closing the socket is also what returns a
+// read parked in ReadMessage or a write stalled on a peer that stopped
+// reading, so no error path can wedge the tear-down.
 func (kws *Websocket) disconnected(err error) {
 	first := false
 	kws.once.Do(func() {
 		first = true
 		kws.setAlive(false)
-		// Push an immediate read deadline so any in-flight ReadMessage in
-		// the read goroutine returns and lets it exit. SetReadDeadline
-		// is delegated to net.Conn, whose contract guarantees concurrent
-		// callers are safe (it is the standard idiom for cancelling a
-		// blocking Read), so no kws.mu lock is required and we cannot
-		// deadlock against the read goroutine's blocking ReadMessage.
-		//
-		// We deliberately do NOT also push an immediate write deadline:
-		// fasthttp/websocket's SetWriteDeadline sets an unsynchronised
-		// struct field that flushFrame reads concurrently from the send
-		// goroutine, so calling it here under -race trips the detector
-		// (verified against TestSocketIOEmitWithAck10000Concurrent).
-		// In practice the writer unblocks via the queue close below,
-		// the read-side deadline tearing down the underlying socket, or
-		// fasthttp closing the request context, which is sufficient.
-		if c := kws.Conn; c != nil {
-			_ = c.SetReadDeadline(time.Unix(0, 1))
-		}
-		// Polling: release any blocked long-poll drain. Frames already
-		// in the buffer are still drainable; subsequent enqueues become
-		// no-ops.
-		if kws.pollQ != nil {
-			kws.pollQ.close()
-		}
+		kws.stopHeartbeat()
 		// Stop the polling handshake timer if scheduled. Without this,
 		// the AfterFunc closure keeps the *Websocket alive on the
 		// runtime timer heap until HandshakeTimeout elapses (10s
@@ -2453,13 +2317,23 @@ func (kws *Websocket) disconnected(err error) {
 		if t := kws.handshakeTimer.Load(); t != nil {
 			t.Stop()
 		}
+		switch {
+		case kws.pollQ != nil:
+			// Polling: release any blocked long-poll drain. Frames
+			// already in the buffer are still drainable; subsequent
+			// enqueues become no-ops.
+			kws.pollQ.close()
+		case kws.Conn == nil:
+		default:
+			kws.armTeardownDeadline(err == nil && kws.closeRequested.Load())
+		}
 	})
 	if !first {
 		return
 	}
 
 	// Remove from the pool BEFORE firing user events so that listeners
-	// observing pool.all() do not see this dying connection.
+	// observing the pool do not see this dying connection.
 	pool.delete(kws.GetUUID())
 
 	// Drain pending outbound ack callbacks: invoke each with
@@ -2497,8 +2371,14 @@ func (kws *Websocket) disconnected(err error) {
 		kws.fireEvent(EventError, nil, err)
 	}
 
-	// Close done last so run() unblocks AFTER user-visible events have fired.
+	// Close done last so waiters unblock AFTER user-visible events have fired.
 	close(kws.done)
+
+	// A polling session owns no goroutine, so nothing remains to join:
+	// release it right away.
+	if kws.pollQ != nil {
+		kws.finishRun()
+	}
 }
 
 // Create random UUID for each connection
@@ -2508,12 +2388,12 @@ func (kws *Websocket) createUUID() string {
 
 // Generate random UUID.
 func (kws *Websocket) randomUUID() string {
-	return uuid.New().String()
+	return utils.UUIDv4()
 }
 
 // Fires event on all connections.
 func fireGlobalEvent(event string, data []byte, error error) {
-	for _, kws := range pool.all() {
+	for _, kws := range pool.snapshot() {
 		kws.fireEvent(event, data, error)
 	}
 }
@@ -2535,7 +2415,8 @@ func (kws *Websocket) fireEvent(event string, data []byte, error error) {
 // args holds the raw-JSON event arguments. Data is populated from args[0]
 // for backwards compatibility with handlers that consume the single-arg
 // shape. SocketAttributes is a defensive copy so listeners cannot race
-// with concurrent SetAttribute mutations.
+// with concurrent SetAttribute mutations; a connection without attributes
+// dispatches nil rather than allocating an empty map per event.
 func (kws *Websocket) fireEventWithAck(event string, args [][]byte, fireErr error, ackID uint64, hasAck bool) {
 	callbacks := listeners.get(event)
 	if len(callbacks) == 0 {
@@ -2544,14 +2425,10 @@ func (kws *Websocket) fireEventWithAck(event string, args [][]byte, fireErr erro
 
 	kws.mu.RLock()
 	uuid := kws.UUID
-	attrs := make(map[string]any, len(kws.attributes))
-	for k, v := range kws.attributes {
-		attrs[k] = v
-	}
+	attrs := maps.Clone(kws.attributes)
 	var auth json.RawMessage
 	if event == EventConnect && len(kws.handshakeAuth) > 0 {
-		auth = make(json.RawMessage, len(kws.handshakeAuth))
-		copy(auth, kws.handshakeAuth)
+		auth = json.RawMessage(utils.CopyBytes(kws.handshakeAuth))
 	}
 	kws.mu.RUnlock()
 
@@ -2619,8 +2496,9 @@ func On(event string, callback eventCallback) {
 }
 
 // Shutdown closes every active socket.io connection in the pool and waits
-// for all of their per-connection goroutines (send, read, pong) to exit,
-// or until ctx is cancelled.
+// for each to release its socket and goroutines, or until ctx is cancelled.
+// Connections still draining their closing handshake when ctx expires are
+// closed outright.
 //
 // Wire this into fiber.App.Shutdown / fiber.App.ShutdownWithContext so an
 // application shutdown deterministically tears down sockets instead of
@@ -2629,22 +2507,27 @@ func On(event string, callback eventCallback) {
 // Returns ctx.Err() when ctx is cancelled before all connections finished
 // draining; otherwise returns nil.
 func Shutdown(ctx context.Context) error {
-	conns := pool.all()
+	conns := pool.snapshot()
 	if len(conns) == 0 {
 		return nil
 	}
+	sockets := make([]*Websocket, 0, len(conns))
+	for _, c := range conns {
+		if kws, ok := c.(*Websocket); ok {
+			sockets = append(sockets, kws)
+		}
+	}
 	done := make(chan struct{})
 	var wg sync.WaitGroup
-	for _, c := range conns {
-		kws, ok := c.(*Websocket)
-		if !ok {
-			continue
-		}
+	for _, kws := range sockets {
 		wg.Add(1)
 		go func(k *Websocket) {
 			defer wg.Done()
 			k.Close()
-			k.workersWg.Wait()
+			select {
+			case <-k.closed:
+			case <-ctx.Done():
+			}
 		}(kws)
 	}
 	go func() { wg.Wait(); close(done) }()
@@ -2652,6 +2535,9 @@ func Shutdown(ctx context.Context) error {
 	case <-done:
 		return nil
 	case <-ctx.Done():
+		for _, k := range sockets {
+			k.closeConn()
+		}
 		return ctx.Err()
 	}
 }

--- a/v3/socketio/socketio.go
+++ b/v3/socketio/socketio.go
@@ -2430,6 +2430,12 @@ func (kws *Websocket) disconnected(err error) {
 			kws.pollQ.close()
 		case kws.Conn == nil:
 		default:
+			// A WebSocket session still owns its socket until finishRun,
+			// so it is tracked as draining before anything can wake the
+			// read loop: finishRun removes the entry, and a reader that
+			// returned before the entry existed would leave a finished
+			// session in the set for good. Shutdown waits for these.
+			kws.markDraining()
 			kws.armCloseDeadline()
 			kws.armTeardownDeadline(err == nil && kws.closeRequested.Load())
 		}
@@ -2440,11 +2446,8 @@ func (kws *Websocket) disconnected(err error) {
 
 	// Remove from the pool BEFORE firing user events so that listeners
 	// observing the pool do not see this dying connection. A WebSocket
-	// session still owns its socket until finishRun, so it is tracked as
-	// draining first: Shutdown must not return while it is in flight.
-	if kws.Conn != nil {
-		kws.markDraining()
-	}
+	// session joined the draining set above, so it is in at least one of
+	// the two sets at any time.
 	pool.delete(kws.GetUUID())
 
 	// Drain pending outbound ack callbacks: invoke each with

--- a/v3/socketio/socketio.go
+++ b/v3/socketio/socketio.go
@@ -763,6 +763,45 @@ func (p *safePool) reset() {
 	p.Unlock()
 }
 
+// draining holds WebSocket sessions that have left the pool but still own
+// their socket: the closing handshake, or the last write, is in flight
+// until finishRun. Shutdown waits for these too, so a session closed a
+// moment before Shutdown cannot outlive it. A session is added before it
+// leaves the pool, so it is in at least one of the two sets at any time.
+var draining = struct {
+	sync.Mutex
+	m map[*Websocket]struct{}
+}{m: make(map[*Websocket]struct{})}
+
+func (kws *Websocket) markDraining() {
+	draining.Lock()
+	draining.m[kws] = struct{}{}
+	draining.Unlock()
+}
+
+func (kws *Websocket) unmarkDraining() {
+	draining.Lock()
+	delete(draining.m, kws)
+	draining.Unlock()
+}
+
+func drainingSessions() []*Websocket {
+	draining.Lock()
+	out := make([]*Websocket, 0, len(draining.m))
+	for kws := range draining.m {
+		out = append(out, kws)
+	}
+	draining.Unlock()
+	return out
+}
+
+//nolint:unused // test helper
+func resetDraining() {
+	draining.Lock()
+	draining.m = make(map[*Websocket]struct{})
+	draining.Unlock()
+}
+
 // safeListeners is a copy-on-write registry of event callbacks.
 //
 // Reads are lock-free: a single atomic.Pointer load yields the current
@@ -892,8 +931,11 @@ func New(callback func(kws *Websocket), config ...websocket.Config) func(fiber.C
 
 		// If the callback actively closed the socket (for example after
 		// inspecting HandshakeAuth), do not emit EventConnect for a connection
-		// user code already rejected.
+		// user code already rejected. The closing handshake it queued still
+		// runs to completion: read drains until the peer's Close frame or
+		// the CloseTimeout deadline, exactly as it would after run.
 		if !kws.IsAlive() {
+			kws.read()
 			kws.finishRun()
 			return
 		}
@@ -1749,6 +1791,12 @@ func (kws *Websocket) heartbeatTick() {
 	}
 	if t := kws.heartbeat.Load(); t != nil && kws.IsAlive() {
 		t.Reset(kws.hbTick)
+		// A tear-down that ran between the check above and the Reset has
+		// already called Stop; take the Reset back so the session is not
+		// retained on the timer heap for another tick.
+		if !kws.IsAlive() {
+			t.Stop()
+		}
 	}
 }
 
@@ -1922,12 +1970,17 @@ func (kws *Websocket) finishRun() {
 		if kws.Conn != nil {
 			// Let an in-flight write finish before closing under it:
 			// closing is what returns a write stalled on a peer that
-			// stopped reading, so the wait is bounded.
-			grace := time.Duration(kws.closeGrace.Load())
-			if grace <= 0 {
-				grace = controlWriteTimeout
+			// stopped reading, so the wait is bounded. The bound is one
+			// budget for the whole tear-down: what is left of the
+			// closing-handshake deadline when one was armed, CloseTimeout
+			// otherwise, and nothing at all when CloseTimeout is zero.
+			wait := time.Duration(kws.closeGrace.Load())
+			if graceful {
+				wait = time.Until(time.Unix(0, kws.teardownDeadline.Load()))
 			}
-			kws.waitSendDone(grace)
+			if wait > 0 {
+				kws.waitSendDone(wait)
+			}
 			if kws.cancelCtx != nil {
 				kws.cancelCtx()
 			}
@@ -1936,6 +1989,7 @@ func (kws *Websocket) finishRun() {
 		} else if kws.cancelCtx != nil {
 			kws.cancelCtx()
 		}
+		kws.unmarkDraining()
 		close(kws.closed)
 	})
 }
@@ -2345,7 +2399,12 @@ func (kws *Websocket) disconnected(err error) {
 	}
 
 	// Remove from the pool BEFORE firing user events so that listeners
-	// observing the pool do not see this dying connection.
+	// observing the pool do not see this dying connection. A WebSocket
+	// session still owns its socket until finishRun, so it is tracked as
+	// draining first: Shutdown must not return while it is in flight.
+	if kws.Conn != nil {
+		kws.markDraining()
+	}
 	pool.delete(kws.GetUUID())
 
 	// Drain pending outbound ack callbacks: invoke each with
@@ -2509,8 +2568,9 @@ func On(event string, callback eventCallback) {
 
 // Shutdown closes every active socket.io connection in the pool and waits
 // for each to release its socket and goroutines, or until ctx is cancelled.
-// Connections still draining their closing handshake when ctx expires are
-// closed outright.
+// Connections that were already closed but are still draining their
+// closing handshake are waited for as well; whatever is still in flight
+// when ctx expires is closed outright.
 //
 // Wire this into fiber.App.Shutdown / fiber.App.ShutdownWithContext so an
 // application shutdown deterministically tears down sockets instead of
@@ -2520,12 +2580,20 @@ func On(event string, callback eventCallback) {
 // draining; otherwise returns nil.
 func Shutdown(ctx context.Context) error {
 	conns := pool.snapshot()
-	if len(conns) == 0 {
+	inFlight := drainingSessions()
+	if len(conns) == 0 && len(inFlight) == 0 {
 		return nil
 	}
-	sockets := make([]*Websocket, 0, len(conns))
+	seen := make(map[*Websocket]struct{}, len(conns)+len(inFlight))
+	sockets := make([]*Websocket, 0, len(conns)+len(inFlight))
 	for _, c := range conns {
 		if kws, ok := c.(*Websocket); ok {
+			seen[kws] = struct{}{}
+			sockets = append(sockets, kws)
+		}
+	}
+	for _, kws := range inFlight {
+		if _, dup := seen[kws]; !dup {
 			sockets = append(sockets, kws)
 		}
 	}
@@ -2535,7 +2603,7 @@ func Shutdown(ctx context.Context) error {
 		wg.Add(1)
 		go func(k *Websocket) {
 			defer wg.Done()
-			k.Close()
+			k.Close() // a no-op for a session that is already draining
 			select {
 			case <-k.closed:
 			case <-ctx.Done():

--- a/v3/socketio/socketio.go
+++ b/v3/socketio/socketio.go
@@ -550,6 +550,12 @@ type Websocket struct {
 	// tear-down armed to return the read loop, so a concurrent idle
 	// refresh that lost the race can reinstate it.
 	teardownDeadline atomic.Int64
+	// closeDeadline is the end (unix nanoseconds) of the tear-down budget:
+	// CloseTimeout from the moment the tear-down began, set by whichever
+	// of beginClose and disconnected ran first. Waiting for queue space,
+	// the closing handshake and an in-flight write all share what is left
+	// of it. Zero when CloseTimeout is zero: nothing waits.
+	closeDeadline atomic.Int64
 	// mu guards UUID, attributes and handshakeAuth.
 	mu sync.RWMutex
 	// Conn is the underlying Fiber WebSocket connection. Treat it as
@@ -1642,15 +1648,17 @@ func (kws *Websocket) Close() {
 
 	disconnect := buildSIODisconnect(kws.getNamespace())
 	if kws.pollQ != nil {
-		// Polling: enqueue SIO DISCONNECT and EIO CLOSE so the next
-		// drain (or any in-flight long-poll) delivers them; the
+		// Polling: queue SIO DISCONNECT and EIO CLOSE so the next
+		// drain (or any in-flight long-poll) delivers them. They are
+		// appended past PollQueueMaxFrames: an EventClose listener
+		// may have filled the queue, and the peer must still learn
+		// the session is over rather than meet an unknown sid. The
 		// queue is closed by disconnected() below, after which
 		// further enqueues are silent no-ops. There is no
 		// equivalent of the WebSocket Close control frame on
 		// polling - the EIO "1" packet is the protocol-level
 		// disconnect signal.
-		kws.pollQ.enqueue(disconnect)
-		kws.pollQ.enqueue([]byte{eioClose})
+		kws.pollQ.enqueueTerminal(disconnect, []byte{eioClose})
 	} else {
 		kws.beginClose(disconnect)
 	}
@@ -1661,19 +1669,24 @@ func (kws *Websocket) Close() {
 // beginClose queues the closing handshake behind everything already in the
 // send queue: the optional SIO DISCONNECT frame, then a Close control
 // frame, both written by the send goroutine. It sets closeRequested so the
-// tear-down leaves the socket open, bounded by CloseTimeout, for the read
-// loop to consume the peer's Close frame. A queue that stays saturated for
-// CloseTimeout means the peer stopped reading; the marker is then dropped
-// and disconnected closes the socket outright.
+// tear-down leaves the socket open for the read loop to consume the peer's
+// Close frame. A saturated queue means the peer stopped reading; the wait
+// for a slot, the closing handshake and the stalled write then share one
+// tear-down budget, CloseTimeout from now, and once it is spent the marker
+// is dropped and disconnected closes the socket outright.
 func (kws *Websocket) beginClose(disconnect []byte) {
 	msg := message{mType: closeFrameMarker, data: disconnect}
+	deadline := kws.armCloseDeadline()
 	select {
 	case kws.queue <- msg:
 		kws.closeRequested.Store(true)
 		return
 	default:
 	}
-	wait := time.Duration(kws.closeGrace.Load())
+	if deadline.IsZero() {
+		return
+	}
+	wait := time.Until(deadline)
 	if wait <= 0 {
 		return
 	}
@@ -1686,6 +1699,24 @@ func (kws *Websocket) beginClose(disconnect []byte) {
 		logf("warn", "close_queue_stalled", "uuid", kws.UUID, "queue_cap", cap(kws.queue))
 	case <-kws.done:
 	}
+}
+
+// armCloseDeadline starts the tear-down budget, CloseTimeout from now, if
+// no earlier caller did, and returns when it ends. The zero time means
+// there is no budget: CloseTimeout is zero and nothing waits.
+func (kws *Websocket) armCloseDeadline() time.Time {
+	if d := kws.closeDeadline.Load(); d != 0 {
+		return time.Unix(0, d)
+	}
+	grace := time.Duration(kws.closeGrace.Load())
+	if grace <= 0 {
+		return time.Time{}
+	}
+	deadline := time.Now().Add(grace)
+	if !kws.closeDeadline.CompareAndSwap(0, deadline.UnixNano()) {
+		return time.Unix(0, kws.closeDeadline.Load())
+	}
+	return deadline
 }
 
 // getNamespace returns the Socket.IO namespace this connection is bound to,
@@ -1980,11 +2011,12 @@ func (kws *Websocket) finishRun() {
 			// closing is what returns a write stalled on a peer that
 			// stopped reading, so the wait is bounded. The bound is one
 			// budget for the whole tear-down: what is left of the
-			// closing-handshake deadline when one was armed, CloseTimeout
-			// otherwise, and nothing at all when CloseTimeout is zero.
-			wait := time.Duration(kws.closeGrace.Load())
-			if graceful {
-				wait = time.Until(time.Unix(0, kws.teardownDeadline.Load()))
+			// deadline armed when it began (waiting for queue space and
+			// the closing handshake already came out of it), and nothing
+			// at all when CloseTimeout is zero.
+			var wait time.Duration
+			if d := kws.closeDeadline.Load(); d != 0 {
+				wait = time.Until(time.Unix(0, d))
 			}
 			if wait > 0 {
 				kws.waitSendDone(wait)
@@ -2022,22 +2054,21 @@ func (kws *Websocket) waitSendDone(d time.Duration) {
 }
 
 // armTeardownDeadline sets the read deadline that returns the read loop:
-// CloseTimeout from now when the closing handshake is queued, so the loop
-// drains until the peer's Close frame; as good as immediately otherwise.
-// The socket itself is closed by finishRun once the send goroutine is out
-// of any write: SetReadDeadline is safe to call concurrently with a read,
-// closing under a write is not on every net.Conn. The immediate deadline
-// is a moment ahead rather than in the past because a conn that
-// implements deadlines with a timer fires a deadline that was reset, not
-// one that was stopped.
+// the end of the tear-down budget when the closing handshake is queued, so
+// the loop drains until the peer's Close frame; as good as immediately
+// otherwise. The socket itself is closed by finishRun once the send
+// goroutine is out of any write: SetReadDeadline is safe to call
+// concurrently with a read, closing under a write is not on every
+// net.Conn. The deadline is always a moment ahead rather than in the past
+// because a conn that implements deadlines with a timer fires a deadline
+// that was reset, not one that was stopped.
 func (kws *Websocket) armTeardownDeadline(graceful bool) {
-	grace := time.Millisecond
+	deadline := time.Now().Add(time.Millisecond)
 	if graceful {
-		if g := time.Duration(kws.closeGrace.Load()); g > 0 {
-			grace = g
+		if d := kws.closeDeadline.Load(); d > deadline.UnixNano() {
+			deadline = time.Unix(0, d)
 		}
 	}
-	deadline := time.Now().Add(grace)
 	kws.teardownDeadline.Store(deadline.UnixNano())
 	_ = kws.Conn.SetReadDeadline(deadline)
 }
@@ -2399,6 +2430,7 @@ func (kws *Websocket) disconnected(err error) {
 			kws.pollQ.close()
 		case kws.Conn == nil:
 		default:
+			kws.armCloseDeadline()
 			kws.armTeardownDeadline(err == nil && kws.closeRequested.Load())
 		}
 	})

--- a/v3/socketio/socketio.go
+++ b/v3/socketio/socketio.go
@@ -1077,21 +1077,29 @@ func (kws *Websocket) handshake() error {
 }
 
 // rejectHandshake answers a rejected SIO CONNECT: CONNECT_ERROR, then the
-// closing handshake. Reading on until the peer's Close frame, bounded by
-// CloseTimeout, keeps the error packet from being lost to a TCP reset that
-// closing with unread inbound data would provoke. Runs before the send
-// goroutine exists, so it writes directly.
+// closing handshake. Reading on until the peer's Close frame keeps the
+// error packet from being lost to a TCP reset that closing with unread
+// inbound data would provoke. One absolute deadline, CloseTimeout from
+// now, bounds all of it - the CONNECT_ERROR write, the Close frame and the
+// drain - so a peer that never answers costs the budget once. Runs before
+// the send goroutine exists, so it writes directly.
 func (kws *Websocket) rejectHandshake(namespace []byte, jsonMessage string) {
 	conn := kws.Conn
-	_ = conn.WriteMessage(TextMessage, buildSIOConnectError(namespace, jsonMessage))
 	grace := time.Duration(kws.closeGrace.Load())
 	if grace <= 0 {
+		// No closing handshake: finishRun closes the socket right away.
+		_ = conn.WriteMessage(TextMessage, buildSIOConnectError(namespace, jsonMessage))
 		return
 	}
-	if err := conn.WriteControl(CloseMessage, websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "handshake rejected"), time.Now().Add(grace)); err != nil {
+	deadline := time.Now().Add(grace)
+	_ = conn.SetWriteDeadline(deadline)
+	if err := conn.WriteMessage(TextMessage, buildSIOConnectError(namespace, jsonMessage)); err != nil {
 		return
 	}
-	_ = conn.SetReadDeadline(time.Now().Add(grace))
+	if err := conn.WriteControl(CloseMessage, websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "handshake rejected"), deadline); err != nil {
+		return
+	}
+	_ = conn.SetReadDeadline(deadline)
 	for {
 		if _, _, err := conn.ReadMessage(); err != nil {
 			return

--- a/v3/socketio/socketio.go
+++ b/v3/socketio/socketio.go
@@ -187,6 +187,10 @@ var (
 	// ErrUnknownEIOPacket is surfaced via EventError when the inbound EIO
 	// packet type byte does not match any recognised Engine.IO opcode.
 	ErrUnknownEIOPacket = errors.New("socketio: unknown EIO packet type")
+	// ErrTooManyArgs is surfaced via EventError when an inbound EVENT
+	// array holds more elements than MaxEventArgs; an ACK array over the
+	// limit is dropped silently, like any other malformed ACK.
+	ErrTooManyArgs = errors.New("socketio: packet exceeds MaxEventArgs")
 )
 
 // Tunable package-level knobs. Mutate them before calling New so each new
@@ -273,6 +277,14 @@ var (
 	// frame inside the EventPayload dispatched to user listeners. Set
 	// to zero to disable the bound (not recommended).
 	MaxEventNameLength = 256
+	// MaxEventArgs caps the number of elements accepted in an inbound
+	// SIO EVENT or ACK array, the event name included. Each element
+	// costs a slice header, so without the cap a payload of MaxPayload
+	// bytes made of one-byte elements would allocate an order of
+	// magnitude more than its own size before any listener runs. 256 is
+	// comfortably above any legitimate argument list. Set to zero to
+	// disable the bound (not recommended).
+	MaxEventArgs = 256
 	// SendQueueSize is the buffered capacity of the per-connection
 	// outbound frame queue. Tune it before connections are accepted;
 	// existing sockets retain the size in effect at New() time.

--- a/v3/socketio/socketio_bench_test.go
+++ b/v3/socketio/socketio_bench_test.go
@@ -141,6 +141,13 @@ func BenchmarkBroadcastFanout(b *testing.B) {
 	ln, stop := benchServer(b)
 	defer stop()
 
+	// The benchmark enqueues far faster than 1024 clients can drain, so
+	// let the queues shed frames instead of tearing the connections down;
+	// a broadcast to an emptied pool would measure nothing.
+	prevDrop := DropFramesOnOverflow
+	DropFramesOnOverflow = true
+	defer func() { DropFramesOnOverflow = prevDrop }()
+
 	conns := make([]*websocket.Conn, fanout)
 	var ready sync.WaitGroup
 	ready.Add(fanout)
@@ -171,6 +178,9 @@ func BenchmarkBroadcastFanout(b *testing.B) {
 	}
 	b.StopTimer()
 	b.ReportMetric(float64(fanout), "subs")
+	if live := len(pool.snapshot()); live != fanout {
+		b.Fatalf("only %d/%d subscribers alive at the end; the benchmark measured a shrinking pool", live, fanout)
+	}
 
 	for _, c := range conns {
 		_ = c.Close()
@@ -208,4 +218,40 @@ func BenchmarkSteadyStateMemory(b *testing.B) {
 	for _, c := range clients {
 		_ = c.Close()
 	}
+}
+
+// BenchmarkParseSIOEvent measures the inbound event parser on a typical
+// chat payload: name plus three arguments of mixed shape.
+func BenchmarkParseSIOEvent(b *testing.B) {
+	payload := []byte(`["chat message",{"user":"alice","text":"hello world, this is a fairly ordinary message"},42,[1,2,3]]`)
+	b.ReportAllocs()
+	for b.Loop() {
+		name, args, err := parseSIOEvent(payload)
+		if err != nil || name != "chat message" || len(args) != 3 {
+			b.Fatalf("unexpected parse result: %q %d %v", name, len(args), err)
+		}
+	}
+}
+
+// BenchmarkBuildSIOEvent measures the outbound event encoder for a JSON
+// argument and for a raw-text argument that must be JSON-string encoded.
+func BenchmarkBuildSIOEvent(b *testing.B) {
+	jsonArg := []byte(`{"user":"alice","text":"hello world, this is a fairly ordinary message"}`)
+	rawArg := []byte(`hello world, this is a fairly ordinary <message> & more`)
+	b.Run("json", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if f := buildSIOEvent(nil, "chat message", jsonArg); len(f) == 0 {
+				b.Fatal("empty frame")
+			}
+		}
+	})
+	b.Run("raw-text", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if f := buildSIOEvent(nil, "chat message", rawArg); len(f) == 0 {
+				b.Fatal("empty frame")
+			}
+		}
+	})
 }

--- a/v3/socketio/socketio_fuzz_test.go
+++ b/v3/socketio/socketio_fuzz_test.go
@@ -511,6 +511,12 @@ func FuzzSplitJSONArray(f *testing.F) {
 			}
 			return
 		}
+		if MaxEventArgs > 0 && len(ref) > MaxEventArgs {
+			if !errors.Is(err, ErrTooManyArgs) {
+				t.Fatalf("%d elements must exceed MaxEventArgs=%d, got err=%v", len(ref), MaxEventArgs, err)
+			}
+			return
+		}
 		if err != nil {
 			t.Fatalf("encoding/json accepted %q, splitter failed: %v", data, err)
 		}

--- a/v3/socketio/socketio_fuzz_test.go
+++ b/v3/socketio/socketio_fuzz_test.go
@@ -129,6 +129,7 @@ func FuzzParseSIOEvent(f *testing.F) {
 		`[]`, `[1]`, `[null]`, `["x", "y"]`,
 		`not json`, `{`, `[`, `["unterminated`,
 		`[{"k":1}]`, `[true,false]`, `["evt",` + string([]byte{0xff}) + `]`,
+		`["` + string([]byte{0xff}) + `"]`, `["a` + string([]byte{0xff, 0xe2, 0x82}) + `b",1]`,
 	} {
 		f.Add([]byte(s))
 	}
@@ -150,6 +151,20 @@ func FuzzParseSIOEvent(f *testing.F) {
 		}
 		if !utf8.ValidString(name) {
 			t.Fatalf("name not valid UTF-8: %q (in %q)", name, payload)
+		}
+		// The name must decode exactly as encoding/json decodes the first
+		// element, escapes and invalid UTF-8 included: the unescaped fast
+		// path and the decoder path may never disagree.
+		elems, splitErr := splitJSONArray(payload, nil)
+		if splitErr != nil || len(elems) == 0 {
+			t.Fatalf("parseSIOEvent succeeded but splitJSONArray failed on %q: %v", payload, splitErr)
+		}
+		var want string
+		if err := json.Unmarshal(elems[0], &want); err != nil {
+			t.Fatalf("name element %q is not a JSON string for encoding/json: %v", elems[0], err)
+		}
+		if name != want {
+			t.Fatalf("name %q differs from encoding/json's %q (in %q)", name, want, payload)
 		}
 	})
 }

--- a/v3/socketio/socketio_fuzz_test.go
+++ b/v3/socketio/socketio_fuzz_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strconv"
+	"strings"
 	"testing"
 	"unicode/utf8"
 )
@@ -213,10 +214,10 @@ func FuzzExtractSIONamespace(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		defer func() {
 			if r := recover(); r != nil {
-				t.Fatalf("extractSIONamespace panic on %q: %v", data, r)
+				t.Fatalf("extractSIOConnect panic on %q: %v", data, r)
 			}
 		}()
-		ns := extractSIONamespace(data)
+		ns, _ := extractSIOConnect(data)
 		if ns == nil {
 			return
 		}
@@ -477,6 +478,49 @@ func FuzzBatchedEIOFrame(f *testing.F) {
 		}
 		if count > MaxBatchPackets+1 {
 			t.Fatalf("dispatched %d > MaxBatchPackets %d", count, MaxBatchPackets)
+		}
+	})
+}
+
+// FuzzSplitJSONArray cross-checks the zero-copy array splitter against
+// encoding/json: for every input both must agree on whether it is a JSON
+// array and, when it is, on the exact bytes of every top-level element.
+func FuzzSplitJSONArray(f *testing.F) {
+	for _, seed := range []string{
+		`["ev"]`, `[]`, ` [ "a" , {"b":[1,2]} , "c,]" ] `, `["a\"b","c\\"]`,
+		`[[[[]]]]`, `{"a":1}`, `["a",]`, `null`, `"s"`, `[1e5,-0,true,null]`,
+		"[\" \"]", `["😀"]`, `[` + strings.Repeat(`"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",`, 4) + `1]`,
+	} {
+		f.Add([]byte(seed))
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		got, err := splitJSONArray(data, nil)
+		var ref []json.RawMessage
+		refErr := json.Unmarshal(data, &ref)
+		if refErr == nil && bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+			// encoding/json accepts a JSON null for a slice; the splitter
+			// only accepts arrays.
+			if err == nil {
+				t.Fatalf("splitter accepted %q", data)
+			}
+			return
+		}
+		if refErr != nil {
+			if err == nil {
+				t.Fatalf("encoding/json rejected %q but the splitter accepted it: %q", data, got)
+			}
+			return
+		}
+		if err != nil {
+			t.Fatalf("encoding/json accepted %q, splitter failed: %v", data, err)
+		}
+		if len(got) != len(ref) {
+			t.Fatalf("element count differs for %q: got %d want %d", data, len(got), len(ref))
+		}
+		for i := range ref {
+			if !bytes.Equal(ref[i], got[i]) {
+				t.Fatalf("element %d differs for %q: got %q want %q", i, data, got[i], ref[i])
+			}
 		}
 	})
 }

--- a/v3/socketio/socketio_lifecycle_test.go
+++ b/v3/socketio/socketio_lifecycle_test.go
@@ -560,6 +560,40 @@ func TestSocketIOHandshakeRejectionDeliversConnectError(t *testing.T) {
 	require.False(t, isTimeout(err), "server did not close the socket: %v", err)
 }
 
+// TestSocketIOHandshakeRejectionBoundedByCloseTimeout verifies that a
+// rejected peer which never answers the Close frame is released after one
+// CloseTimeout: the CONNECT_ERROR write, the Close frame and the drain
+// share a single absolute deadline. The client reads raw bytes so the
+// websocket library does not answer the Close frame on its behalf.
+func TestSocketIOHandshakeRejectionBoundedByCloseTimeout(t *testing.T) {
+	resetSIOGlobals(t)
+	prev := CloseTimeout
+	CloseTimeout = 300 * time.Millisecond
+	defer func() { CloseTimeout = prev }()
+
+	ln, teardown := newSIOTestServer(t, func(_ *Websocket) {})
+	defer teardown()
+
+	conn := dialSIO(t, ln)
+	defer conn.Close()
+	_, _, err := conn.ReadMessage() // EIO OPEN
+	require.NoError(t, err)
+
+	start := time.Now()
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`40["not","an","object"]`)))
+
+	// CONNECT_ERROR and the Close frame arrive; the client answers nothing.
+	// The server closes the socket when its deadline expires: after the
+	// peer had its CloseTimeout to answer, and well inside a single budget
+	// plus scheduling slack, never two of them.
+	err = rawReadUntilError(conn, 2*time.Second)
+	require.Error(t, err)
+	require.False(t, isTimeout(err), "server did not close the socket: %v", err)
+	elapsed := time.Since(start)
+	require.GreaterOrEqual(t, elapsed, CloseTimeout, "socket closed before the peer could answer the Close frame")
+	require.Less(t, elapsed, 1500*time.Millisecond)
+}
+
 // TestSocketIOPollingSessionReleasesOnDisconnect verifies that a polling
 // session, which owns no goroutine, still signals its release.
 func TestSocketIOPollingSessionReleasesOnDisconnect(t *testing.T) {
@@ -637,6 +671,24 @@ func TestParseSIOEventNames(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "a\"bé", name)
 	require.Len(t, args, 1)
+
+	// No escapes, valid UTF-8: the bytes are the name.
+	name, _, err = parseSIOEvent([]byte(`["héllo wörld"]`))
+	require.NoError(t, err)
+	require.Equal(t, "héllo wörld", name)
+
+	// json.Valid accepts invalid UTF-8 inside a string and encoding/json
+	// decodes each offending byte as U+FFFD; the unescaped fast path must
+	// come out the same as the escaped path and the old parser did, so a
+	// listener registered for the decoded name still matches.
+	name, _, err = parseSIOEvent([]byte("[\"\xff\"]"))
+	require.NoError(t, err)
+	require.Equal(t, "\ufffd", name)
+	var want string
+	require.NoError(t, json.Unmarshal([]byte("\"a\xffb\xe2\x82\""), &want))
+	name, _, err = parseSIOEvent([]byte("[\"a\xffb\xe2\x82\",1]"))
+	require.NoError(t, err)
+	require.Equal(t, want, name)
 
 	_, _, err = parseSIOEvent([]byte(`[1,2]`))
 	require.ErrorIs(t, err, errEventNameNotString)

--- a/v3/socketio/socketio_lifecycle_test.go
+++ b/v3/socketio/socketio_lifecycle_test.go
@@ -200,7 +200,41 @@ func TestSocketIOCloseWithSaturatedQueueUsesOneBudget(t *testing.T) {
 	waitClosed(t, kws, 10*time.Second)
 	elapsed := time.Since(start)
 	require.GreaterOrEqual(t, elapsed, CloseTimeout, "Close gave up on a queue slot before CloseTimeout")
-	require.Less(t, elapsed, 700*time.Millisecond, "the tear-down spent more than one CloseTimeout budget")
+	// Two budgets would be at least 800ms; the bound stays below that while
+	// leaving the asynchronous read-loop and finishRun path scheduling slack.
+	require.Less(t, elapsed, 750*time.Millisecond, "the tear-down spent more than one CloseTimeout budget")
+}
+
+// TestSocketIODrainingSetEmptyAfterConcurrentTeardown verifies that a
+// tear-down started outside the read loop (a heartbeat timeout, simulated
+// directly) while the peer closes at the same moment never leaves a
+// finished session in the draining set: the session is marked before the
+// read loop is woken, so finishRun's removal cannot run first.
+func TestSocketIODrainingSetEmptyAfterConcurrentTeardown(t *testing.T) {
+	resetSIOGlobals(t)
+	kwsCh := captureConnect(t)
+	ln, teardown := newSIOTestServer(t, func(_ *Websocket) {})
+	defer teardown()
+
+	for i := 0; i < 25; i++ {
+		conn := dialSIO(t, ln)
+		require.NoError(t, sioHandshake(t, conn))
+		kws := awaitSession(t, kwsCh)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			kws.disconnected(ErrHeartbeatTimeout)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = conn.Close()
+		}()
+		wg.Wait()
+		waitClosed(t, kws, 5*time.Second)
+	}
+	require.Empty(t, drainingSessions(), "finished sessions must not linger in the draining set")
 }
 
 // TestSocketIOStalledPeerDoesNotWedgeTeardown floods a peer that stopped

--- a/v3/socketio/socketio_lifecycle_test.go
+++ b/v3/socketio/socketio_lifecycle_test.go
@@ -2,6 +2,7 @@ package socketio
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"net"
@@ -123,9 +124,11 @@ func TestSocketIOCloseTimeoutClosesUnresponsivePeer(t *testing.T) {
 	kws.Close()
 	require.False(t, kws.IsAlive(), "Close must mark the session dead synchronously")
 
-	// The client never reads. The server gives up after CloseTimeout.
+	// The client never reads. The server gives up after CloseTimeout, and
+	// CloseTimeout is one budget for the whole tear-down, not one for the
+	// read side and another for the writer.
 	waitClosed(t, kws, 3*time.Second)
-	require.Less(t, time.Since(start), 2500*time.Millisecond)
+	require.Less(t, time.Since(start), 1500*time.Millisecond)
 
 	err := rawReadUntilError(conn, 2*time.Second)
 	require.Error(t, err)
@@ -187,6 +190,98 @@ func TestSocketIOStalledPeerDoesNotWedgeTeardown(t *testing.T) {
 	start := time.Now()
 	waitClosed(t, kws, 10*time.Second)
 	require.Less(t, time.Since(start), 5*time.Second, "stalled write held the tear-down")
+}
+
+// TestSocketIONewCallbackCloseCompletesClosingHandshake pins the documented
+// auth-rejection pattern: a New callback that calls Close before the read
+// loop ever ran. The closing handshake must still complete (SIO
+// DISCONNECT, Close frame, wait for the peer's Close) before the socket is
+// closed, or the client would see a transport error and reconnect.
+func TestSocketIONewCallbackCloseCompletesClosingHandshake(t *testing.T) {
+	resetSIOGlobals(t)
+	connectFired := make(chan struct{}, 1)
+	On(EventConnect, func(_ *EventPayload) {
+		select {
+		case connectFired <- struct{}{}:
+		default:
+		}
+	})
+	closedCh := make(chan *Websocket, 1)
+	On(EventClose, func(p *EventPayload) {
+		select {
+		case closedCh <- p.Kws:
+		default:
+		}
+	})
+
+	ln, teardown := newSIOTestServer(t, func(kws *Websocket) {
+		kws.Close() // e.g. after inspecting kws.HandshakeAuth()
+	})
+	defer teardown()
+
+	conn := dialSIO(t, ln)
+	defer conn.Close()
+	require.NoError(t, sioHandshake(t, conn))
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	mType, msg, err := sioReadSkipPings(conn)
+	require.NoError(t, err)
+	require.Equal(t, websocket.TextMessage, mType)
+	require.Equal(t, "41", string(msg), "SIO DISCONNECT must reach the rejected client")
+	_, _, err = conn.ReadMessage()
+	require.Truef(t, websocket.IsCloseError(err, websocket.CloseNormalClosure),
+		"expected Close frame with code 1000, got %v", err)
+
+	var kws *Websocket
+	select {
+	case kws = <-closedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("EventClose did not fire")
+	}
+	waitClosed(t, kws, 2*time.Second)
+	err = rawReadUntilError(conn, 2*time.Second)
+	require.Error(t, err)
+	require.False(t, isTimeout(err), "server did not close the socket: %v", err)
+
+	select {
+	case <-connectFired:
+		t.Fatal("EventConnect fired for a session the callback rejected")
+	default:
+	}
+}
+
+// TestSocketIOShutdownWaitsForClosingSessions verifies that Shutdown also
+// waits for a session that was closed just before it was called and is
+// still draining its closing handshake, even though it already left the
+// pool.
+func TestSocketIOShutdownWaitsForClosingSessions(t *testing.T) {
+	resetSIOGlobals(t)
+	prev := CloseTimeout
+	CloseTimeout = 300 * time.Millisecond
+	defer func() { CloseTimeout = prev }()
+	kwsCh := captureConnect(t)
+
+	ln, teardown := newSIOTestServer(t, func(_ *Websocket) {})
+	defer teardown()
+
+	conn := dialSIO(t, ln)
+	defer conn.Close()
+	require.NoError(t, sioHandshake(t, conn))
+	kws := awaitSession(t, kwsCh)
+
+	// The client never answers the Close frame, so the session drains for
+	// the full CloseTimeout after leaving the pool.
+	kws.Close()
+	require.Empty(t, pool.snapshot(), "a closed session must leave the pool at once")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, Shutdown(ctx))
+	select {
+	case <-kws.closed:
+	default:
+		t.Fatal("Shutdown returned while the session was still draining")
+	}
 }
 
 // TestSocketIOClientDisconnectPacketCompletesClosingHandshake verifies that

--- a/v3/socketio/socketio_lifecycle_test.go
+++ b/v3/socketio/socketio_lifecycle_test.go
@@ -554,6 +554,30 @@ func TestParseSIOEventNames(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to parse event payload")
 }
 
+// TestSplitJSONArrayBoundsElements pins the MaxEventArgs cap: an array with
+// more elements than the limit is rejected before its slice headers are
+// allocated, on both the EVENT and the ACK path.
+func TestSplitJSONArrayBoundsElements(t *testing.T) {
+	prev := MaxEventArgs
+	MaxEventArgs = 3
+	defer func() { MaxEventArgs = prev }()
+
+	got, err := splitJSONArray([]byte(`[1,2,3]`), nil)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	_, err = splitJSONArray([]byte(`[1,2,3,4]`), nil)
+	require.ErrorIs(t, err, ErrTooManyArgs)
+	_, _, err = parseSIOEvent([]byte(`["ev",1,2,3]`))
+	require.ErrorIs(t, err, ErrTooManyArgs)
+	_, err = parseSIOAckArgs([]byte(`[1,2,3,4]`))
+	require.ErrorIs(t, err, ErrTooManyArgs)
+
+	MaxEventArgs = 0
+	got, err = splitJSONArray([]byte(`[1,2,3,4,5,6,7,8,9]`), nil)
+	require.NoError(t, err)
+	require.Len(t, got, 9)
+}
+
 func TestParseSIOAckArgs(t *testing.T) {
 	args, err := parseSIOAckArgs([]byte(`[]`))
 	require.NoError(t, err)

--- a/v3/socketio/socketio_lifecycle_test.go
+++ b/v3/socketio/socketio_lifecycle_test.go
@@ -571,11 +571,25 @@ func TestParseSIOAckArgs(t *testing.T) {
 // TestBuildSIOEventEncodesLikeEncodingJSON pins the SWAR JSON string
 // encoder to encoding/json's output for event names and raw-text arguments.
 func TestBuildSIOEventEncodesLikeEncodingJSON(t *testing.T) {
-	for _, name := range []string{"plain", `q"uote`, "<tag>&", "ünï", "\x00ctl\t", "\xff invalid", "  sep", "back\\slash"} {
+	for _, name := range []string{"plain", `q"uote`, "<tag>&", "ünï", "\x00ctl\t", "  sep", "back\\slash"} {
 		want, err := json.Marshal(name)
 		require.NoError(t, err)
 		require.Equal(t, `42[`+string(want)+`]`, string(buildSIOEvent(nil, name, nil)), "name %q", name)
 		require.Equal(t, `42["e",`+string(want)+`]`, string(buildSIOEvent(nil, "e", []byte(name))), "raw arg %q", name)
+	}
+	// Invalid UTF-8 is replaced with U+FFFD by both encoders, but how the
+	// replacement character itself is spelled differs between Go releases
+	// (escaped as \ufffd up to Go 1.26, literal from Go 1.27), so compare
+	// what the frames decode to rather than their bytes.
+	invalid := "\xff invalid"
+	var want string
+	require.NoError(t, json.Unmarshal([]byte(`"\ufffd invalid"`), &want))
+	for _, frame := range [][]byte{buildSIOEvent(nil, invalid, nil), buildSIOEvent(nil, "e", []byte(invalid))} {
+		elems, err := splitJSONArray(frame[2:], nil)
+		require.NoError(t, err, "frame %q", frame)
+		var got string
+		require.NoError(t, json.Unmarshal(elems[len(elems)-1], &got), "frame %q", frame)
+		require.Equal(t, want, got, "frame %q", frame)
 	}
 	// Valid JSON passes through untouched.
 	require.Equal(t, `42/ns,["e",{"a":1},[2],"s",3]`,

--- a/v3/socketio/socketio_lifecycle_test.go
+++ b/v3/socketio/socketio_lifecycle_test.go
@@ -1,0 +1,628 @@
+package socketio
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fasthttp/websocket"
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/require"
+)
+
+// captureConnect registers an EventConnect listener that hands the first
+// connected session to the returned channel.
+func captureConnect(t *testing.T) <-chan *Websocket {
+	t.Helper()
+	kwsCh := make(chan *Websocket, 8)
+	On(EventConnect, func(p *EventPayload) {
+		select {
+		case kwsCh <- p.Kws:
+		default:
+		}
+	})
+	return kwsCh
+}
+
+func awaitSession(t *testing.T, ch <-chan *Websocket) *Websocket {
+	t.Helper()
+	select {
+	case kws := <-ch:
+		return kws
+	case <-time.After(2 * time.Second):
+		t.Fatal("EventConnect did not fire")
+		return nil
+	}
+}
+
+// rawReadUntilError drains the socket underneath a client until it errors,
+// returning that error. A server that never closed the socket shows up as
+// a deadline error.
+func rawReadUntilError(conn *websocket.Conn, timeout time.Duration) error {
+	raw := conn.NetConn()
+	_ = raw.SetReadDeadline(time.Now().Add(timeout))
+	buf := make([]byte, 4096)
+	for {
+		if _, err := raw.Read(buf); err != nil {
+			return err
+		}
+	}
+}
+
+func isTimeout(err error) bool {
+	var ne net.Error
+	return errors.As(err, &ne) && ne.Timeout()
+}
+
+// TestSocketIOCloseCompletesClosingHandshakeAndReleasesSocket pins the
+// server-initiated close sequence: SIO DISCONNECT, then a Close frame, then,
+// once the peer answered, the socket is closed by the server. Before this
+// the middleware left the hijacked socket open after the handler returned
+// and nothing in socketio closed it.
+func TestSocketIOCloseCompletesClosingHandshakeAndReleasesSocket(t *testing.T) {
+	resetSIOGlobals(t)
+	kwsCh := captureConnect(t)
+
+	ln, teardown := newSIOTestServer(t, func(_ *Websocket) {})
+	defer teardown()
+
+	conn := dialSIO(t, ln)
+	defer conn.Close()
+	require.NoError(t, sioHandshake(t, conn))
+	kws := awaitSession(t, kwsCh)
+
+	go kws.Close()
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	mType, msg, err := sioReadSkipPings(conn)
+	require.NoError(t, err)
+	require.Equal(t, websocket.TextMessage, mType)
+	require.Equal(t, "41", string(msg), "SIO DISCONNECT must precede the Close frame")
+
+	// The library answers the Close frame from inside ReadMessage and
+	// reports it as a CloseError.
+	_, _, err = conn.ReadMessage()
+	require.Truef(t, websocket.IsCloseError(err, websocket.CloseNormalClosure),
+		"expected Close frame with code 1000, got %v", err)
+
+	// The peer answered, so the server releases the session right away,
+	// well inside CloseTimeout.
+	waitClosed(t, kws, 2*time.Second)
+	require.False(t, kws.IsAlive())
+
+	// And the socket itself is gone: a raw read reports the close instead
+	// of blocking until the deadline.
+	err = rawReadUntilError(conn, 2*time.Second)
+	require.Error(t, err)
+	require.False(t, isTimeout(err), "server did not close the socket: %v", err)
+}
+
+// TestSocketIOCloseTimeoutClosesUnresponsivePeer verifies that a peer which
+// never answers the Close frame cannot pin the session: after CloseTimeout
+// the socket is closed regardless.
+func TestSocketIOCloseTimeoutClosesUnresponsivePeer(t *testing.T) {
+	resetSIOGlobals(t)
+	prev := CloseTimeout
+	CloseTimeout = 300 * time.Millisecond
+	defer func() { CloseTimeout = prev }()
+
+	kwsCh := captureConnect(t)
+	ln, teardown := newSIOTestServer(t, func(_ *Websocket) {})
+	defer teardown()
+
+	conn := dialSIO(t, ln)
+	defer conn.Close()
+	require.NoError(t, sioHandshake(t, conn))
+	kws := awaitSession(t, kwsCh)
+
+	start := time.Now()
+	kws.Close()
+	require.False(t, kws.IsAlive(), "Close must mark the session dead synchronously")
+
+	// The client never reads. The server gives up after CloseTimeout.
+	waitClosed(t, kws, 3*time.Second)
+	require.Less(t, time.Since(start), 2500*time.Millisecond)
+
+	err := rawReadUntilError(conn, 2*time.Second)
+	require.Error(t, err)
+	require.False(t, isTimeout(err), "server did not close the socket: %v", err)
+}
+
+// TestSocketIOStalledPeerDoesNotWedgeTeardown floods a peer that stopped
+// reading over a real TCP socket, so the send goroutine blocks inside a
+// write. The queue overflow tears the session down, and the tear-down must
+// complete: closing the socket is what returns the stalled write. The old
+// implementation waited for the writer before closing anything and hung.
+func TestSocketIOStalledPeerDoesNotWedgeTeardown(t *testing.T) {
+	resetSIOGlobals(t)
+	prevClose, prevDrop := CloseTimeout, DropFramesOnOverflow
+	CloseTimeout = 300 * time.Millisecond
+	DropFramesOnOverflow = false
+	defer func() { CloseTimeout, DropFramesOnOverflow = prevClose, prevDrop }()
+
+	kwsCh := captureConnect(t)
+	disc := make(chan error, 1)
+	On(EventDisconnect, func(p *EventPayload) {
+		select {
+		case disc <- p.Error:
+		default:
+		}
+	})
+
+	app := fiber.New()
+	app.Use(upgradeMiddleware)
+	app.Get("/", New(func(_ *Websocket) {}))
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = app.Listener(ln) }()
+	defer func() { _ = app.ShutdownWithTimeout(5 * time.Second) }()
+
+	dialer := &websocket.Dialer{HandshakeTimeout: 5 * time.Second}
+	conn, _, err := dialer.Dial("ws://"+ln.Addr().String()+"/", nil)
+	require.NoError(t, err)
+	defer conn.Close()
+	require.NoError(t, sioHandshake(t, conn))
+	kws := awaitSession(t, kwsCh)
+
+	// Never read again. 64 KiB frames fill the kernel buffers, then the
+	// send goroutine blocks, then the queue overflows.
+	payload := bytes.Repeat([]byte("x"), 64<<10)
+	go func() {
+		for i := 0; i < 4000 && kws.IsAlive(); i++ {
+			kws.Emit(payload)
+		}
+	}()
+
+	select {
+	case err := <-disc:
+		require.ErrorIs(t, err, ErrSendQueueClosed)
+	case <-time.After(15 * time.Second):
+		t.Fatal("queue overflow never tore the session down")
+	}
+
+	start := time.Now()
+	waitClosed(t, kws, 10*time.Second)
+	require.Less(t, time.Since(start), 5*time.Second, "stalled write held the tear-down")
+}
+
+// TestSocketIOClientDisconnectPacketCompletesClosingHandshake verifies that
+// an inbound SIO DISCONNECT is answered with a Close frame, reported as a
+// clean disconnect, and followed by the socket being closed.
+func TestSocketIOClientDisconnectPacketCompletesClosingHandshake(t *testing.T) {
+	resetSIOGlobals(t)
+	kwsCh := captureConnect(t)
+	disc := make(chan error, 1)
+	On(EventDisconnect, func(p *EventPayload) {
+		select {
+		case disc <- p.Error:
+		default:
+		}
+	})
+
+	ln, teardown := newSIOTestServer(t, func(_ *Websocket) {})
+	defer teardown()
+
+	conn := dialSIO(t, ln)
+	defer conn.Close()
+	require.NoError(t, sioHandshake(t, conn))
+	kws := awaitSession(t, kwsCh)
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("41")))
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, _, err := sioReadSkipPings(conn)
+	require.Truef(t, websocket.IsCloseError(err, websocket.CloseNormalClosure),
+		"expected a Close frame after SIO DISCONNECT, got %v", err)
+
+	select {
+	case err := <-disc:
+		require.NoError(t, err, "a client SIO DISCONNECT is a clean close")
+	case <-time.After(2 * time.Second):
+		t.Fatal("EventDisconnect did not fire")
+	}
+	waitClosed(t, kws, 2*time.Second)
+
+	err = rawReadUntilError(conn, 2*time.Second)
+	require.Error(t, err)
+	require.False(t, isTimeout(err), "server did not close the socket: %v", err)
+}
+
+// TestSocketIOPeerCloseCauses checks the EventDisconnect cause for the two
+// ways a peer can go away: a Close frame with a normal code is clean, an
+// abrupt TCP close is an error.
+func TestSocketIOPeerCloseCauses(t *testing.T) {
+	resetSIOGlobals(t)
+	kwsCh := captureConnect(t)
+	disc := make(chan error, 2)
+	On(EventDisconnect, func(p *EventPayload) {
+		select {
+		case disc <- p.Error:
+		default:
+		}
+	})
+
+	ln, teardown := newSIOTestServer(t, func(_ *Websocket) {})
+	defer teardown()
+
+	polite := dialSIO(t, ln)
+	defer polite.Close()
+	require.NoError(t, sioHandshake(t, polite))
+	kwsPolite := awaitSession(t, kwsCh)
+
+	require.NoError(t, polite.WriteControl(websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseGoingAway, "bye"), time.Now().Add(time.Second)))
+	select {
+	case err := <-disc:
+		require.NoError(t, err, "a Close frame with code 1001 is a clean close")
+	case <-time.After(2 * time.Second):
+		t.Fatal("EventDisconnect did not fire for the Close frame")
+	}
+	waitClosed(t, kwsPolite, 2*time.Second)
+
+	abrupt := dialSIO(t, ln)
+	require.NoError(t, sioHandshake(t, abrupt))
+	kwsAbrupt := awaitSession(t, kwsCh)
+	_ = abrupt.Close() // closes the socket without a Close frame
+	select {
+	case err := <-disc:
+		require.Error(t, err, "an abrupt TCP close is reported as an error")
+	case <-time.After(2 * time.Second):
+		t.Fatal("EventDisconnect did not fire for the abrupt close")
+	}
+	waitClosed(t, kwsAbrupt, 2*time.Second)
+}
+
+// TestSocketIOEventPingControlFrame verifies that a WebSocket Ping control
+// frame reaches EventPing with its payload and is still answered with a
+// Pong. The library consumes control frames inside ReadMessage, so the
+// events only fire through the installed handlers.
+func TestSocketIOEventPingControlFrame(t *testing.T) {
+	resetSIOGlobals(t)
+	kwsCh := captureConnect(t)
+	pingCh := make(chan []byte, 1)
+	On(EventPing, func(p *EventPayload) {
+		select {
+		case pingCh <- p.Data:
+		default:
+		}
+	})
+
+	ln, teardown := newSIOTestServer(t, func(_ *Websocket) {})
+	defer teardown()
+
+	conn := dialSIO(t, ln)
+	defer conn.Close()
+	require.NoError(t, sioHandshake(t, conn))
+	_ = awaitSession(t, kwsCh)
+
+	pongCh := make(chan string, 1)
+	conn.SetPongHandler(func(data string) error {
+		select {
+		case pongCh <- data:
+		default:
+		}
+		return nil
+	})
+	// The pong handler runs inside ReadMessage; keep a reader parked.
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	go func() {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	require.NoError(t, conn.WriteControl(websocket.PingMessage, []byte("hello"), time.Now().Add(time.Second)))
+
+	select {
+	case data := <-pingCh:
+		require.Equal(t, "hello", string(data))
+	case <-time.After(2 * time.Second):
+		t.Fatal("EventPing did not fire for a Ping control frame")
+	}
+	select {
+	case data := <-pongCh:
+		require.Equal(t, "hello", data)
+	case <-time.After(2 * time.Second):
+		t.Fatal("no Pong answered the Ping")
+	}
+}
+
+// TestSocketIOLateConnectOtherNamespaceRejected verifies that a CONNECT for
+// a second namespace on an established connection is answered with
+// CONNECT_ERROR rather than acknowledged into a namespace whose events
+// would all be dropped, while a repeated CONNECT for the bound namespace is
+// acknowledged again.
+func TestSocketIOLateConnectOtherNamespaceRejected(t *testing.T) {
+	resetSIOGlobals(t)
+	kwsCh := captureConnect(t)
+
+	ln, teardown := newSIOTestServer(t, func(_ *Websocket) {})
+	defer teardown()
+
+	conn := dialSIO(t, ln)
+	defer conn.Close()
+	require.NoError(t, sioHandshake(t, conn))
+	kws := awaitSession(t, kwsCh)
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("40/admin,")))
+	_, msg, err := sioReadSkipPings(conn)
+	require.NoError(t, err)
+	require.Equal(t, `44/admin,{"message":"Invalid namespace"}`, string(msg))
+	require.True(t, kws.IsAlive(), "a rejected late CONNECT must not end the connection")
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("40")))
+	_, msg, err = sioReadSkipPings(conn)
+	require.NoError(t, err)
+	require.Equal(t, `40{"sid":"`+kws.GetUUID()+`"}`, string(msg))
+}
+
+// TestSocketIOBroadcastAcrossNamespaces verifies that a broadcast builds the
+// right frame for each namespace while sharing it between recipients.
+func TestSocketIOBroadcastAcrossNamespaces(t *testing.T) {
+	resetSIOGlobals(t)
+	kwsCh := captureConnect(t)
+
+	ln, teardown := newSIOTestServer(t, func(_ *Websocket) {})
+	defer teardown()
+
+	root1 := dialSIO(t, ln)
+	defer root1.Close()
+	require.NoError(t, sioHandshake(t, root1))
+	awaitSession(t, kwsCh)
+	root2 := dialSIO(t, ln)
+	defer root2.Close()
+	require.NoError(t, sioHandshake(t, root2))
+	awaitSession(t, kwsCh)
+
+	admin := dialSIO(t, ln)
+	defer admin.Close()
+	_, _, err := admin.ReadMessage() // EIO OPEN
+	require.NoError(t, err)
+	require.NoError(t, admin.WriteMessage(websocket.TextMessage, []byte("40/admin,")))
+	_, msg, err := admin.ReadMessage()
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(string(msg), "40/admin,"), "got %q", msg)
+	awaitSession(t, kwsCh)
+
+	Broadcast([]byte(`"hi"`))
+
+	for _, c := range []*websocket.Conn{root1, root2} {
+		_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, msg, err := sioReadSkipPings(c)
+		require.NoError(t, err)
+		require.Equal(t, `42["message","hi"]`, string(msg))
+	}
+	_ = admin.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err = sioReadSkipPings(admin)
+	require.NoError(t, err)
+	require.Equal(t, `42/admin,["message","hi"]`, string(msg))
+}
+
+// TestSocketIOEventCloseListenerEmitsBeforeDisconnect verifies that frames
+// emitted from an EventClose listener are delivered ahead of the SIO
+// DISCONNECT packet: the closing frames are queued after the listener ran.
+func TestSocketIOEventCloseListenerEmitsBeforeDisconnect(t *testing.T) {
+	resetSIOGlobals(t)
+	kwsCh := captureConnect(t)
+	On(EventClose, func(p *EventPayload) {
+		p.Kws.EmitEvent("bye", []byte(`"now"`))
+	})
+
+	ln, teardown := newSIOTestServer(t, func(_ *Websocket) {})
+	defer teardown()
+
+	conn := dialSIO(t, ln)
+	defer conn.Close()
+	require.NoError(t, sioHandshake(t, conn))
+	kws := awaitSession(t, kwsCh)
+
+	go kws.Close()
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err := sioReadSkipPings(conn)
+	require.NoError(t, err)
+	require.Equal(t, `42["bye","now"]`, string(msg))
+	_, msg, err = sioReadSkipPings(conn)
+	require.NoError(t, err)
+	require.Equal(t, "41", string(msg))
+}
+
+// TestSocketIOHandshakeRejectionDeliversConnectError verifies that a
+// rejected CONNECT still gets its CONNECT_ERROR through before the socket
+// is closed, with a Close frame in between.
+func TestSocketIOHandshakeRejectionDeliversConnectError(t *testing.T) {
+	resetSIOGlobals(t)
+	prev := CloseTimeout
+	CloseTimeout = 500 * time.Millisecond
+	defer func() { CloseTimeout = prev }()
+
+	ln, teardown := newSIOTestServer(t, func(_ *Websocket) {})
+	defer teardown()
+
+	conn := dialSIO(t, ln)
+	defer conn.Close()
+	_, _, err := conn.ReadMessage() // EIO OPEN
+	require.NoError(t, err)
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`40["not","an","object"]`)))
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, `44{"message":"Invalid auth payload"}`, string(msg))
+	_, _, err = conn.ReadMessage()
+	require.Truef(t, websocket.IsCloseError(err, websocket.ClosePolicyViolation),
+		"expected Close frame with code 1008, got %v", err)
+
+	err = rawReadUntilError(conn, 2*time.Second)
+	require.Error(t, err)
+	require.False(t, isTimeout(err), "server did not close the socket: %v", err)
+}
+
+// TestSocketIOPollingSessionReleasesOnDisconnect verifies that a polling
+// session, which owns no goroutine, still signals its release.
+func TestSocketIOPollingSessionReleasesOnDisconnect(t *testing.T) {
+	resetSIOGlobals(t)
+	kwsCh := captureConnect(t)
+
+	_, c, td := newPollingTestServer(t, func(_ *Websocket) {})
+	defer td()
+
+	sid, _, _ := pollOpen(t, c)
+	_, _ = pollPost(t, c, sid, []byte(`40`))
+	kws := awaitSession(t, kwsCh)
+	require.True(t, kws.IsPolling())
+
+	kws.Close()
+	waitClosed(t, kws, 2*time.Second)
+}
+
+// ---------------------------------------------------------------------------
+// codec
+// ---------------------------------------------------------------------------
+
+func TestSplitJSONArray(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+		err  bool
+	}{
+		{in: `["ev"]`, want: []string{`"ev"`}},
+		{in: `[]`, want: nil},
+		{in: ` [ ] `, want: nil},
+		{in: `["ev",{"a":[1,2]},[3,4],"x,y]"]`, want: []string{`"ev"`, `{"a":[1,2]}`, `[3,4]`, `"x,y]"`}},
+		{in: " [ \"ev\" , 1 ,\t\"a\\\"b\" ]\n", want: []string{`"ev"`, `1`, `"a\"b"`}},
+		{in: `["a\\",1]`, want: []string{`"a\\"`, `1`}},
+		{in: `["[","{","}",","]`, want: []string{`"["`, `"{"`, `"}"`, `","`}},
+		{in: `[null,true,false,-1.5e3,"é"]`, want: []string{`null`, `true`, `false`, `-1.5e3`, `"é"`}},
+		{in: `[{"deep":{"deeper":[{"x":"]"}]}}]`, want: []string{`{"deep":{"deeper":[{"x":"]"}]}}`}},
+		{in: `{"a":1}`, err: true},
+		{in: `["a"`, err: true},
+		{in: `["a",]`, err: true},
+		{in: `[,]`, err: true},
+		{in: `not json`, err: true},
+		{in: ``, err: true},
+		{in: `"str"`, err: true},
+	}
+	for _, tc := range cases {
+		got, err := splitJSONArray([]byte(tc.in), nil)
+		if tc.err {
+			require.Errorf(t, err, "input %q", tc.in)
+			continue
+		}
+		require.NoErrorf(t, err, "input %q", tc.in)
+		require.Lenf(t, got, len(tc.want), "input %q: %q", tc.in, got)
+		for i := range tc.want {
+			require.Equalf(t, tc.want[i], string(got[i]), "input %q element %d", tc.in, i)
+		}
+	}
+}
+
+// TestParseSIOEventAliasesPayload pins the zero-copy contract: arguments
+// are sub-slices of the frame, whose buffer belongs to the connection.
+func TestParseSIOEventAliasesPayload(t *testing.T) {
+	payload := []byte(`["ev",{"k":1},2]`)
+	name, args, err := parseSIOEvent(payload)
+	require.NoError(t, err)
+	require.Equal(t, "ev", name)
+	require.Len(t, args, 2)
+	off := bytes.Index(payload, []byte(`{"k":1}`))
+	require.Same(t, &payload[off], &args[0][0], "args must alias the payload, not copy it")
+	require.Equal(t, len(args[0]), cap(args[0]), "capacity must be clipped so appends cannot clobber the next argument")
+}
+
+func TestParseSIOEventNames(t *testing.T) {
+	name, args, err := parseSIOEvent([]byte(`["a\"bé",1]`))
+	require.NoError(t, err)
+	require.Equal(t, "a\"bé", name)
+	require.Len(t, args, 1)
+
+	_, _, err = parseSIOEvent([]byte(`[1,2]`))
+	require.ErrorIs(t, err, errEventNameNotString)
+
+	_, _, err = parseSIOEvent([]byte(`[]`))
+	require.ErrorIs(t, err, ErrEmptyEventArray)
+
+	_, _, err = parseSIOEvent([]byte(`{"ev":1}`))
+	require.ErrorIs(t, err, errNotJSONArray)
+	require.Contains(t, err.Error(), "failed to parse event payload")
+}
+
+func TestParseSIOAckArgs(t *testing.T) {
+	args, err := parseSIOAckArgs([]byte(`[]`))
+	require.NoError(t, err)
+	require.Nil(t, args)
+	args, err = parseSIOAckArgs([]byte(`[[1,2]]`))
+	require.NoError(t, err)
+	require.Equal(t, [][]byte{[]byte(`[1,2]`)}, args)
+	args, err = parseSIOAckArgs([]byte(`[1,2]`))
+	require.NoError(t, err)
+	require.Equal(t, [][]byte{[]byte(`1`), []byte(`2`)}, args)
+	_, err = parseSIOAckArgs([]byte(`1`))
+	require.Error(t, err)
+}
+
+// TestBuildSIOEventEncodesLikeEncodingJSON pins the SWAR JSON string
+// encoder to encoding/json's output for event names and raw-text arguments.
+func TestBuildSIOEventEncodesLikeEncodingJSON(t *testing.T) {
+	for _, name := range []string{"plain", `q"uote`, "<tag>&", "ünï", "\x00ctl\t", "\xff invalid", "  sep", "back\\slash"} {
+		want, err := json.Marshal(name)
+		require.NoError(t, err)
+		require.Equal(t, `42[`+string(want)+`]`, string(buildSIOEvent(nil, name, nil)), "name %q", name)
+		require.Equal(t, `42["e",`+string(want)+`]`, string(buildSIOEvent(nil, "e", []byte(name))), "raw arg %q", name)
+	}
+	// Valid JSON passes through untouched.
+	require.Equal(t, `42/ns,["e",{"a":1},[2],"s",3]`,
+		string(buildSIOEventWithAck([]byte("/ns"), 0, false, "e", [][]byte{[]byte(`{"a":1}`), nil, []byte(`[2]`), []byte(`"s"`), []byte(`3`)})))
+	require.Equal(t, `427["e"]`, string(buildSIOEventWithAck(nil, 7, true, "e", nil)))
+}
+
+func TestBuildEIOOpenFrameDecodes(t *testing.T) {
+	frame, err := buildEIOOpenFrame(`s"id`)
+	require.NoError(t, err)
+	require.Equal(t, byte(eioOpen), frame[0])
+	var open eioOpenPacket
+	require.NoError(t, json.Unmarshal(frame[1:], &open))
+	require.Equal(t, `s"id`, open.SID)
+	require.NotNil(t, open.Upgrades)
+	require.Empty(t, open.Upgrades)
+	require.Equal(t, int(PingInterval.Milliseconds()), open.PingInterval)
+	require.Equal(t, int(PingTimeout.Milliseconds()), open.PingTimeout)
+	require.Equal(t, int(MaxPayload), open.MaxPayload)
+}
+
+func TestBuildSIOConnectFrames(t *testing.T) {
+	require.Equal(t, `40{"sid":"abc"}`, string(buildSIOConnectAckSID(nil, "abc")))
+	require.Equal(t, `40/admin,{"sid":"a\"b"}`, string(buildSIOConnectAckSID([]byte("/admin"), `a"b`)))
+	require.Equal(t, `44/admin,{"message":"x"}`, string(buildSIOConnectError([]byte("/admin"), `{"message":"x"}`)))
+	require.Equal(t, `41`, string(buildSIODisconnect(nil)))
+	require.Equal(t, `41/admin,`, string(buildSIODisconnect([]byte("/admin"))))
+}
+
+func TestIsValidNamespaceTable(t *testing.T) {
+	long := "/" + strings.Repeat("abcDEF019_-./", 8)
+	for _, ok := range []string{"", "/", "/a", "/a-b.c_d/e", long} {
+		require.Truef(t, isValidNamespace([]byte(ok)), "%q should be valid", ok)
+	}
+	for _, bad := range []string{"admin", "/a b", "/ab,c", "/ünï", "/a\"b", long + " ", "/" + strings.Repeat("a", 40) + "," + strings.Repeat("b", 40)} {
+		require.Falsef(t, isValidNamespace([]byte(bad)), "%q should be invalid", bad)
+	}
+}
+
+func TestBroadcastFramesCache(t *testing.T) {
+	var c broadcastFrames
+	msg := []byte(`"m"`)
+	root := c.frame(nil, msg)
+	require.Equal(t, `42["message","m"]`, string(root))
+	require.Same(t, &root[0], &c.frame(nil, msg)[0], "root frame must be built once")
+	admin := c.frame([]byte("/admin"), msg)
+	require.Equal(t, `42/admin,["message","m"]`, string(admin))
+	require.Same(t, &admin[0], &c.frame([]byte("/admin"), msg)[0], "namespace frame must be built once")
+	require.NotSame(t, &root[0], &admin[0])
+}

--- a/v3/socketio/socketio_lifecycle_test.go
+++ b/v3/socketio/socketio_lifecycle_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"net"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -133,6 +135,72 @@ func TestSocketIOCloseTimeoutClosesUnresponsivePeer(t *testing.T) {
 	err := rawReadUntilError(conn, 2*time.Second)
 	require.Error(t, err)
 	require.False(t, isTimeout(err), "server did not close the socket: %v", err)
+}
+
+// TestSocketIOCloseWithSaturatedQueueUsesOneBudget verifies that Close on a
+// session whose send queue is saturated behind a peer that stopped reading
+// releases the socket after one CloseTimeout: the wait for a queue slot,
+// the closing-handshake deadline and the wait for the stalled writer share
+// a single budget instead of each starting their own. It runs over a real
+// TCP socket, like TestSocketIOStalledPeerDoesNotWedgeTeardown: the send
+// goroutine really blocks inside a write once the kernel buffers are full,
+// and closing the socket is what returns it.
+func TestSocketIOCloseWithSaturatedQueueUsesOneBudget(t *testing.T) {
+	resetSIOGlobals(t)
+	prevClose, prevDrop, prevSize := CloseTimeout, DropFramesOnOverflow, SendQueueSize
+	CloseTimeout = 400 * time.Millisecond
+	DropFramesOnOverflow = true
+	SendQueueSize = 4
+	defer func() { CloseTimeout, DropFramesOnOverflow, SendQueueSize = prevClose, prevDrop, prevSize }()
+
+	kwsCh := captureConnect(t)
+	var drops atomic.Int64
+	On(EventError, func(p *EventPayload) {
+		if errors.Is(p.Error, ErrSendQueueOverflow) {
+			drops.Add(1)
+		}
+	})
+
+	app := fiber.New()
+	app.Use(upgradeMiddleware)
+	app.Get("/", New(func(_ *Websocket) {}))
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = app.Listener(ln) }()
+	defer func() { _ = app.ShutdownWithTimeout(5 * time.Second) }()
+
+	dialer := &websocket.Dialer{HandshakeTimeout: 5 * time.Second}
+	conn, _, err := dialer.Dial("ws://"+ln.Addr().String()+"/", nil)
+	require.NoError(t, err)
+	defer conn.Close()
+	require.NoError(t, sioHandshake(t, conn))
+	kws := awaitSession(t, kwsCh)
+
+	// Never read again. 64 KiB frames fill the kernel buffers, then the
+	// send goroutine blocks and the queue stays full; the overflow policy
+	// drops the rest rather than tearing the session down, so Close finds
+	// a saturated queue behind a stalled writer.
+	payload := bytes.Repeat([]byte("x"), 64<<10)
+	var flood sync.WaitGroup
+	flood.Add(1)
+	go func() {
+		defer flood.Done()
+		for kws.IsAlive() {
+			kws.Emit(payload)
+		}
+	}()
+	// Joined before the deferred restore of the tunables the flood reads.
+	defer flood.Wait()
+	require.Eventually(t, func() bool {
+		return len(kws.queue) == cap(kws.queue) && drops.Load() >= 32
+	}, 15*time.Second, time.Millisecond)
+
+	start := time.Now()
+	kws.Close()
+	waitClosed(t, kws, 10*time.Second)
+	elapsed := time.Since(start)
+	require.GreaterOrEqual(t, elapsed, CloseTimeout, "Close gave up on a queue slot before CloseTimeout")
+	require.Less(t, elapsed, 700*time.Millisecond, "the tear-down spent more than one CloseTimeout budget")
 }
 
 // TestSocketIOStalledPeerDoesNotWedgeTeardown floods a peer that stopped

--- a/v3/socketio/socketio_protocol_iter2_test.go
+++ b/v3/socketio/socketio_protocol_iter2_test.go
@@ -467,7 +467,7 @@ func TestSocketIOEIO3Rejected(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	go func() { _ = app.Listener(ln) }()
-	defer func() { _ = app.Shutdown() }()
+	defer func() { _ = app.ShutdownWithTimeout(5 * time.Second) }()
 
 	httpClient := &http.Client{Timeout: 5 * time.Second}
 	resp, err := httpClient.Get("http://" + ln.Addr().String() + "/?EIO=3")

--- a/v3/socketio/socketio_test.go
+++ b/v3/socketio/socketio_test.go
@@ -443,8 +443,15 @@ func upgradeMiddleware(c fiber.Ctx) error {
 func resetSIOGlobals(t *testing.T) {
 	t.Helper()
 	pool.reset()
+	resetDraining()
 	listeners.reset()
 	t.Cleanup(func() {
+		// Snapshot the pool and the draining set before touching any
+		// global: every session took those locks after reading the
+		// tunables it captured, so the snapshots order the write below
+		// after those reads for the race detector.
+		sessions := pool.all()
+		inFlight := drainingSessions()
 		// Close every still-pooled connection so its goroutines exit
 		// before the next test snapshots them. Raw test clients rarely
 		// answer the Close frame, so shorten the closing-handshake
@@ -452,7 +459,6 @@ func resetSIOGlobals(t *testing.T) {
 		prevClose := CloseTimeout
 		CloseTimeout = 200 * time.Millisecond
 		defer func() { CloseTimeout = prevClose }()
-		sessions := pool.all()
 		for _, w := range sessions {
 			if k, ok := w.(*Websocket); ok {
 				func() {
@@ -480,7 +486,17 @@ func resetSIOGlobals(t *testing.T) {
 				t.Errorf("resetSIOGlobals: session %s did not release within 5s; goroutine leak suspected", k.UUID)
 			}
 		}
+		// Sessions already closed but still draining their closing
+		// handshake finish as soon as the test's client went away.
+		for _, k := range inFlight {
+			select {
+			case <-k.closed:
+			case <-time.After(5 * time.Second):
+				t.Errorf("resetSIOGlobals: draining session %s did not release within 5s", k.UUID)
+			}
+		}
 		pool.reset()
+		resetDraining()
 		listeners.reset()
 	})
 }

--- a/v3/socketio/socketio_test.go
+++ b/v3/socketio/socketio_test.go
@@ -123,7 +123,7 @@ func TestParallelConnections(t *testing.T) {
 	wg := sync.WaitGroup{}
 
 	defer func() {
-		_ = app.Shutdown()
+		_ = app.ShutdownWithTimeout(5 * time.Second)
 		_ = ln.Close()
 	}()
 
@@ -445,8 +445,13 @@ func resetSIOGlobals(t *testing.T) {
 	pool.reset()
 	listeners.reset()
 	t.Cleanup(func() {
-		// Close every still-pooled connection so its read/send/pong
-		// goroutines exit before the next test snapshots them.
+		// Close every still-pooled connection so its goroutines exit
+		// before the next test snapshots them. Raw test clients rarely
+		// answer the Close frame, so shorten the closing-handshake
+		// drain for the leftovers rather than wait CloseTimeout each.
+		prevClose := CloseTimeout
+		CloseTimeout = 200 * time.Millisecond
+		defer func() { CloseTimeout = prevClose }()
 		sessions := pool.all()
 		for _, w := range sessions {
 			if k, ok := w.(*Websocket); ok {
@@ -456,34 +461,39 @@ func resetSIOGlobals(t *testing.T) {
 				}()
 			}
 		}
-		// Wait on workersWg per session so the goroutines have
-		// actually exited before the next test starts. Establishes
-		// happen-before from the previous test's goroutine reads (e.g.
-		// pong reading PingInterval/PingTimeout) to any mutation the
-		// next test performs on package-level tunables; without this,
-		// -race flags cross-test reads vs writes. Each Wait is bounded
+		// Wait for each session to release its socket and goroutines
+		// before the next test starts. Establishes happen-before from
+		// the previous test's goroutine reads (e.g. the heartbeat
+		// reading PingInterval/PingTimeout) to any mutation the next
+		// test performs on package-level tunables; without this,
+		// -race flags cross-test reads vs writes. Each wait is bounded
 		// so a leaked goroutine surfaces as a test failure rather
 		// than hanging the whole suite.
 		for _, w := range sessions {
 			k, ok := w.(*Websocket)
-			if !ok {
+			if !ok || k.closed == nil {
 				continue
 			}
-			done := make(chan struct{})
-			go func() {
-				defer func() { _ = recover() }()
-				defer close(done)
-				k.workersWg.Wait()
-			}()
 			select {
-			case <-done:
+			case <-k.closed:
 			case <-time.After(5 * time.Second):
-				t.Errorf("resetSIOGlobals: workersWg.Wait timed out for session %s; goroutine leak suspected", k.UUID)
+				t.Errorf("resetSIOGlobals: session %s did not release within 5s; goroutine leak suspected", k.UUID)
 			}
 		}
 		pool.reset()
 		listeners.reset()
 	})
+}
+
+// waitClosed blocks until kws has released its socket and goroutines, or
+// fails the test after timeout.
+func waitClosed(t *testing.T, kws *Websocket, timeout time.Duration) {
+	t.Helper()
+	select {
+	case <-kws.closed:
+	case <-time.After(timeout):
+		t.Fatalf("session %s did not release within %v", kws.UUID, timeout)
+	}
 }
 
 //
@@ -557,6 +567,16 @@ func (s *WebsocketMock) fireEvent(_ string, _ []byte, _ error) {
 // ---------------------------------------------------------------------------
 // Socket.IO test helpers
 // ---------------------------------------------------------------------------
+
+// eioOpenPacket mirrors the JSON payload of the Engine.IO OPEN packet so
+// tests can decode what the server put on the wire.
+type eioOpenPacket struct {
+	SID          string   `json:"sid"`
+	Upgrades     []string `json:"upgrades"`
+	PingInterval int      `json:"pingInterval"`
+	PingTimeout  int      `json:"pingTimeout"`
+	MaxPayload   int      `json:"maxPayload"`
+}
 
 // sioHandshake performs the Engine.IO / Socket.IO connection handshake:
 //
@@ -648,7 +668,7 @@ func newSIOTestServer(t *testing.T, callback func(*Websocket)) (*fasthttputil.In
 	go func() { _ = app.Listener(ln) }()
 
 	return ln, func() {
-		_ = app.Shutdown()
+		_ = app.ShutdownWithTimeout(5 * time.Second)
 		_ = ln.Close()
 	}
 }
@@ -877,8 +897,8 @@ func TestSocketIODisconnect(t *testing.T) {
 // client triggers an EventPong on the server when the client replies.
 //
 // We intentionally do NOT mutate the global PingInterval here: that races
-// with previously-spawned pong goroutines reading the same global. Instead,
-// we drive a single PING manually from the server side via kws.write.
+// with heartbeats of earlier sessions reading the same global. Instead, we
+// drive a single PING manually from the server side via kws.write.
 func TestSocketIOHeartbeat(t *testing.T) {
 	resetSIOGlobals(t)
 
@@ -1858,7 +1878,7 @@ func TestSocketIOPackageShutdown(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	go func() { _ = app.Listener(ln) }()
-	defer func() { _ = app.Shutdown() }()
+	defer func() { _ = app.ShutdownWithTimeout(5 * time.Second) }()
 
 	const n = 5
 	conns := make([]*websocket.Conn, 0, n)
@@ -1875,6 +1895,16 @@ func TestSocketIOPackageShutdown(t *testing.T) {
 		require.NoError(t, derr)
 		require.NoError(t, sioHandshake(t, c))
 		conns = append(conns, c)
+		// Keep reading, as a real client does: the library answers the
+		// server's Close frame from inside ReadMessage, which is what
+		// lets the closing handshake complete.
+		go func(c *websocket.Conn) {
+			for {
+				if _, _, err := c.ReadMessage(); err != nil {
+					return
+				}
+			}
+		}(c)
 	}
 
 	// Wait until every handshake has fired EventConnect.
@@ -1885,7 +1915,10 @@ func TestSocketIOPackageShutdown(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	start := time.Now()
 	require.NoError(t, Shutdown(ctx))
+	require.Less(t, time.Since(start), 2*time.Second,
+		"Shutdown should complete as soon as the peers answer the Close frame")
 
 	// Each connection produced exactly one EventDisconnect.
 	require.Eventually(t, func() bool {
@@ -2098,7 +2131,7 @@ func TestSocketIONoGoroutineLeak(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	go func() { _ = app.Listener(ln) }()
-	defer func() { _ = app.Shutdown() }()
+	defer func() { _ = app.ShutdownWithTimeout(5 * time.Second) }()
 
 	wsURL := "ws://" + ln.Addr().String() + "/"
 
@@ -2651,16 +2684,10 @@ func TestSocketIOOnAfterFireDoesNotAffectInflight(t *testing.T) {
 //
 // Run under -race to surface any latent data race.
 func TestSocketIOConcurrentEmitClose(t *testing.T) {
-	// Iteration-2 race fixed in socketio.go:
-	//   - Close() now gates its kws.mu-protected write block behind a
-	//     dedicated closeOnce so concurrent callers cannot double-write.
-	//   - run() now performs a kws.mu.Lock()/Unlock() barrier after
-	//     workersWg.Wait() so any in-flight Close() writer has finished
-	//     before the upgrade handler returns and the vendored websocket
-	//     package's deferred releaseConn() nils the embedded *fasthttp.Conn.
-	//   - Close() skips direct Conn writes once handlerDone marks that the
-	//     upgrade handler is returning and releaseConn may nil the embedded
-	//     *fasthttp.Conn without taking kws.mu.
+	// Close() never writes to the socket itself: it queues the closing
+	// frames behind the pending emits and the send goroutine, the sole
+	// writer, puts them on the wire, so concurrent Close/Emit callers
+	// cannot interleave frames or race the socket's release.
 	resetSIOGlobals(t)
 
 	// Stable connect listener: stash kws handles as connections come in.
@@ -2682,7 +2709,7 @@ func TestSocketIOConcurrentEmitClose(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	go func() { _ = app.Listener(ln) }()
-	defer func() { _ = app.Shutdown() }()
+	defer func() { _ = app.ShutdownWithTimeout(5 * time.Second) }()
 
 	const numConns = 50
 	wsURL := "ws://" + ln.Addr().String() + "/"
@@ -2842,7 +2869,7 @@ func TestSocketIOEmitToVanishedConn(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	go func() { _ = app.Listener(ln) }()
-	defer func() { _ = app.Shutdown() }()
+	defer func() { _ = app.ShutdownWithTimeout(5 * time.Second) }()
 
 	wsURL := "ws://" + ln.Addr().String() + "/"
 	dialer := &websocket.Dialer{HandshakeTimeout: 5 * time.Second}


### PR DESCRIPTION
# Description

An audit of the socketio middleware for correctness, Engine.IO v4 / Socket.IO v5 compliance and performance, plus the root cause of the flaky `Test Socket.io` workflow. The module now builds on websocket middleware v1.2.6 (coalesced writes, pooled `ReadMessage` that hands over an owned buffer, one `Conn` per upgrade) and on `gofiber/utils/v2` for its SIMD/SWAR helpers.

## Improvements and fixes

### Connection lifecycle (bugs)

- **The socket was never closed.** Since the websocket middleware started leaving the hijacked socket open after the handler returns (`KeepHijackedConns`), nothing in socketio ever called `Close` on it. Every server-initiated `Close`, heartbeat timeout, queue overflow and handshake rejection leaked a file descriptor until the peer happened to close its side; a dead peer never does. Every tear-down now ends in `finishRun`, which closes the socket and signals a `closed` channel that `Shutdown` waits on.
- **A peer that stopped reading could wedge the tear-down forever.** The send goroutine blocked inside `WriteMessage` held the read lock that `Close` needed, and nothing closed the socket to return the write. `Close` no longer writes to the socket itself; it queues the closing frames and the send goroutine, the sole writer, puts them on the wire. The tear-down closes the socket once the writer is out of its write, bounded by `CloseTimeout`, which is what returns a stalled write. Covered by a test over a real TCP socket.
- **No closing handshake.** `Close` wrote `41` plus a Close frame and stopped reading, so any unread inbound byte turned the close into a TCP reset and `socket.io-client` reported `transport close` and auto-reconnected instead of `io server disconnect`. `Close` now queues SIO DISCONNECT and a Close frame *behind* the emits already pending (an `EventClose` listener can still send a last message), keeps reading, discarding frames, until the peer's Close frame or EOF, then closes the socket. New `CloseTimeout` (default 5s) bounds it. A client SIO DISCONNECT (`41`) and a rejected handshake (`44`) get the same treatment.
- **Stale guards for a released connection.** `hasConn`, `handlerDone`, the `kws.mu` write barrier and the send retry loop all defended against a websocket version that pooled and nil'd `Conn` after the handler returned; the middleware has allocated one `Conn` per upgrade since v1.2.x. They are gone. `RetrySendTimeout` and `MaxSendRetry` stay exported as deprecated no-ops.
- **Half the goroutines.** The read loop runs on the upgrade handler's goroutine (as the plain websocket middleware does) and the heartbeat is a runtime timer, so a WebSocket connection costs two goroutines instead of four and a polling session costs none instead of two. An idle read deadline of `PingInterval + PingTimeout`, refreshed at most every quarter of that, backs the heartbeat up and is what lets the tear-down wake a parked read on every `net.Conn` (fasthttp's in-memory `pipeConn` only fires a deadline set while one is already armed, which the old immediate-deadline unblock relied on and which never worked there).
- **Polling snapshot strings aliased the request buffer.** Fiber hands out unsafe strings unless `Immutable` is set; the query and param snapshot now copies them.

### Protocol compliance

- A peer Close frame with code 1000, 1001 or no code is a clean disconnect (`EventDisconnect` with a nil `Error`), matching the `websocket/event` package; before, every client close arrived as a `*CloseError` plus an `EventError`.
- `EventPing` and `EventPong` fire for RFC 6455 control frames through installed ping/pong handlers. The old checks for `PingMessage`/`PongMessage`/`CloseMessage` in the read loop were dead code: `NextReader` never returns control frames.
- A CONNECT for a *second* namespace on an established connection is answered with `44/<ns>,{"message":"Invalid namespace"}` instead of being acknowledged into a namespace whose every event the cross-namespace guard would drop; a repeated CONNECT for the bound namespace is acknowledged again.
- New `WriteTimeout` (default 0, disabled) bounds a single frame write; a peer that stops reading is otherwise only detected by the heartbeat.

### Performance

- **Inbound events and acks are parsed without copies.** `parseSIOEvent` used `json.Unmarshal` into `[]json.RawMessage` (reflection, one copy per element) and then copied everything again into a contiguous buffer, on top of the copy `ReadMessage` had already made. The payload is now validated once with `json.Valid` and split into sub-slices by a small structural scanner whose string bodies are skipped with `utils.IndexAny2` (AVX2 on amd64 for 32+ byte runs, SWAR otherwise). The frame buffer belongs to the connection on both transports, so listeners keep the same retention guarantee.
- **Outbound frames are built in one pre-sized allocation.** Event names and raw-text arguments go through `utils.AppendJSONString` (SWAR, byte-identical to `encoding/json`, HTML escaping included) instead of `json.Marshal`; the OPEN and CONNECT payloads are hand-built. The old builder's comment claimed pre-sizing that the code did not do.
- **Broadcast builds each namespace's frame once** and shares it read-only between recipients, and the pool caches its snapshot until membership changes instead of copying the map on every call.
- Lock-free namespace reads (`atomic.Pointer`), `maps.Clone` attribute snapshots (nil for a connection without attributes, as in `websocket/event`), `simd.MemchrNotWord` in the namespace validator, `utils.UUIDv4`.

### The flaky CI hang

The failed attempt of the latest `main` run ([job 102481924143](https://github.com/gofiber/contrib/actions/runs/34356355820/job/102481924143)) timed out after 10 minutes in `TestPollingGateReleasedBeforeBodyWrite`, inside the deferred `app.Shutdown()`. The goroutine dump shows one fasthttp worker parked in `RequestHeader.Read` on a connection that never sent a byte, and one `net/http` `persistConn` holding the other end. fasthttp marks a connection *active* before reading its first request, so `closeIdleConns` skips it and an unbounded `Shutdown` waits forever; `net/http`'s `Transport` produces exactly such a connection when two requests race for one (the dial that loses is parked, unused, in the idle pool). The polling test server now closes its client's idle connections before a shutdown with a timeout and runs with `ReadTimeout`/`IdleTimeout`; every other test server shutdown is bounded as well. The concurrent-GET test waits on the poll gate instead of sleeping 50 ms, and leftover sessions at test cleanup drain with a short `CloseTimeout`.

Fixes: no linked issue.

## Changes introduced

- [x] Benchmarks: `benchstat` over `go test -run '^$' -bench . -benchmem -count=6` on a 4 vCPU runner, before and after:

  | Benchmark | Before | After |
  |---|---|---|
  | Parse inbound event (name + 3 args) | 2.71 µs, 16 allocs | 0.75 µs, 2 allocs (-72%) |
  | Build outbound event, JSON argument | 716 ns, 5 allocs | 421 ns, 1 alloc (-41%) |
  | Build outbound event, raw-text argument | 1.13 µs, 12 allocs | 198 ns, 1 alloc (-82%) |
  | Round trip: emit, listener, reply (1 connection) | 15.9 µs, 24 allocs | 8.5 µs, 10 allocs (-47%) |
  | Broadcast to 1024 subscribers | 1.58 ms, 7192 allocs | 0.54 ms, 2009 allocs (-66%) |
  | Connect: handshake and close | 119 µs, 143 allocs | 140 µs, 155 allocs (+17%) |

  The connect path is the one regression. Building the *previous* socketio code against the new websocket dependency shows the same shift (129 µs, 157 allocs), so it comes from the middleware's upgrade now running through `net/http`'s upgrader on a fasthttp hijack, which is what enables the write coalescing behind the round-trip gain. `BenchmarkBroadcastFanout` was also fixed: it enqueued faster than 1024 clients could drain, the queues overflowed and tore the connections down, and the loop then broadcast to an empty pool; it now runs with `DropFramesOnOverflow` and fails if the pool shrank. New `BenchmarkParseSIOEvent` and `BenchmarkBuildSIOEvent`.
- [x] Documentation Update: `v3/socketio/README.md`: features (closing handshake, goroutine budget, zero-copy/SWAR codec, coalesced writes), the one-namespace limitation, the polling rate-limiting note, both tunables tables (`CloseTimeout`, `WriteTimeout`, the deprecations), the events and payload tables (`EventDisconnect` causes, `EventPing` payload, `EventClose` ordering, `SocketAttributes` nil when empty, `Data`/`Args` aliasing), and a new *Performance* section with the table above.
- [x] Changelog/What's New:
  - socketio: the socket is closed on every tear-down; a server-side `Close`, a heartbeat timeout or a queue overflow no longer leaks the connection, and a peer that stopped reading cannot wedge the tear-down.
  - socketio: `Close` performs the closing handshake (SIO DISCONNECT, Close frame, wait for the peer's Close frame bounded by the new `CloseTimeout`), so `socket.io-client` reports `io server disconnect` and does not reconnect.
  - socketio: two goroutines per WebSocket connection instead of four, none per polling session.
  - socketio: zero-copy inbound parsing and SWAR outbound encoding via `gofiber/utils/v2`; broadcasts build each namespace's frame once. Round trip 47% faster, broadcast to 1024 subscribers 66% faster.
  - socketio: `EventPing`/`EventPong` fire for WebSocket control frames; a peer Close frame with code 1000/1001/none is a clean disconnect; a CONNECT for a second namespace is answered with CONNECT_ERROR.
  - socketio: new `WriteTimeout`; `RetrySendTimeout` and `MaxSendRetry` are deprecated no-ops.
  - socketio: depends on `github.com/gofiber/contrib/v3/websocket` v1.2.6 (coalesced writes, pooled reads).
- [x] Migration Guide: no code changes needed. Behavioural differences to be aware of: `Close` still marks the session dead and fires `EventClose`/`EventDisconnect` synchronously, but the frames are now written by the send goroutine right after and the socket closes once the peer answers (or after `CloseTimeout`); `EventDisconnect.Error` is nil for a peer Close frame with code 1000/1001/none where it used to carry a `*websocket.CloseError`; `EventPayload.SocketAttributes` is nil for a connection without attributes (reads are safe, writes into it were pointless); a client `41` is now answered with a Close frame; a late CONNECT for another namespace gets `44` instead of `40`; setting `RetrySendTimeout`/`MaxSendRetry` has no effect.
- [ ] API Alignment with Express: not applicable.
- [x] API Longevity: additive only. `CloseTimeout` and `WriteTimeout` are new package-level tunables in the existing style; nothing exported was removed or re-signed, and the deprecated knobs stay exported.
- [x] Examples: `go test -run '^$' -bench . -benchmem` in `v3/socketio` runs the whole set; `-bench 'ParseSIOEvent|BuildSIOEvent'` isolates the codec. `example/auth-and-ack` builds unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improvement to existing features and functionality)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)
- [x] Documentation update (changes to documentation)

## Checklist

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage. (Not applicable: no new API surface beyond two tunables.)
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation in the module README (this repository has no `/docs/` directory).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features: `socketio_lifecycle_test.go` covers socket release after `Close`, the `CloseTimeout` bound against an unresponsive peer, a stalled writer over real TCP, the client `41` handshake, close-frame causes, control-frame events, the late CONNECT answer, cross-namespace broadcast, `EventClose` ordering, CONNECT_ERROR delivery on a rejected handshake, polling session release, the splitter and the builders; `FuzzSplitJSONArray` cross-checks the splitter against `encoding/json`.
- [x] Ensured that new and existing unit tests pass locally with the changes (`go test -race ./...` in `v3/socketio`, plus three shuffled repeat runs, one at `GOMAXPROCS=2`; `golangci-lint` v2.13.2 with the repo config reports no issues).
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community. (`github.com/gofiber/utils/v2` moves from indirect to direct; it was already in the graph through fiber and the websocket middleware. `github.com/google/uuid` stays as a test dependency.)
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [x] Provided benchmarks for the new code to analyze and improve upon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MminBRUC4DQS6ss59t7Z4V

---
_Generated by [Claude Code](https://claude.ai/code/session_01MminBRUC4DQS6ss59t7Z4V)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable close and write timeouts for Socket.IO connections.
  - Added limits for inbound event and acknowledgment arguments.
  - Improved orderly disconnect handshakes, bounded shutdown, peer-close handling, and namespace error responses.
  - Ensured terminal polling packets are delivered even when queues are full.

- **Performance**
  - Reduced overhead through zero-copy event processing and write coalescing.
  - Improved broadcast efficiency through frame reuse.

- **Deprecations**
  - Retry-send and read timeout settings are deprecated and have no effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->