### PR TITLE
feat(uptime): add service insights and availability trend

### DIFF
--- a/v3/uptime/README.md
+++ b/v3/uptime/README.md
@@ -219,6 +219,38 @@ turn every request into another attempt against the unavailable store.
 The same snapshot payload is available at `UI.Path + "/api/status"` for custom
 dashboards.
 
+## Service insights
+
+Each service card has an **Insights** button, collapsed by default. Expanding
+it shows four metrics and a daily availability trend for the same `DaysToShow`
+window as the existing uptime bars:
+
+- **Availability**: total up slots divided by total expected slots across valid
+  days, rather than an average of daily percentages.
+- **Downtime**: the sum of the daily estimated downtime.
+- **Affected days**: valid days with at least one missed expected slot.
+- **Stable streak**: consecutive perfect days backward from the newest valid
+  day, including today when every completed expected slot so far is up. Newest
+  no-data days are skipped; an internal no-data gap or imperfect day stops the
+  streak. `N+ days` means it reaches the window boundary and the service existed
+  before that window, so the streak may be longer.
+
+Days without data or expected slots do not contribute to the metrics and are
+not treated as downtime. With no valid days, all four metrics display `—`, and
+the trend displays `No data`. Missing days create gaps in the trend.
+
+Expanded cards stay expanded across automatic refreshes; reloading the page
+collapses them again. Charts are rendered only while expanded. The trend uses
+native SVG and Vanilla JavaScript, with zero additional dependencies, storage
+queries, or persistent data. Existing daily bars remain keyboard accessible.
+
+Each service in the status JSON also includes a `summary` object with
+`has_data`, `availability_rate`, `estimated_downtime_seconds`, `affected_days`,
+`stable_streak_days`, and `stable_streak_capped`. When `has_data` is false, the
+numeric fields are zero and `stable_streak_capped` is false; clients should
+display no data rather than 0% availability. These metrics add no latency,
+incident, or alerting semantics and require no new configuration.
+
 ## Dashboard favicon
 
 The built-in dashboard includes an embedded favicon by default. Set

--- a/v3/uptime/dashboard.gohtml
+++ b/v3/uptime/dashboard.gohtml
@@ -380,6 +380,104 @@ button:hover:not(.bar) {
 .bar.gray.is-active {
   background-color: rgb(var(--none-rgb) / 0.52);
 }
+.insights-control {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+  border-top: 1px solid var(--border);
+  padding-top: 6px;
+  margin-top: -6px;
+}
+.insights-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  padding: 4px 8px;
+  border-color: transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+.insights-toggle:after {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-right: 1px solid currentColor;
+  border-bottom: 1px solid currentColor;
+  transform: rotate(45deg);
+}
+.insights-toggle[aria-expanded="true"]:after { transform: rotate(225deg); }
+.insights-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.service-insights {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+  gap: 24px;
+  align-items: center;
+  min-width: 0;
+}
+.service-insights[hidden] { display: none; }
+.insights-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  margin: 0;
+  background: var(--border);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.insights-metric {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 12px;
+  background: var(--bg);
+  overflow-wrap: anywhere;
+}
+.insights-metric dt { color: var(--muted); font-size: 0.78rem; }
+.insights-metric dd {
+  order: -1;
+  margin: 0 0 3px;
+  font-size: clamp(1.1rem, 2vw, 1.45rem);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.insights-trend { min-width: 0; margin: 0; }
+.insights-trend figcaption { color: var(--muted); font-size: 0.8rem; margin-bottom: 12px; }
+.trend-plot { display: grid; grid-template-columns: 40px minmax(0, 1fr); }
+.trend-axis {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 2px 0;
+  color: var(--muted);
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+}
+.trend-svg { display: block; width: 100%; height: 128px; overflow: visible; }
+.trend-grid, .trend-guide { stroke: var(--border); stroke-width: 1; }
+.trend-guide { stroke-dasharray: 3 3; }
+.trend-path {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.trend-point { fill: var(--accent); }
+.trend-dates {
+  display: flex;
+  justify-content: space-between;
+  margin: 6px 0 0 40px;
+  color: var(--muted);
+  font-size: 0.7rem;
+}
+.trend-empty { margin: 0; padding: 36px 0; color: var(--muted); text-align: center; }
 .empty {
   margin-top: 28px;
   padding: 18px 0;
@@ -534,6 +632,7 @@ footer {
   }
   .status-line { justify-self: end; }
   .service { grid-template-columns: 1fr; }
+  .service-insights { grid-template-columns: 1fr; gap: 18px; }
   .bars {
     display: flex;
     flex-wrap: wrap;
@@ -592,6 +691,7 @@ footer {
     <span id="page-scroll-dock-value" class="page-scroll-dock__core">0%</span>
   </button>
   <div id="uptime-hovercard" class="hovercard" role="tooltip" hidden></div>
+  <div id="trend-hovercard" class="hovercard" aria-hidden="true" hidden></div>
   <script>
 const initialStatus = {{ .StatusJSON }};
 const apiPath = {{ .APIPathJSON }};
@@ -616,6 +716,8 @@ let lastStatus = initialStatus;
 let lastSuccessAt = initialStatus ? Date.now() : 0;
 let activeBar = null;
 let refreshInFlight = false;
+const expandedServices = new Set();
+let activeTrend = null;
 
 function t(key) {
   return messages[key] || key;
@@ -761,10 +863,223 @@ function bindBars() {
   });
 }
 
+function renderInsightsToggle(article, service, index) {
+  const control = document.createElement("div");
+  control.className = "insights-control";
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "insights-toggle";
+  button.textContent = "Insights";
+  button.dataset.serviceId = service.id;
+  const container = document.createElement("div");
+  container.className = "service-insights";
+  container.id = "service-insights-" + index;
+  button.setAttribute("aria-controls", container.id);
+  function setExpanded(expanded) {
+    button.setAttribute("aria-expanded", String(expanded));
+    container.hidden = !expanded;
+    container.replaceChildren();
+    if (expanded) renderServiceInsights(container, service);
+  }
+  button.addEventListener("click", function() {
+    const expanded = !expandedServices.has(service.id);
+    if (expanded) expandedServices.add(service.id);
+    else expandedServices.delete(service.id);
+    hideTrendHoverCard();
+    setExpanded(expanded);
+  });
+  setExpanded(expandedServices.has(service.id));
+  control.appendChild(button);
+  article.append(control, container);
+}
+
+function formatDays(days, capped) {
+  return days + (capped ? "+" : "") + (days === 1 && !capped ? " day" : " days");
+}
+
+function renderServiceInsights(container, service) {
+  const summary = service.summary || {};
+  const metrics = document.createElement("dl");
+  metrics.className = "insights-metrics";
+  const values = [
+    ["Availability", percent(summary.availability_rate)],
+    ["Downtime", formatSeconds(summary.estimated_downtime_seconds)],
+    ["Affected days", formatDays(summary.affected_days, false)],
+    ["Stable streak", formatDays(summary.stable_streak_days, summary.stable_streak_capped)]
+  ];
+  values.forEach(function(entry) {
+    const metric = document.createElement("div");
+    metric.className = "insights-metric";
+    const label = document.createElement("dt");
+    label.textContent = entry[0];
+    const value = document.createElement("dd");
+    value.textContent = summary.has_data ? entry[1] : "—";
+    metric.append(label, value);
+    metrics.appendChild(metric);
+  });
+  container.append(metrics, renderTrendChart(service.daily || []));
+}
+
+function validTrendDay(day) {
+  return day.has_data && day.expected_slots > 0;
+}
+
+function trendDomain(days) {
+  let minimum = 1;
+  days.forEach(function(day) {
+    if (validTrendDay(day) && Number.isFinite(day.uptime_rate)) {
+      minimum = Math.min(minimum, day.uptime_rate);
+    }
+  });
+  return minimum >= 0.99 ? 0.99 : Math.max(0, Math.floor(minimum * 100) - 1) / 100;
+}
+
+function buildTrendPath(days, x, y) {
+  let connected = false;
+  const commands = [];
+  days.forEach(function(day, index) {
+    if (!validTrendDay(day)) {
+      connected = false;
+      return;
+    }
+    commands.push((connected ? "L" : "M") + x(index) + " " + y(day.uptime_rate));
+    // A round-capped zero-length segment also shows isolated valid days.
+    if (!connected) commands.push("l0 0");
+    connected = true;
+  });
+  return commands.join(" ");
+}
+
+function nearestTrendIndex(clientX, rect, count) {
+  if (count <= 1 || rect.width <= 0) return 0;
+  const fraction = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+  return Math.round(fraction * (count - 1));
+}
+
+function hideTrendHoverCard() {
+  const card = $("trend-hovercard");
+  card.hidden = true;
+  card.classList.remove("is-visible");
+  if (activeTrend) {
+    activeTrend.guide.setAttribute("visibility", "hidden");
+    activeTrend.point.setAttribute("visibility", "hidden");
+    activeTrend = null;
+  }
+}
+
+function showTrendHoverCard(day, event) {
+  const card = $("trend-hovercard");
+  const title = document.createElement("span");
+  title.className = "hovercard-title";
+  title.textContent = day.day;
+  card.replaceChildren(title);
+  if (validTrendDay(day)) {
+    card.append(
+      cardRow("Availability", percent(day.uptime_rate)),
+      cardRow("Downtime", formatSeconds(day.estimated_downtime_seconds)),
+      cardRow(t("slots"), day.up_slots + " / " + day.expected_slots)
+    );
+  } else {
+    card.appendChild(cardNote(t("noData")));
+  }
+  card.hidden = false;
+  const margin = 12;
+  const width = card.offsetWidth;
+  const height = card.offsetHeight;
+  const left = Math.max(margin, Math.min(event.clientX - width / 2, window.innerWidth - width - margin));
+  let top = event.clientY + margin;
+  if (top + height > window.innerHeight - margin) top = event.clientY - height - margin;
+  card.style.left = left + "px";
+  card.style.top = Math.max(margin, Math.min(top, window.innerHeight - height - margin)) + "px";
+  card.classList.add("is-visible");
+}
+
+function renderTrendChart(days) {
+  const figure = document.createElement("figure");
+  figure.className = "insights-trend";
+  const caption = document.createElement("figcaption");
+  caption.textContent = "Availability trend · " + formatDays(days.length, false);
+  figure.appendChild(caption);
+  if (!days.some(validTrendDay)) {
+    const empty = document.createElement("p");
+    empty.className = "trend-empty";
+    empty.textContent = t("noData");
+    figure.appendChild(empty);
+    return figure;
+  }
+
+  const lower = trendDomain(days);
+  const x = (index) => days.length > 1 ? 8 + index / (days.length - 1) * 584 : 300;
+  const y = (rate) => {
+    const clamped = Number.isFinite(rate) ? Math.max(lower, Math.min(1, rate)) : lower;
+    return 8 + (1 - clamped) / (1 - lower) * 112;
+  };
+  const svgNode = (name, attributes) => {
+    const node = document.createElementNS("http://www.w3.org/2000/svg", name);
+    Object.entries(attributes).forEach(([key, value]) => node.setAttribute(key, String(value)));
+    return node;
+  };
+  const svg = svgNode("svg", { class: "trend-svg", viewBox: "0 0 600 128", preserveAspectRatio: "none", "aria-hidden": "true", focusable: "false" });
+  [8, 64, 120].forEach(function(height) {
+    svg.appendChild(svgNode("line", { class: "trend-grid", x1: 8, x2: 592, y1: height, y2: height, "vector-effect": "non-scaling-stroke" }));
+  });
+  const path = svgNode("path", { class: "trend-path", d: buildTrendPath(days, x, y), "vector-effect": "non-scaling-stroke" });
+  const guide = svgNode("line", { class: "trend-guide", y1: 8, y2: 120, visibility: "hidden" });
+  const point = svgNode("circle", { class: "trend-point", r: 3, visibility: "hidden" });
+  const hit = svgNode("rect", { class: "trend-hit-area", x: 8, y: 8, width: 584, height: 112, fill: "transparent" });
+  hit.addEventListener("pointermove", function(event) {
+    if (activeTrend && activeTrend.guide !== guide) hideTrendHoverCard();
+    const index = nearestTrendIndex(event.clientX, hit.getBoundingClientRect(), days.length);
+    const day = days[index];
+    guide.setAttribute("x1", x(index));
+    guide.setAttribute("x2", x(index));
+    guide.setAttribute("visibility", "visible");
+    point.setAttribute("visibility", validTrendDay(day) ? "visible" : "hidden");
+    if (validTrendDay(day)) {
+      point.setAttribute("cx", x(index));
+      point.setAttribute("cy", y(day.uptime_rate));
+    }
+    activeTrend = { guide, point };
+    showTrendHoverCard(day, event);
+  });
+  hit.addEventListener("pointerleave", hideTrendHoverCard);
+  hit.addEventListener("pointercancel", hideTrendHoverCard);
+  svg.append(path, guide, point, hit);
+
+  const plot = document.createElement("div");
+  plot.className = "trend-plot";
+  const axis = document.createElement("div");
+  axis.className = "trend-axis";
+  axis.setAttribute("aria-hidden", "true");
+  ["100%", Math.round(lower * 100) + "%"].forEach(function(text) {
+    const label = document.createElement("span");
+    label.textContent = text;
+    axis.appendChild(label);
+  });
+  plot.append(axis, svg);
+  const dates = document.createElement("div");
+  dates.className = "trend-dates";
+  const endpoints = days.length === 1 ? [days[0]] : [days[0], days[days.length - 1]];
+  endpoints.forEach(function(day) {
+    const label = document.createElement("span");
+    label.textContent = day.day;
+    dates.appendChild(label);
+  });
+  figure.append(plot, dates);
+  return figure;
+}
+
 function renderStatus(status) {
   if (!status) return;
   lastStatus = status;
   hideHoverCard();
+  hideTrendHoverCard();
+  const focusedToggle = document.activeElement && document.activeElement.closest(".insights-toggle");
+  const focusedServiceID = focusedToggle ? focusedToggle.dataset.serviceId : null;
+  const serviceIDs = new Set((status.services || []).map(service => service.id));
+  expandedServices.forEach(function(id) {
+    if (!serviceIDs.has(id)) expandedServices.delete(id);
+  });
 
   $("updated-at").textContent = formatTime(status.generated_at);
   setStatus(status.storage && status.storage.status === "ok" ? "live" : "error");
@@ -788,7 +1103,7 @@ function renderStatus(status) {
     root.appendChild(empty);
     return;
   }
-  status.services.forEach(function(service) {
+  status.services.forEach(function(service, index) {
     const article = document.createElement("article");
     article.className = "service";
 
@@ -823,9 +1138,15 @@ function renderStatus(status) {
     });
 
     article.append(info, bars);
+    renderInsightsToggle(article, service, index);
     root.appendChild(article);
   });
   bindBars();
+  if (focusedServiceID !== null) {
+    root.querySelectorAll(".insights-toggle").forEach(function(button) {
+      if (button.dataset.serviceId === focusedServiceID) button.focus({ preventScroll: true });
+    });
+  }
 }
 
 function updateSummary(services) {
@@ -852,6 +1173,11 @@ function formatSeconds(seconds) {
   const value = Math.max(0, Number(seconds || 0));
   if (value < 60) return Math.round(value) + "s";
   if (value < 3600) return Math.floor(value / 60) + "m";
+  if (value >= 86400) {
+    const days = Math.floor(value / 86400);
+    const hours = Math.floor((value % 86400) / 3600);
+    return hours ? days + "d " + hours + "h" : days + "d";
+  }
   const hours = Math.floor(value / 3600);
   const minutes = Math.floor((value % 3600) / 60);
   return minutes ? hours + "h " + minutes + "m" : hours + "h";
@@ -909,10 +1235,12 @@ function scrollUpQuarter() {
 
 $("page-scroll-dock").addEventListener("click", scrollUpQuarter);
 window.addEventListener("scroll", function() {
+  hideTrendHoverCard();
   updateScrollDock();
   repositionHoverCard();
 }, { passive: true });
 window.addEventListener("resize", function() {
+  hideTrendHoverCard();
   updateScrollDock();
   repositionHoverCard();
 });

--- a/v3/uptime/dashboard.gohtml
+++ b/v3/uptime/dashboard.gohtml
@@ -399,18 +399,19 @@ button:hover:not(.bar):not(.insights-toggle) {
   background-color: transparent;
   color: var(--muted);
   font-size: 0.8rem;
+  line-height: 1.25;
   transition: background-color 500ms ease;
 }
 .insights-toggle:hover { background-color: var(--accent-soft); }
-.insights-toggle:after {
-  content: "";
-  width: 6px;
-  height: 6px;
-  border-right: 1px solid currentColor;
-  border-bottom: 1px solid currentColor;
-  transform: rotate(45deg);
+.insights-icon {
+  display: block;
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+  transform-origin: center;
+  transition: transform 200ms ease;
 }
-.insights-toggle[aria-expanded="true"]:after { transform: rotate(225deg); }
+.insights-toggle[aria-expanded="true"] .insights-icon { transform: rotate(-180deg); }
 .insights-toggle:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
@@ -451,18 +452,20 @@ button:hover:not(.bar):not(.insights-toggle) {
 }
 .insights-trend { min-width: 0; margin: 0; }
 .insights-trend figcaption { color: var(--muted); font-size: 0.8rem; margin-bottom: 12px; }
-.trend-plot { display: grid; grid-template-columns: 40px minmax(0, 1fr); }
+.trend-plot { display: grid; grid-template-columns: 48px minmax(0, 1fr); }
 .trend-axis {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  padding: 2px 0;
+  position: relative;
   color: var(--muted);
   font-size: 0.7rem;
   font-variant-numeric: tabular-nums;
 }
+.trend-axis span {
+  position: absolute;
+  right: 8px;
+  transform: translateY(-50%);
+}
 .trend-svg { display: block; width: 100%; height: 128px; overflow: visible; }
-.trend-grid, .trend-guide { stroke: var(--border); stroke-width: 1; }
+.trend-grid, .trend-guide, .trend-ticks { stroke: var(--border); stroke-width: 1; }
 .trend-guide { stroke-dasharray: 3 3; }
 .trend-path {
   fill: none;
@@ -473,12 +476,19 @@ button:hover:not(.bar):not(.insights-toggle) {
 }
 .trend-point { fill: var(--accent); }
 .trend-dates {
-  display: flex;
-  justify-content: space-between;
-  margin: 6px 0 0 40px;
+  position: relative;
+  height: 1.45em;
+  margin: 6px 0 0 48px;
   color: var(--muted);
   font-size: 0.7rem;
 }
+.trend-dates span {
+  position: absolute;
+  transform: translateX(-50%);
+  white-space: nowrap;
+}
+.trend-dates span:first-child:not(:only-child) { transform: none; }
+.trend-dates span:last-child:not(:only-child) { transform: translateX(-100%); }
 .trend-empty { margin: 0; padding: 36px 0; color: var(--muted); text-align: center; }
 .empty {
   margin-top: 28px;
@@ -516,6 +526,7 @@ button:hover:not(.bar):not(.insights-toggle) {
 .hovercard[hidden] {
   display: none;
 }
+#trend-hovercard { width: min(244px, calc(100vw - 24px)); }
 .hovercard.is-visible {
   opacity: 1;
   visibility: visible;
@@ -648,11 +659,15 @@ footer {
     height: 24px;
   }
 }
+@media (max-width: 480px) {
+  .trend-dates .trend-date-secondary { display: none; }
+}
 @media (prefers-reduced-motion: reduce) {
   .header-divider:after { animation: none; }
   .bar,
   .hovercard,
   .insights-toggle,
+  .insights-icon,
   button { transition: none; }
 }
   </style>
@@ -866,12 +881,24 @@ function bindBars() {
   });
 }
 
+function svgNode(name, attributes) {
+  const node = document.createElementNS("http://www.w3.org/2000/svg", name);
+  Object.entries(attributes).forEach(([key, value]) => node.setAttribute(key, String(value)));
+  return node;
+}
+
 function renderInsightsToggle(article, heading, service, index) {
   const button = document.createElement("button");
   button.type = "button";
   button.className = "insights-toggle";
   button.textContent = "Insights";
   button.dataset.serviceId = service.id;
+  const icon = svgNode("svg", {
+    class: "insights-icon", viewBox: "0 0 16 16", "aria-hidden": "true", focusable: "false",
+    fill: "none", stroke: "currentColor", "stroke-width": 1.5, "stroke-linecap": "round", "stroke-linejoin": "round"
+  });
+  icon.appendChild(svgNode("path", { d: "M4 6 8 10 12 6" }));
+  button.appendChild(icon);
   const container = document.createElement("div");
   container.className = "service-insights";
   container.id = "service-insights-" + index;
@@ -957,6 +984,11 @@ function nearestTrendIndex(clientX, rect, count) {
   return Math.round(fraction * (count - 1));
 }
 
+function trendTickIndices(count) {
+  const ticks = Math.min(count, 5);
+  return Array.from({ length: ticks }, (_, index) => ticks > 1 ? Math.round(index * (count - 1) / (ticks - 1)) : 0);
+}
+
 function hideTrendHoverCard() {
   const card = $("trend-hovercard");
   card.hidden = true;
@@ -968,7 +1000,7 @@ function hideTrendHoverCard() {
   }
 }
 
-function showTrendHoverCard(day, event) {
+function showTrendHoverCard(day, anchor) {
   const card = $("trend-hovercard");
   const title = document.createElement("span");
   title.className = "hovercard-title";
@@ -985,11 +1017,15 @@ function showTrendHoverCard(day, event) {
   }
   card.hidden = false;
   const margin = 12;
+  const gap = 16;
   const width = card.offsetWidth;
   const height = card.offsetHeight;
-  const left = Math.max(margin, Math.min(event.clientX - width / 2, window.innerWidth - width - margin));
-  let top = event.clientY + margin;
-  if (top + height > window.innerHeight - margin) top = event.clientY - height - margin;
+  // Stay beside the selected point instead of following every cursor movement.
+  let left = anchor.x + gap;
+  if (left + width > window.innerWidth - margin) left = anchor.x - width - gap;
+  left = Math.max(margin, Math.min(left, window.innerWidth - width - margin));
+  let top = anchor.y - height - gap;
+  if (top < margin) top = anchor.y + gap;
   card.style.left = left + "px";
   card.style.top = Math.max(margin, Math.min(top, window.innerHeight - height - margin)) + "px";
   card.classList.add("is-visible");
@@ -998,8 +1034,9 @@ function showTrendHoverCard(day, event) {
 function renderTrendChart(days) {
   const figure = document.createElement("figure");
   figure.className = "insights-trend";
+  figure.setAttribute("aria-label", "Daily availability trend");
   const caption = document.createElement("figcaption");
-  caption.textContent = "Availability trend · " + formatDays(days.length, false);
+  caption.textContent = formatDays(days.length, false);
   figure.appendChild(caption);
   if (!days.some(validTrendDay)) {
     const empty = document.createElement("p");
@@ -1010,27 +1047,28 @@ function renderTrendChart(days) {
   }
 
   const lower = trendDomain(days);
+  const tickIndices = trendTickIndices(days.length);
+  const tickRates = Array.from({ length: 5 }, (_, index) => 1 - index * (1 - lower) / 4);
   const x = (index) => days.length > 1 ? 8 + index / (days.length - 1) * 584 : 300;
   const y = (rate) => {
     const clamped = Number.isFinite(rate) ? Math.max(lower, Math.min(1, rate)) : lower;
     return 8 + (1 - clamped) / (1 - lower) * 112;
   };
-  const svgNode = (name, attributes) => {
-    const node = document.createElementNS("http://www.w3.org/2000/svg", name);
-    Object.entries(attributes).forEach(([key, value]) => node.setAttribute(key, String(value)));
-    return node;
-  };
   const svg = svgNode("svg", { class: "trend-svg", viewBox: "0 0 600 128", preserveAspectRatio: "none", "aria-hidden": "true", focusable: "false" });
-  [8, 64, 120].forEach(function(height) {
+  tickRates.forEach(function(rate) {
+    const height = y(rate);
     svg.appendChild(svgNode("line", { class: "trend-grid", x1: 8, x2: 592, y1: height, y2: height, "vector-effect": "non-scaling-stroke" }));
   });
+  svg.appendChild(svgNode("path", { class: "trend-ticks", d: tickIndices.map(index => "M" + x(index) + " 120v4").join(" "), "vector-effect": "non-scaling-stroke" }));
   const path = svgNode("path", { class: "trend-path", d: buildTrendPath(days, x, y), "vector-effect": "non-scaling-stroke" });
   const guide = svgNode("line", { class: "trend-guide", y1: 8, y2: 120, visibility: "hidden" });
   const point = svgNode("circle", { class: "trend-point", r: 3, visibility: "hidden" });
   const hit = svgNode("rect", { class: "trend-hit-area", x: 8, y: 8, width: 584, height: 112, fill: "transparent" });
   hit.addEventListener("pointermove", function(event) {
     if (activeTrend && activeTrend.guide !== guide) hideTrendHoverCard();
-    const index = nearestTrendIndex(event.clientX, hit.getBoundingClientRect(), days.length);
+    const rect = hit.getBoundingClientRect();
+    const index = nearestTrendIndex(event.clientX, rect, days.length);
+    if (activeTrend && activeTrend.index === index) return;
     const day = days[index];
     guide.setAttribute("x1", x(index));
     guide.setAttribute("x2", x(index));
@@ -1040,8 +1078,11 @@ function renderTrendChart(days) {
       point.setAttribute("cx", x(index));
       point.setAttribute("cy", y(day.uptime_rate));
     }
-    activeTrend = { guide, point };
-    showTrendHoverCard(day, event);
+    activeTrend = { guide, point, index };
+    showTrendHoverCard(day, {
+      x: rect.left + (x(index) - 8) / 584 * rect.width,
+      y: validTrendDay(day) ? rect.top + (y(day.uptime_rate) - 8) / 112 * rect.height : rect.top + rect.height / 2
+    });
   });
   hit.addEventListener("pointerleave", hideTrendHoverCard);
   hit.addEventListener("pointercancel", hideTrendHoverCard);
@@ -1052,18 +1093,22 @@ function renderTrendChart(days) {
   const axis = document.createElement("div");
   axis.className = "trend-axis";
   axis.setAttribute("aria-hidden", "true");
-  ["100%", Math.round(lower * 100) + "%"].forEach(function(text) {
+  tickRates.forEach(function(rate) {
     const label = document.createElement("span");
-    label.textContent = text;
+    label.textContent = Number((rate * 100).toFixed(2)) + "%";
+    label.style.top = y(rate) + "px";
     axis.appendChild(label);
   });
   plot.append(axis, svg);
   const dates = document.createElement("div");
   dates.className = "trend-dates";
-  const endpoints = days.length === 1 ? [days[0]] : [days[0], days[days.length - 1]];
-  endpoints.forEach(function(day) {
+  tickIndices.forEach(function(index, tick) {
+    const day = days[index];
     const label = document.createElement("span");
-    label.textContent = day.day;
+    label.textContent = day.day.slice(5);
+    label.title = day.day;
+    if (tickIndices.length === 5 && tick % 2 === 1) label.className = "trend-date-secondary";
+    label.style.left = x(index) / 600 * 100 + "%";
     dates.appendChild(label);
   });
   figure.append(plot, dates);

--- a/v3/uptime/dashboard.gohtml
+++ b/v3/uptime/dashboard.gohtml
@@ -136,7 +136,7 @@ button {
   font: inherit;
   transition: border-color 140ms ease, background 140ms ease, box-shadow 140ms ease, transform 140ms ease;
 }
-button:hover:not(.bar) {
+button:hover:not(.bar):not(.insights-toggle) {
   border-color: var(--accent);
   transform: translateY(-1px);
 }
@@ -273,7 +273,7 @@ button:hover:not(.bar) {
 .service {
   display: grid;
   grid-template-columns: minmax(180px, 270px) minmax(0, 1fr);
-  gap: 18px;
+  gap: 8px 18px;
   align-items: center;
   min-width: 0;
   padding: 15px;
@@ -282,6 +282,14 @@ button:hover:not(.bar) {
   border-radius: 8px;
   box-shadow: var(--shadow);
   overflow: visible;
+}
+.service-heading {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
 }
 .service-name {
   display: flex;
@@ -380,25 +388,20 @@ button:hover:not(.bar) {
 .bar.gray.is-active {
   background-color: rgb(var(--none-rgb) / 0.52);
 }
-.insights-control {
-  grid-column: 1 / -1;
-  display: flex;
-  justify-content: flex-end;
-  border-top: 1px solid var(--border);
-  padding-top: 6px;
-  margin-top: -6px;
-}
 .insights-toggle {
   display: inline-flex;
   align-items: center;
+  flex: 0 0 auto;
   gap: 9px;
   padding: 4px 8px;
-  border-color: transparent;
+  border: 0;
   border-radius: 4px;
-  background: transparent;
+  background-color: transparent;
   color: var(--muted);
   font-size: 0.8rem;
+  transition: background-color 500ms ease;
 }
+.insights-toggle:hover { background-color: var(--accent-soft); }
 .insights-toggle:after {
   content: "";
   width: 6px;
@@ -415,19 +418,18 @@ button:hover:not(.bar) {
 .service-insights {
   grid-column: 1 / -1;
   display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+  grid-template-columns: 260px minmax(0, 1fr);
   gap: 24px;
   align-items: center;
   min-width: 0;
+  margin-top: 10px;
 }
 .service-insights[hidden] { display: none; }
 .insights-metrics {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1px;
   margin: 0;
-  background: var(--border);
-  border: 1px solid var(--border);
+  background: var(--panel-soft);
   border-radius: 6px;
   overflow: hidden;
 }
@@ -435,15 +437,15 @@ button:hover:not(.bar) {
   display: flex;
   flex-direction: column;
   min-width: 0;
-  padding: 12px;
-  background: var(--bg);
+  padding: 12px 14px;
   overflow-wrap: anywhere;
 }
-.insights-metric dt { color: var(--muted); font-size: 0.78rem; }
+.insights-metric:nth-child(even) { border-left: 1px solid var(--border); }
+.insights-metric:nth-child(n+3) { border-top: 1px solid var(--border); }
+.insights-metric dt { color: var(--muted); font-size: 0.75rem; }
 .insights-metric dd {
-  order: -1;
-  margin: 0 0 3px;
-  font-size: clamp(1.1rem, 2vw, 1.45rem);
+  margin: 4px 0 0;
+  font-size: 1.15rem;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
 }
@@ -650,6 +652,7 @@ footer {
   .header-divider:after { animation: none; }
   .bar,
   .hovercard,
+  .insights-toggle,
   button { transition: none; }
 }
   </style>
@@ -863,9 +866,7 @@ function bindBars() {
   });
 }
 
-function renderInsightsToggle(article, service, index) {
-  const control = document.createElement("div");
-  control.className = "insights-control";
+function renderInsightsToggle(article, heading, service, index) {
   const button = document.createElement("button");
   button.type = "button";
   button.className = "insights-toggle";
@@ -889,8 +890,8 @@ function renderInsightsToggle(article, service, index) {
     setExpanded(expanded);
   });
   setExpanded(expandedServices.has(service.id));
-  control.appendChild(button);
-  article.append(control, container);
+  heading.appendChild(button);
+  article.appendChild(container);
 }
 
 function formatDays(days, capped) {
@@ -1107,6 +1108,8 @@ function renderStatus(status) {
     const article = document.createElement("article");
     article.className = "service";
 
+    const heading = document.createElement("div");
+    heading.className = "service-heading";
     const info = document.createElement("div");
     const nameLine = document.createElement("div");
     nameLine.className = "service-name";
@@ -1117,7 +1120,7 @@ function renderStatus(status) {
     name.className = "name";
     name.textContent = service.name;
     nameLine.append(dot, name);
-    info.appendChild(nameLine);
+    heading.appendChild(nameLine);
 
     if (service.description) {
       const description = document.createElement("div");
@@ -1137,8 +1140,8 @@ function renderStatus(status) {
       bars.appendChild(dayMarkup(day));
     });
 
-    article.append(info, bars);
-    renderInsightsToggle(article, service, index);
+    article.append(heading, info, bars);
+    renderInsightsToggle(article, heading, service, index);
     root.appendChild(article);
   });
   bindBars();

--- a/v3/uptime/status.go
+++ b/v3/uptime/status.go
@@ -57,6 +57,26 @@ type ServiceStatus struct {
 	SampleIntervalSeconds int64 `json:"sample_interval_seconds"`
 	// Daily contains per-day uptime history.
 	Daily []DayStatus `json:"daily"`
+	// Summary contains derived metrics for the same history window as Daily.
+	Summary ServiceSummary `json:"summary"`
+}
+
+// ServiceSummary contains derived metrics for the history window represented by Daily.
+type ServiceSummary struct {
+	// HasData reports whether any day has data and a positive expected slot count.
+	HasData bool `json:"has_data"`
+	// AvailabilityRate is total up slots divided by total expected slots over valid days.
+	AvailabilityRate float64 `json:"availability_rate"`
+	// EstimatedDowntimeSeconds sums the normalized downtime of valid days.
+	EstimatedDowntimeSeconds int64 `json:"estimated_downtime_seconds"`
+	// AffectedDays counts valid days that missed at least one expected slot.
+	AffectedDays int `json:"affected_days"`
+	// StableStreakDays counts consecutive perfect days backward from the newest
+	// valid day, including today if perfect so far. An internal no-data day ends it.
+	StableStreakDays int `json:"stable_streak_days"`
+	// StableStreakCapped reports that the streak reaches the start of the returned
+	// window and the service predates it, so the streak may be longer.
+	StableStreakCapped bool `json:"stable_streak_capped"`
 }
 
 // DayStatus is the service uptime summary for one local day.
@@ -216,6 +236,7 @@ func (u *runtime) buildStatus(ctx context.Context, now time.Time) (StatusRespons
 		for _, day := range days {
 			serviceStatus.Daily = append(serviceStatus.Daily, u.dayStatus(service.ID, day, today, createdDay, service.CreatedAt, now, interval, dailyByService, todayByService))
 		}
+		serviceStatus.Summary = summarizeService(serviceStatus.Daily, createdDay < fromDay)
 		resp.Services = append(resp.Services, serviceStatus)
 	}
 

--- a/v3/uptime/status_test.go
+++ b/v3/uptime/status_test.go
@@ -1,9 +1,142 @@
 package uptime
 
 import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"slices"
 	"testing"
 	"time"
+
+	"github.com/gofiber/contrib/v3/uptime/internal/storage"
+	"github.com/gofiber/fiber/v3"
 )
+
+func TestServiceSummaryStatusAPI(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		createdAt time.Time
+		daily     []storage.DailyStatus
+		todayUp   int
+		wantDays  []DayStatus
+		want      ServiceSummary
+	}{
+		{
+			name:      "weighted partial creation day and healthy today",
+			createdAt: now.Add(-24 * time.Hour),
+			daily:     []storage.DailyStatus{{ServiceID: "api", Day: "2026-09-08", UpSlots: 6, ExpectedSlots: 12, Finalized: true}},
+			todayUp:   12,
+			wantDays: []DayStatus{
+				{Day: "2026-09-07", Status: "gray"},
+				{Day: "2026-09-08", UptimeRate: .5, UpSlots: 6, ExpectedSlots: 12, EstimatedDowntimeSeconds: 21600, Finalized: true, HasData: true, Status: "red"},
+				{Day: "2026-09-09", UptimeRate: 1, UpSlots: 12, ExpectedSlots: 12, HasData: true, Status: "green"},
+			},
+			want: ServiceSummary{HasData: true, AvailabilityRate: .75, EstimatedDowntimeSeconds: 21600, AffectedDays: 1, StableStreakDays: 1},
+		},
+		{
+			name:      "older service capped at returned window",
+			createdAt: now.AddDate(0, 0, -10),
+			daily: []storage.DailyStatus{
+				{ServiceID: "api", Day: "2026-09-07", UpSlots: 24, ExpectedSlots: 24, Finalized: true},
+				{ServiceID: "api", Day: "2026-09-08", UpSlots: 24, ExpectedSlots: 24, Finalized: true},
+			},
+			todayUp: 12,
+			wantDays: []DayStatus{
+				{Day: "2026-09-07", UptimeRate: 1, UpSlots: 24, ExpectedSlots: 24, Finalized: true, HasData: true, Status: "green"},
+				{Day: "2026-09-08", UptimeRate: 1, UpSlots: 24, ExpectedSlots: 24, Finalized: true, HasData: true, Status: "green"},
+				{Day: "2026-09-09", UptimeRate: 1, UpSlots: 12, ExpectedSlots: 12, HasData: true, Status: "green"},
+			},
+			want: ServiceSummary{HasData: true, AvailabilityRate: 1, StableStreakDays: 3, StableStreakCapped: true},
+		},
+		{
+			name:      "new service without a completed slot",
+			createdAt: now,
+			todayUp:   1,
+			wantDays: []DayStatus{
+				{Day: "2026-09-07", Status: "gray"},
+				{Day: "2026-09-08", Status: "gray"},
+				{Day: "2026-09-09", Status: "gray"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			store := &summaryReadStore{snapshotStore: newSnapshotStore()}
+			store.services = []storage.Service{{ID: "api", Name: "API", CreatedAt: tt.createdAt, LastSeenAt: now, SampleInterval: time.Hour}}
+			store.daily = tt.daily
+			store.today = []storage.TodaySampleStatus{{ServiceID: "api", Day: "2026-09-09", UpSlots: tt.todayUp}}
+			u := newSnapshotUptimeWithConfig(store.snapshotStore, Config{
+				ServiceID: "api", SampleInterval: time.Hour, DaysToShow: 3, RetentionDays: 3, Timezone: time.UTC,
+			})
+			u.store = store
+			status, err := u.buildStatus(context.Background(), now)
+			requireNoError(t, err)
+			requireLen(t, status.Services, 1)
+			requireEqual(t, tt.want, status.Services[0].Summary)
+			requireEqual(t, statusUp, status.Services[0].CurrentStatus)
+			if !slices.Equal(tt.wantDays, status.Services[0].Daily) {
+				t.Fatalf("daily = %+v, want %+v", status.Services[0].Daily, tt.wantDays)
+			}
+
+			// Exercise the real JSON handler using this deterministic snapshot.
+			u.snapshotCache = cloneSnapshot(status)
+			u.snapshotCachedAt = time.Now()
+			u.snapshotTTL = time.Hour
+			u.snapshotHasCache = true
+			app := newSnapshotApp(u)
+			resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/uptime/api/status", nil))
+			requireNoError(t, err)
+			t.Cleanup(func() { requireNoError(t, resp.Body.Close()) })
+			requireEqual(t, fiber.StatusOK, resp.StatusCode)
+			var payload struct {
+				Services []struct {
+					Summary       *ServiceSummary `json:"summary"`
+					Daily         []DayStatus     `json:"daily"`
+					CurrentStatus string          `json:"current_status"`
+				}
+			}
+			requireNoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+			requireLen(t, payload.Services, 1)
+			if payload.Services[0].Summary == nil {
+				t.Fatal("JSON service is missing the additive summary object")
+			}
+			requireEqual(t, tt.want, *payload.Services[0].Summary)
+			requireEqual(t, statusUp, payload.Services[0].CurrentStatus)
+			if !slices.Equal(tt.wantDays, payload.Services[0].Daily) {
+				t.Fatal("JSON changed daily history")
+			}
+			requireEqual(t, 1, store.listServicesCalls)
+			requireEqual(t, 1, store.dailyReads)
+			requireEqual(t, 1, store.todayReads)
+			requireEqual(t, 0, store.rollupCalls)
+			requireEqual(t, 0, store.cleanupCalls)
+
+			status.Services[0].Summary = ServiceSummary{}
+			requireEqual(t, tt.want, u.snapshotCache.Services[0].Summary)
+		})
+	}
+}
+
+// Count the existing logical reads without adding a separate mock backend.
+type summaryReadStore struct {
+	*snapshotStore
+	dailyReads int
+	todayReads int
+}
+
+func (s *summaryReadStore) QueryDaily(ctx context.Context, options storage.QueryDailyOptions) ([]storage.DailyStatus, error) {
+	s.dailyReads++
+	return s.snapshotStore.QueryDaily(ctx, options)
+}
+
+func (s *summaryReadStore) QueryTodaySamples(ctx context.Context, options storage.QueryTodaySamplesOptions) ([]storage.TodaySampleStatus, error) {
+	s.todayReads++
+	return s.snapshotStore.QueryTodaySamples(ctx, options)
+}
 
 func TestExpectedSlotsForWindow(t *testing.T) {
 	t.Parallel()

--- a/v3/uptime/summary.go
+++ b/v3/uptime/summary.go
@@ -1,0 +1,43 @@
+package uptime
+
+// summarizeService consumes normalized days in oldest-to-newest order.
+// It reuses DayStatus slot and downtime semantics without consulting storage or time.
+func summarizeService(days []DayStatus, historyTruncated bool) ServiceSummary {
+	var summary ServiceSummary
+	var upSlots, expectedSlots int64
+	for _, day := range days {
+		if !day.HasData || day.ExpectedSlots <= 0 {
+			continue
+		}
+		upSlots += int64(day.UpSlots)
+		expectedSlots += int64(day.ExpectedSlots)
+		summary.EstimatedDowntimeSeconds += day.EstimatedDowntimeSeconds
+		if day.UpSlots < day.ExpectedSlots {
+			summary.AffectedDays++
+		}
+	}
+	if expectedSlots == 0 {
+		return summary
+	}
+	summary.HasData = true
+	summary.AvailabilityRate = float64(upSlots) / float64(expectedSlots)
+
+	for i := len(days) - 1; i >= 0; i-- {
+		day := days[i]
+		if !day.HasData || day.ExpectedSlots <= 0 {
+			// Only skip unknown days at the newest edge (e.g. just after midnight).
+			if summary.StableStreakDays == 0 {
+				continue
+			}
+			break
+		}
+		if day.UpSlots != day.ExpectedSlots {
+			break
+		}
+		summary.StableStreakDays++
+		if i == 0 {
+			summary.StableStreakCapped = historyTruncated
+		}
+	}
+	return summary
+}

--- a/v3/uptime/summary_test.go
+++ b/v3/uptime/summary_test.go
@@ -1,0 +1,61 @@
+package uptime
+
+import (
+	"math"
+	"slices"
+	"testing"
+)
+
+func TestSummarizeService(t *testing.T) {
+	t.Parallel()
+
+	perfect := DayStatus{HasData: true, UpSlots: 100, ExpectedSlots: 100, Finalized: true}
+	partial := DayStatus{HasData: true, UpSlots: 10, ExpectedSlots: 10}
+	missed := DayStatus{HasData: true, UpSlots: 99, ExpectedSlots: 100, EstimatedDowntimeSeconds: 3, UptimeRate: 1}
+	outage := DayStatus{HasData: true, ExpectedSlots: 100, EstimatedDowntimeSeconds: 300}
+	unknown := DayStatus{UpSlots: 100, ExpectedSlots: 100, EstimatedDowntimeSeconds: 999}
+	zeroExpected := DayStatus{HasData: true, EstimatedDowntimeSeconds: 999}
+	tests := []struct {
+		name      string
+		days      []DayStatus
+		truncated bool
+		want      ServiceSummary
+	}{
+		{name: "empty"},
+		{name: "all no data", days: []DayStatus{unknown, zeroExpected}, truncated: true},
+		{name: "zero expected excluded", days: []DayStatus{zeroExpected}},
+		{name: "all perfect", days: []DayStatus{perfect, perfect}, want: ServiceSummary{HasData: true, AvailabilityRate: 1, StableStreakDays: 2}},
+		{name: "weighted unequal slots", days: []DayStatus{outage, partial}, want: ServiceSummary{HasData: true, AvailabilityRate: 10.0 / 110, EstimatedDowntimeSeconds: 300, AffectedDays: 1, StableStreakDays: 1}},
+		{name: "partial creation day weighting", days: []DayStatus{partial, missed}, want: ServiceSummary{HasData: true, AvailabilityRate: 109.0 / 110, EstimatedDowntimeSeconds: 3, AffectedDays: 1}},
+		{name: "no data excluded from aggregates", days: []DayStatus{unknown, zeroExpected, missed}, want: ServiceSummary{HasData: true, AvailabilityRate: .99, EstimatedDowntimeSeconds: 3, AffectedDays: 1}},
+		{name: "downtime summed", days: []DayStatus{missed, outage}, want: ServiceSummary{HasData: true, AvailabilityRate: .495, EstimatedDowntimeSeconds: 303, AffectedDays: 2}},
+		{name: "total outage is data", days: []DayStatus{outage}, want: ServiceSummary{HasData: true, EstimatedDowntimeSeconds: 300, AffectedDays: 1}},
+		{name: "one missed slot ignores rounded rate", days: []DayStatus{missed}, want: ServiceSummary{HasData: true, AvailabilityRate: .99, EstimatedDowntimeSeconds: 3, AffectedDays: 1}},
+		{name: "today perfect so far", days: []DayStatus{perfect, partial}, want: ServiceSummary{HasData: true, AvailabilityRate: 1, StableStreakDays: 2}},
+		{name: "latest imperfect stops streak", days: []DayStatus{perfect, missed}, truncated: true, want: ServiceSummary{HasData: true, AvailabilityRate: .995, EstimatedDowntimeSeconds: 3, AffectedDays: 1}},
+		{name: "older imperfect stops streak", days: []DayStatus{perfect, missed, perfect, partial}, truncated: true, want: ServiceSummary{HasData: true, AvailabilityRate: 309.0 / 310, EstimatedDowntimeSeconds: 3, AffectedDays: 1, StableStreakDays: 2}},
+		{name: "skip newest no data", days: []DayStatus{perfect, partial, unknown, zeroExpected}, want: ServiceSummary{HasData: true, AvailabilityRate: 1, StableStreakDays: 2}},
+		{name: "skip newest no data before imperfect", days: []DayStatus{perfect, missed, unknown}, truncated: true, want: ServiceSummary{HasData: true, AvailabilityRate: .995, EstimatedDowntimeSeconds: 3, AffectedDays: 1}},
+		{name: "internal no data breaks streak", days: []DayStatus{perfect, unknown, partial}, truncated: true, want: ServiceSummary{HasData: true, AvailabilityRate: 1, StableStreakDays: 1}},
+		{name: "internal zero expected breaks streak", days: []DayStatus{perfect, zeroExpected, partial}, truncated: true, want: ServiceSummary{HasData: true, AvailabilityRate: 1, StableStreakDays: 1}},
+		{name: "history boundary capped", days: []DayStatus{perfect, partial}, truncated: true, want: ServiceSummary{HasData: true, AvailabilityRate: 1, StableStreakDays: 2, StableStreakCapped: true}},
+		{name: "boundary capped after newest no data", days: []DayStatus{perfect, unknown}, truncated: true, want: ServiceSummary{HasData: true, AvailabilityRate: 1, StableStreakDays: 1, StableStreakCapped: true}},
+		{name: "created within window exact", days: []DayStatus{unknown, perfect, partial}, want: ServiceSummary{HasData: true, AvailabilityRate: 1, StableStreakDays: 2}},
+		{name: "created on left edge exact", days: []DayStatus{perfect}, want: ServiceSummary{HasData: true, AvailabilityRate: 1, StableStreakDays: 1}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			before := slices.Clone(tt.days)
+			got := summarizeService(tt.days, tt.truncated)
+			if math.Abs(got.AvailabilityRate-tt.want.AvailabilityRate) > 1e-12 {
+				t.Fatalf("availability = %v, want %v", got.AvailabilityRate, tt.want.AvailabilityRate)
+			}
+			got.AvailabilityRate = tt.want.AvailabilityRate
+			requireEqual(t, tt.want, got)
+			if !slices.Equal(before, tt.days) {
+				t.Fatal("summary mutated daily history")
+			}
+		})
+	}
+}

--- a/v3/uptime/ui_test.go
+++ b/v3/uptime/ui_test.go
@@ -1,0 +1,53 @@
+package uptime
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestDashboardInsightsTemplate(t *testing.T) {
+	t.Parallel()
+
+	const unsafeText = `</script><img src=x onerror="alert(1)">`
+	status := StatusResponse{Services: []ServiceStatus{{
+		ID: unsafeText, Name: unsafeText, Description: unsafeText,
+		Daily:   []DayStatus{{Day: "2026-09-09", HasData: true, UpSlots: 1, ExpectedSlots: 1, UptimeRate: 1}},
+		Summary: ServiceSummary{HasData: true, AvailabilityRate: 1, StableStreakDays: 1, StableStreakCapped: true},
+	}}}
+	body, err := renderDashboardHTML(ConfigDefault, status, "/uptime/api/status")
+	requireNoError(t, err)
+	requireNotContains(t, body, unsafeText)
+	requireEqual(t, 1, strings.Count(body, "<script>"))
+	requireEqual(t, 1, strings.Count(body, "</script>"))
+
+	// Verify that safe embedding preserves the full API data, including summary.
+	_, initial, ok := strings.Cut(body, "const initialStatus = ")
+	if !ok {
+		t.Fatal("missing initial status JSON")
+	}
+	var decoded StatusResponse
+	requireNoError(t, json.NewDecoder(strings.NewReader(initial)).Decode(&decoded))
+	requireLen(t, decoded.Services, 1)
+	requireEqual(t, unsafeText, decoded.Services[0].Name)
+	requireEqual(t, status.Services[0].Summary, decoded.Services[0].Summary)
+	requireLen(t, decoded.Services[0].Daily, 1)
+	requireEqual(t, status.Services[0].Daily[0], decoded.Services[0].Daily[0])
+
+	for _, contract := range []string{
+		`button.textContent = "Insights"`,
+		`"aria-expanded"`, `"aria-controls"`,
+		`.service-insights[hidden] { display: none; }`,
+		`id="trend-hovercard"`, `id="uptime-hovercard"`,
+		`"aria-hidden": "true", focusable: "false"`,
+		`document.createElementNS("http://www.w3.org/2000/svg"`,
+	} {
+		requireContains(t, body, contract)
+	}
+	for _, unsafe := range []string{
+		"innerHTML", "insertAdjacentHTML", "eval(", "new Function", "foreignObject",
+		"<script src=", "@import", "localStorage", "sessionStorage",
+	} {
+		requireNotContains(t, body, unsafe)
+	}
+}


### PR DESCRIPTION
Adds a lightweight insights view to each Uptime service card, while keeping the existing status overview compact.

- Adds weighted availability, estimated downtime, affected days, and stable streak metrics.
- Adds a daily availability trend using native SVG and Vanilla JavaScript.
- Keeps insights collapsed by default and preserves expanded cards across automatic refreshes.
- Handles no-data gaps explicitly and reports truncated stable streaks as `N+ days`.
- Exposes the derived metrics through a new `summary` object in the status JSON API.
- Reuses the existing daily uptime data without additional storage queries or persistence.
- Adds no new dependencies or configuration.

The summary metrics are derived entirely from the existing `DayStatus` history. Availability is weighted by total up/expected slots rather than averaging daily percentages.

### Preview

<img width="1509" height="600" alt="QQ20260910-010520" src="https://github.com/user-attachments/assets/1c5e565d-6a68-40b7-92df-eef5f20db2a7" />

<img width="1513" height="555" alt="QQ20260910-010626" src="https://github.com/user-attachments/assets/b4cb1ba8-39fc-4662-b0ca-9447e363a9ec" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expandable **Service insights** panels to service cards.
  * Added availability, downtime, affected days, stable streak, and daily availability trend details.
  * Added interactive trend charts with hover details and responsive, reduced-motion support.
  * Added summary metrics to the status data for each service.
* **Documentation**
  * Documented service insights, trend charts, and summary data in the uptime README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->