### PR TITLE
🐛 fix(jwt): enforce crit, answer rejections with a challenge, resolve the parser once

### DIFF
--- a/v3/jwt/README.md
+++ b/v3/jwt/README.md
@@ -152,15 +152,34 @@ For an overview and additional examples, see the Fiber Extractors guide:
   3.1](https://www.rfc-editor.org/rfc/rfc6750#section-3.1) asks for. A challenge
   already on the response is never replaced, whether an `ErrorHandler` of yours
   or an earlier authentication middleware put it there.
-- **Tokens in the query string are not stored in shared caches.** When the token
-  arrived in the query, the successful response is marked `Cache-Control: private`,
-  as [RFC 6750 Section
+- **Tokens in the URL are not stored in shared caches.** When the request URL
+  carries a token - a query parameter, a form parameter (Fiber's `FormValue`
+  reads the query before the body), or a route parameter - the successful
+  response is marked `Cache-Control: private`, as [RFC 6750 Section
   2.3](https://www.rfc-editor.org/rfc/rfc6750#section-2.3) asks, since the URL a
   shared cache keys on contains the token. A policy the handler set is kept,
   except that `public` is dropped and `private` added unless the policy already
-  keeps the response out of shared caches. Responses to tokens that arrived in a
-  header or a cookie are untouched, including from an extractor chain that could
-  have read the query but did not.
+  keeps the response out of shared caches; a policy too malformed to parse, such
+  as one with an unterminated quoted string, is replaced rather than appended to.
+
+  What decides this is whether the URL carries a credential, not which extractor
+  supplied the one that authenticated: a chain that preferred a cookie still
+  answered a request whose URL a cache would key on. A request whose URL holds
+  nothing is untouched, including one to a chain that could have read the query
+  but found it empty.
+
+  **Register a cache outside this middleware**, not inside it:
+
+  ```go
+  app.Use(cache.New())            // sees the finished response
+  app.Use(jwtware.New(cfg))
+  ```
+
+  The directive is put on the response before your handler runs as well as
+  after, so a cache registered *inside* this middleware still sees it in the
+  ordinary case. The exception it cannot cover is a handler that replaces
+  `Cache-Control` outright: such a cache reads the replacement as its own stack
+  unwinds, which is before this middleware can merge the policy back.
 
 ### What your application has to configure
 

--- a/v3/jwt/README.md
+++ b/v3/jwt/README.md
@@ -152,6 +152,21 @@ For an overview and additional examples, see the Fiber Extractors guide:
   3.1](https://www.rfc-editor.org/rfc/rfc6750#section-3.1) asks for. A challenge
   already on the response is never replaced, whether an `ErrorHandler` of yours
   or an earlier authentication middleware put it there.
+
+  A custom `ErrorHandler` has to leave the status somewhere the middleware can
+  read it: on the response (`c.Status(...)`), or in a returned `*fiber.Error`.
+  Both work, including `fiber.ErrUnauthorized` on its own. What it cannot do is
+  return some error of its own and rely on `fiber.Config.ErrorHandler` to turn
+  that into a 401 later - the status does not exist yet when the challenge is
+  applied, and guessing at it would put `WWW-Authenticate` on the 403s and 500s
+  such a handler also produces. If you do route rejections through your own
+  error type, set the challenge there:
+
+  ```go
+  ErrorHandler: func(c fiber.Ctx, err error) error {
+      return fiber.ErrUnauthorized // or c.Status(fiber.StatusUnauthorized)
+  },
+  ```
 - **Tokens in the URL are not stored in shared caches.** When the request URL
   carries a token - a query parameter, a form parameter (Fiber's `FormValue`
   reads the query before the body), or a route parameter - the successful

--- a/v3/jwt/README.md
+++ b/v3/jwt/README.md
@@ -168,18 +168,29 @@ For an overview and additional examples, see the Fiber Extractors guide:
   nothing is untouched, including one to a chain that could have read the query
   but found it empty.
 
-  **Register a cache outside this middleware**, not inside it:
+  **Register a cache inside this middleware**, so that every request is
+  authenticated before it can be answered:
 
   ```go
-  app.Use(cache.New())            // sees the finished response
   app.Use(jwtware.New(cfg))
+  app.Use(cache.New())            // runs only for authenticated requests
   ```
 
-  The directive is put on the response before your handler runs as well as
-  after, so a cache registered *inside* this middleware still sees it in the
-  ordinary case. The exception it cannot cover is a handler that replaces
-  `Cache-Control` outright: such a cache reads the replacement as its own stack
-  unwinds, which is before this middleware can merge the policy back.
+  A cache registered *outside* it answers from its store before this middleware
+  runs at all, so a hit is served with no authentication whatsoever. Fiber's
+  cache keys on the method, path and query by default - not on cookies
+  (`KeyCookies`) or on the `Authorization` header (`KeyHeaders`) - so with any
+  extractor that reads a cookie or a header, a stored response is handed to
+  requests that present no credential at all. Put a cache in front of this
+  middleware only if its key covers every credential your extractor reads.
+
+  Either way, a cache key that does not identify the user shares one user's
+  response with the next: that is your key's business, not this middleware's.
+  What this middleware guarantees is the directive, and for a URL that carries a
+  token it goes on before your handler runs, so an inner cache sees it when it
+  decides whether to store. The one case that leaves is a handler which replaces
+  `Cache-Control` outright, since such a cache reads the replacement before this
+  middleware regains control.
 
 ### What your application has to configure
 

--- a/v3/jwt/README.md
+++ b/v3/jwt/README.md
@@ -113,11 +113,12 @@ For an overview and additional examples, see the Fiber Extractors guide:
   such as `alg`, or names a parameter the header does not contain, is rejected as
   well. Nothing else uses `crit`, so leaving `KnownCriticalHeaders` unset is the
   safe default.
-- **`exp` and `nbf`** are validated on every request by
+- **`exp` and `nbf`** are validated by default on every request by
   `github.com/golang-jwt/jwt/v5` ([RFC 7519 Sections 4.1.4 and
   4.1.5](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.4)). Use
   `jwt.WithLeeway`, `jwt.WithExpirationRequired` or `jwt.WithNotBeforeRequired` in
-  `ParserOptions` to tighten this.
+  `ParserOptions` to tighten this - and note that `jwt.WithoutClaimsValidation()`
+  in `ParserOptions` turns it off entirely, so an expired token is accepted.
 - **Base64url segments must be unpadded** ([RFC 7515 Section
   2](https://www.rfc-editor.org/rfc/rfc7515#section-2)), and an `Authorization`
   header has to be well-formed `token68` ([RFC 9110 Section

--- a/v3/jwt/README.md
+++ b/v3/jwt/README.md
@@ -150,8 +150,13 @@ For an overview and additional examples, see the Fiber Extractors guide:
   presented no usable credential is answered with a bare `Bearer realm="..."`
   instead, which [RFC 6750 Section
   3.1](https://www.rfc-editor.org/rfc/rfc6750#section-3.1) asks for. A challenge
-  already on the response is never replaced, whether an `ErrorHandler` of yours
-  or an earlier authentication middleware put it there.
+  already on the response is never replaced. One your `ErrorHandler` wrote is the
+  answer and is left exactly as it is; one inherited from an authentication
+  middleware that ran earlier is kept and this middleware's added beside it,
+  which [RFC 9110 Section
+  11.6.1](https://www.rfc-editor.org/rfc/rfc9110#section-11.6.1) allows and
+  which leaves the client both a scheme it may be able to use and the reason its
+  token was refused.
 
   A custom `ErrorHandler` has to leave the status somewhere the middleware can
   read it: on the response (`c.Status(...)`), or in a returned `*fiber.Error`.
@@ -181,7 +186,8 @@ For an overview and additional examples, see the Fiber Extractors guide:
   supplied the one that authenticated: a chain that preferred a cookie still
   answered a request whose URL a cache would key on. A request whose URL holds
   nothing is untouched, including one to a chain that could have read the query
-  but found it empty.
+  but found it absent or empty - `?token=` names the parameter without carrying
+  a credential, and the extractors read it as no credential too.
 
   **Register a cache inside this middleware**, so that every request is
   authenticated before it can be answered:

--- a/v3/jwt/README.md
+++ b/v3/jwt/README.md
@@ -143,8 +143,12 @@ For an overview and additional examples, see the Fiber Extractors guide:
   WWW-Authenticate: Bearer realm="Restricted", error="invalid_token", error_description="The access token expired"
   ```
 
-  The scheme is taken from the extractor (`Bearer` unless the token comes from an
-  `Authorization` header with another scheme), the realm from `Realm`, and the
+  The schemes are taken from the extractor: an `Authorization` header names its
+  own, and every other source - a query parameter, a cookie, a form field, a
+  route parameter, one of your own - carries what RFC 6750 calls a bearer token
+  and so contributes `Bearer`. A chain offers each of them, in the order it tries
+  them, so a client refused on the credential it did send is never told to retry
+  with a scheme it never used. The realm comes from `Realm`, and the
   `error_description` from the reason the token failed. Error parameters are only
   added for the bearer scheme, as RFC 6750 defines them, and a request that
   presented no usable credential is answered with a bare `Bearer realm="..."`

--- a/v3/jwt/README.md
+++ b/v3/jwt/README.md
@@ -136,14 +136,21 @@ For an overview and additional examples, see the Fiber Extractors guide:
   The scheme is taken from the extractor (`Bearer` unless the token comes from an
   `Authorization` header with another scheme), the realm from `Realm`, and the
   `error_description` from the reason the token failed. Error parameters are only
-  added for the bearer scheme, as RFC 6750 defines them. An `ErrorHandler` that
-  sets its own `WWW-Authenticate` keeps it.
-- **Tokens in the query string are not cached.** When the extractor can read the
-  token from the query, successful responses are marked `Cache-Control: private`,
+  added for the bearer scheme, as RFC 6750 defines them, and a request that
+  presented no usable credential is answered with a bare `Bearer realm="..."`
+  instead, which [RFC 6750 Section
+  3.1](https://www.rfc-editor.org/rfc/rfc6750#section-3.1) asks for. A challenge
+  already on the response is never replaced, whether an `ErrorHandler` of yours
+  or an earlier authentication middleware put it there.
+- **Tokens in the query string are not stored in shared caches.** When the token
+  arrived in the query, the successful response is marked `Cache-Control: private`,
   as [RFC 6750 Section
   2.3](https://www.rfc-editor.org/rfc/rfc6750#section-2.3) asks, since the URL a
-  shared cache keys on contains the token. A handler that sets its own
-  `Cache-Control` keeps it.
+  shared cache keys on contains the token. A policy the handler set is kept,
+  except that `public` is dropped and `private` added unless the policy already
+  keeps the response out of shared caches. Responses to tokens that arrived in a
+  header or a cookie are untouched, including from an extractor chain that could
+  have read the query but did not.
 
 ### What your application has to configure
 
@@ -176,6 +183,10 @@ the values involved:
   ```go
   SuccessHandler: func(c fiber.Ctx) error {
       if typ, _ := jwtware.FromContext(c).Header["typ"].(string); !strings.EqualFold(typ, "at+jwt") {
+          // A rejection from here does not pass through the middleware's own
+          // rejection path, so it has to carry its own challenge.
+          c.Set(fiber.HeaderWWWAuthenticate,
+              `Bearer realm="Restricted", error="invalid_token", error_description="The access token is of an unexpected type"`)
           return c.Status(fiber.StatusUnauthorized).SendString("unexpected token type")
       }
       return c.Next()
@@ -189,7 +200,7 @@ the values involved:
 A request that carries no credentials at all is answered with **400** and
 `missing or malformed JWT`, which is what this middleware has always done and
 what the extractor can tell us: it reports a missing and a malformed credential
-as the same error. [RFC 6750 Section
+as the same error, which is also why its challenge names no error code. [RFC 6750 Section
 3.1](https://www.rfc-editor.org/rfc/rfc6750#section-3.1) reserves 400 for a
 malformed request and answers a request that "lacks any authentication
 information" with 401 instead. If you need those OAuth 2.0 semantics exactly,

--- a/v3/jwt/README.md
+++ b/v3/jwt/README.md
@@ -12,6 +12,7 @@ JWT returns a JSON Web Token (JWT) auth middleware.
 For valid token, it sets the token in Ctx.Locals (and in the underlying `context.Context` when `PassLocalsToContext` is enabled) and calls next handler.
 For invalid token, it returns "401 - Unauthorized" error.
 For missing token, it returns "400 - Bad Request" error.
+Either way the response carries the `WWW-Authenticate` challenge required by [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#section-15.5.2) and [RFC 6750](https://www.rfc-editor.org/rfc/rfc6750#section-3). See [Standards compliance](#standards-compliance).
 
 Special thanks and credits to [Echo](https://echo.labstack.com/middleware/jwt)
 
@@ -46,6 +47,7 @@ jwtware.FromContext(ctx any) *jwt.Token    // jwt "github.com/golang-jwt/jwt/v5"
 | Next               | `func(fiber.Ctx) bool`               | Defines a function to skip this middleware when it returns true                       | `nil`                        |
 | SuccessHandler     | `func(fiber.Ctx) error`              | Executed when a token is valid.                                                       | `c.Next()`                   |
 | ErrorHandler       | `func(fiber.Ctx, error) error`       | ErrorHandler defines a function which is executed for an invalid token.               | `401 Invalid or expired JWT` |
+| Realm              | `string`                             | Protected area named in the `WWW-Authenticate` challenge sent with a rejection.       | `"Restricted"`               |
 | SigningKey         | `SigningKey`                         | Signing key used to validate the token. Used as a fallback if `SigningKeys` is empty. | `nil`                        |
 | SigningKeys        | `map[string]SigningKey`              | Map of signing keys used to validate tokens via the `kid` header.                     | `nil`                        |
 | Claims             | `jwt.Claims`                         | Claims are extendable claims data defining token content.                             | `jwt.MapClaims{}`            |
@@ -54,6 +56,7 @@ jwtware.FromContext(ctx any) *jwt.Token    // jwt "github.com/golang-jwt/jwt/v5"
 | KeyFunc            | `jwt.Keyfunc`                        | User-defined function that supplies the public key for token validation.              | `nil` (uses internal default)|
 | JWKSetURLs         | `[]string`                           | List of JSON Web Key (JWK) Set URLs used to obtain signing keys for parsing JWTs.     | `nil`                        |
 | ParserOptions      | `[]jwt.ParserOption`                 | List of [`jwt.ParserOption`](https://pkg.go.dev/github.com/golang-jwt/jwt/v5#ParserOption), provides additional options for JWT parsing.                | `nil`                        |
+| KnownCriticalHeaders | `[]string`                         | JWS `crit` header parameters this application understands and processes itself.       | `nil`                        |
 
 ## Available Extractors
 
@@ -85,6 +88,126 @@ For an overview and additional examples, see the Fiber Extractors guide:
 - **Cookie-based extractors** (`FromCookie`): Secure for web applications but requires proper cookie security settings (HttpOnly, Secure, SameSite).
 
 **Recommendation**: Use `FromAuthHeader("Bearer")` (the default) for production applications unless you have specific requirements that necessitate alternative extractors.
+
+## Standards compliance
+
+### What the middleware enforces
+
+- **The signing algorithm comes from your configuration, not from the token.** When
+  `SigningKey.JWTAlg` is set - or when every entry of `SigningKeys` sets it - the
+  parser rejects any other `alg` before a key is looked up, as
+  [RFC 8725 Section 3.1](https://www.rfc-editor.org/rfc/rfc8725#section-3.1) asks.
+  Pass `jwt.WithValidMethods` in `ParserOptions` to pin the algorithms yourself; a
+  value you pass wins over the derived one. Configurations that leave the
+  algorithm open (`KeyFunc`, `JWKSetURLs`, or a `SigningKey` without `JWTAlg`)
+  are only as strict as the key material and the JWK `alg` allow, so pinning is
+  worth it.
+- **`alg: none` is refused**, and keys are never read out of the token: the `jwk`,
+  `jku`, `x5u` and `x5c` header parameters are ignored, per
+  [RFC 8725 Sections 3.4 and 3.5](https://www.rfc-editor.org/rfc/rfc8725#section-3.4).
+- **Critical header parameters** (`crit`) are checked as
+  [RFC 7515 Section 4.1.11](https://www.rfc-editor.org/rfc/rfc7515#section-4.1.11)
+  requires: a token that marks a header parameter critical is rejected unless the
+  parameter is listed in `KnownCriticalHeaders`. A `crit` value that is not a
+  non-empty array of names, repeats a name, names a registered JOSE parameter
+  such as `alg`, or names a parameter the header does not contain, is rejected as
+  well. Nothing else uses `crit`, so leaving `KnownCriticalHeaders` unset is the
+  safe default.
+- **`exp` and `nbf`** are validated on every request by
+  `github.com/golang-jwt/jwt/v5` ([RFC 7519 Sections 4.1.4 and
+  4.1.5](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.4)). Use
+  `jwt.WithLeeway`, `jwt.WithExpirationRequired` or `jwt.WithNotBeforeRequired` in
+  `ParserOptions` to tighten this.
+- **Base64url segments must be unpadded** ([RFC 7515 Section
+  2](https://www.rfc-editor.org/rfc/rfc7515#section-2)), and an `Authorization`
+  header has to be well-formed `token68` ([RFC 9110 Section
+  11.6.2](https://www.rfc-editor.org/rfc/rfc9110#section-11.6.2)).
+- **Rejections carry a challenge.** Every 400, 401 and 407 response the
+  middleware produces gets a `WWW-Authenticate` (or `Proxy-Authenticate`) header,
+  which [RFC 9110 Section
+  15.5.2](https://www.rfc-editor.org/rfc/rfc9110#section-15.5.2) requires of a 401
+  and [RFC 6750 Section 3](https://www.rfc-editor.org/rfc/rfc6750#section-3)
+  requires of a resource server refusing a bearer token:
+
+  ```text
+  WWW-Authenticate: Bearer realm="Restricted", error="invalid_token", error_description="The access token expired"
+  ```
+
+  The scheme is taken from the extractor (`Bearer` unless the token comes from an
+  `Authorization` header with another scheme), the realm from `Realm`, and the
+  `error_description` from the reason the token failed. Error parameters are only
+  added for the bearer scheme, as RFC 6750 defines them. An `ErrorHandler` that
+  sets its own `WWW-Authenticate` keeps it.
+- **Tokens in the query string are not cached.** When the extractor can read the
+  token from the query, successful responses are marked `Cache-Control: private`,
+  as [RFC 6750 Section
+  2.3](https://www.rfc-editor.org/rfc/rfc6750#section-2.3) asks, since the URL a
+  shared cache keys on contains the token. A handler that sets its own
+  `Cache-Control` keeps it.
+
+### What your application has to configure
+
+Some rules cannot be applied by a middleware, because only the application knows
+the values involved:
+
+- **`aud`** - [RFC 7519 Section
+  4.1.3](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.3) requires a token
+  whose audience is not this application to be rejected. The audience is only
+  checked when you name it:
+
+  ```go
+  app.Use(jwtware.New(jwtware.Config{
+      SigningKey: jwtware.SigningKey{JWTAlg: jwtware.RS256, Key: publicKey},
+      ParserOptions: []jwt.ParserOption{
+          jwt.WithAudience("https://api.example.com"),
+          jwt.WithIssuer("https://issuer.example.com"),
+          jwt.WithExpirationRequired(),
+      },
+  }))
+  ```
+
+- **`typ`** - if your deployment issues several kinds of JWT, check the media type
+  as [RFC 8725 Section
+  3.11](https://www.rfc-editor.org/rfc/rfc8725#section-3.11) recommends. For
+  example, an OAuth 2.0 access token per [RFC
+  9068](https://www.rfc-editor.org/rfc/rfc9068#section-2.1) carries
+  `"typ": "at+jwt"`:
+
+  ```go
+  SuccessHandler: func(c fiber.Ctx) error {
+      if typ, _ := jwtware.FromContext(c).Header["typ"].(string); !strings.EqualFold(typ, "at+jwt") {
+          return c.Status(fiber.StatusUnauthorized).SendString("unexpected token type")
+      }
+      return c.Next()
+  },
+  ```
+
+- **`jti`** - replay detection needs state the middleware does not keep.
+
+### Status code for a request without credentials
+
+A request that carries no credentials at all is answered with **400** and
+`missing or malformed JWT`, which is what this middleware has always done and
+what the extractor can tell us: it reports a missing and a malformed credential
+as the same error. [RFC 6750 Section
+3.1](https://www.rfc-editor.org/rfc/rfc6750#section-3.1) reserves 400 for a
+malformed request and answers a request that "lacks any authentication
+information" with 401 instead. If you need those OAuth 2.0 semantics exactly,
+say so in an `ErrorHandler`:
+
+```go
+ErrorHandler: func(c fiber.Ctx, err error) error {
+    if errors.Is(err, extractors.ErrNotFound) {
+        if c.Get(fiber.HeaderAuthorization) == "" {
+            // No credentials at all: challenge without naming an error.
+            c.Set(fiber.HeaderWWWAuthenticate, `Bearer realm="Restricted"`)
+            return c.SendStatus(fiber.StatusUnauthorized)
+        }
+        return c.Status(fiber.StatusBadRequest).SendString(jwtware.ErrMissingToken.Error())
+    }
+    return c.Status(fiber.StatusUnauthorized).SendString("Invalid or expired JWT")
+},
+```
 
 ## HS256 Example
 

--- a/v3/jwt/README.md
+++ b/v3/jwt/README.md
@@ -197,6 +197,11 @@ For an overview and additional examples, see the Fiber Extractors guide:
   but found it absent or empty - `?token=` names the parameter without carrying
   a credential, and the extractors read it as no credential too.
 
+  The three sources above are the ones a middleware can recognise. An extractor
+  of your own reads wherever you wrote it to, so if that is somewhere in the URL,
+  mark the response yourself - there is nothing in its metadata to tell this
+  middleware where it looked.
+
   **Register a cache inside this middleware**, so that every request is
   authenticated before it can be answered:
 

--- a/v3/jwt/README.md
+++ b/v3/jwt/README.md
@@ -129,9 +129,13 @@ For an overview and additional examples, see the Fiber Extractors guide:
   in `ParserOptions` turns it off entirely, so an expired token is accepted.
 - **Base64url segments must be unpadded** by default ([RFC 7515 Section
   2](https://www.rfc-editor.org/rfc/rfc7515#section-2)) - `jwt.WithPaddingAllowed()`
-  in `ParserOptions` accepts padded segments - and an `Authorization` header has
-  to be well-formed `token68` ([RFC 9110 Section
-  11.6.2](https://www.rfc-editor.org/rfc/rfc9110#section-11.6.2)).
+  in `ParserOptions` accepts padded segments. An `Authorization` header read by
+  `FromAuthHeader` with a scheme - the default `FromAuthHeader("Bearer")`
+  included - also has to be well-formed `token68` ([RFC 9110 Section
+  11.6.2](https://www.rfc-editor.org/rfc/rfc9110#section-11.6.2)); that check is
+  the extractor's, so `FromAuthHeader("")`, `FromHeader("Authorization")` and an
+  extractor of your own hand the header over unchecked, and a
+  `TokenProcessorFunc` runs after it in any case.
 - **Rejections carry a challenge.** Every 400, 401 and 407 response the
   middleware produces gets a `WWW-Authenticate` (or `Proxy-Authenticate`) header,
   which [RFC 9110 Section

--- a/v3/jwt/README.md
+++ b/v3/jwt/README.md
@@ -167,7 +167,8 @@ For an overview and additional examples, see the Fiber Extractors guide:
   token was refused.
 
   A custom `ErrorHandler` has to leave the status somewhere the middleware can
-  read it: on the response (`c.Status(...)`), or in a returned `*fiber.Error`.
+  read it: on the response (`c.SendStatus(...)`, or `c.Status(...)` followed by a
+  send), or in a returned `*fiber.Error`.
   Both work, including `fiber.ErrUnauthorized` on its own. What it cannot do is
   return some error of its own and rely on `fiber.Config.ErrorHandler` to turn
   that into a 401 later - the status does not exist yet when the challenge is
@@ -177,7 +178,7 @@ For an overview and additional examples, see the Fiber Extractors guide:
 
   ```go
   ErrorHandler: func(c fiber.Ctx, err error) error {
-      return fiber.ErrUnauthorized // or c.Status(fiber.StatusUnauthorized)
+      return fiber.ErrUnauthorized // or c.SendStatus(fiber.StatusUnauthorized)
   },
   ```
 - **Tokens in the URL are not stored in shared caches.** When the request URL
@@ -379,6 +380,7 @@ package main
 import (
  "github.com/gofiber/fiber/v3"
 
+ "github.com/gofiber/fiber/v3/extractors"
  jwtware "github.com/gofiber/contrib/v3/jwt"
 )
 
@@ -440,6 +442,8 @@ import (
 
  "github.com/gofiber/fiber/v3"
 
+
+ "github.com/gofiber/fiber/v3/extractors"
  "github.com/golang-jwt/jwt/v5"
 
  jwtware "github.com/gofiber/contrib/v3/jwt"
@@ -564,6 +568,7 @@ import (
  "fmt"
   "github.com/gofiber/fiber/v3"
 
+  "github.com/gofiber/fiber/v3/extractors"
   jwtware "github.com/gofiber/contrib/v3/jwt"
   "github.com/golang-jwt/jwt/v5"
 )

--- a/v3/jwt/README.md
+++ b/v3/jwt/README.md
@@ -105,6 +105,11 @@ For an overview and additional examples, see the Fiber Extractors guide:
 - **`alg: none` is refused**, and keys are never read out of the token: the `jwk`,
   `jku`, `x5u` and `x5c` header parameters are ignored, per
   [RFC 8725 Sections 3.4 and 3.5](https://www.rfc-editor.org/rfc/rfc8725#section-3.4).
+  This describes the built-in key lookup - `SigningKey`, `SigningKeys` and
+  `JWKSetURLs`. A `KeyFunc` of your own is handed the parsed token and can read
+  whatever it likes out of the header, and a `SigningKey.Key` set to
+  `jwt.UnsafeAllowNoneSignatureType` accepts `alg: none` by design; neither is
+  something the middleware overrides.
 - **Critical header parameters** (`crit`) are checked as
   [RFC 7515 Section 4.1.11](https://www.rfc-editor.org/rfc/rfc7515#section-4.1.11)
   requires: a token that marks a header parameter critical is rejected unless the
@@ -112,16 +117,20 @@ For an overview and additional examples, see the Fiber Extractors guide:
   non-empty array of names, repeats a name, names a registered JOSE parameter
   such as `alg`, or names a parameter the header does not contain, is rejected as
   well. Nothing else uses `crit`, so leaving `KnownCriticalHeaders` unset is the
-  safe default.
+  safe default. `b64` ([RFC 7797](https://www.rfc-editor.org/rfc/rfc7797)) cannot
+  be declared: it changes how the payload is encoded, which the parser has
+  already settled before your code sees the token, so naming it panics at `New`
+  and tokens carrying it are always rejected.
 - **`exp` and `nbf`** are validated by default on every request by
   `github.com/golang-jwt/jwt/v5` ([RFC 7519 Sections 4.1.4 and
   4.1.5](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.4)). Use
   `jwt.WithLeeway`, `jwt.WithExpirationRequired` or `jwt.WithNotBeforeRequired` in
   `ParserOptions` to tighten this - and note that `jwt.WithoutClaimsValidation()`
   in `ParserOptions` turns it off entirely, so an expired token is accepted.
-- **Base64url segments must be unpadded** ([RFC 7515 Section
-  2](https://www.rfc-editor.org/rfc/rfc7515#section-2)), and an `Authorization`
-  header has to be well-formed `token68` ([RFC 9110 Section
+- **Base64url segments must be unpadded** by default ([RFC 7515 Section
+  2](https://www.rfc-editor.org/rfc/rfc7515#section-2)) - `jwt.WithPaddingAllowed()`
+  in `ParserOptions` accepts padded segments - and an `Authorization` header has
+  to be well-formed `token68` ([RFC 9110 Section
   11.6.2](https://www.rfc-editor.org/rfc/rfc9110#section-11.6.2)).
 - **Rejections carry a challenge.** Every 400, 401 and 407 response the
   middleware produces gets a `WWW-Authenticate` (or `Proxy-Authenticate`) header,

--- a/v3/jwt/challenge.go
+++ b/v3/jwt/challenge.go
@@ -1,0 +1,211 @@
+package jwtware
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/extractors"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// The RFC 6750 Section 3.1 error codes this middleware can report.
+const (
+	errorInvalidRequest = "invalid_request"
+	errorInvalidToken   = "invalid_token"
+)
+
+// challengeReason enumerates the failures a challenge can describe. RFC 6750
+// Section 3 allows a human readable error_description, and keeping the texts in
+// a table lets every finished header value be assembled once, at startup.
+type challengeReason int
+
+const (
+	reasonUnknown challengeReason = iota
+	reasonMissing
+	reasonCritical
+	reasonAlgorithm
+	reasonExpired
+	reasonNotYetValid
+	reasonUsedBeforeIssued
+	reasonAudience
+	reasonIssuer
+	reasonMissingClaim
+	reasonClaims
+	reasonSignature
+	reasonMalformed
+	reasonUnverifiable
+)
+
+// challengeDescriptions holds the error_description text for every reason. The
+// underlying error strings are deliberately not forwarded: they can name
+// configuration details, and the grammar in RFC 6750 Section 3 admits neither
+// quotes nor backslashes.
+var challengeDescriptions = [...]string{
+	reasonUnknown:          "",
+	reasonMissing:          "The access token is missing or malformed",
+	reasonCritical:         "The access token uses an unsupported critical extension",
+	reasonAlgorithm:        "The access token is signed with an unexpected algorithm",
+	reasonExpired:          "The access token expired",
+	reasonNotYetValid:      "The access token is not valid yet",
+	reasonUsedBeforeIssued: "The access token was used before it was issued",
+	reasonAudience:         "The access token is meant for a different audience",
+	reasonIssuer:           "The access token was issued by an unexpected issuer",
+	reasonMissingClaim:     "The access token is missing a required claim",
+	reasonClaims:           "The access token claims are invalid",
+	reasonSignature:        "The access token signature is invalid",
+	reasonMalformed:        "The access token is malformed",
+	reasonUnverifiable:     "The access token could not be verified",
+}
+
+// challenge holds the authentication challenge that has to accompany a rejected
+// request.
+//
+// RFC 9110 Section 15.5.2 requires every 401 response to carry a
+// "WWW-Authenticate" header, and RFC 6750 Section 3 requires a resource server
+// that refuses a bearer token to describe the failure in that header. The header
+// values depend only on the configuration and the kind of failure, so they are
+// all built when the middleware is, and a rejected request just looks one up.
+type challenge struct {
+	badRequest   []string
+	unauthorized []string
+	// keepExisting records that the error handler is the caller's, and so may
+	// have written a challenge of its own that must not be overwritten.
+	keepExisting bool
+}
+
+// newChallenge renders the challenges for the configured credential source.
+func newChallenge(cfg Config, keepExisting bool) *challenge {
+	scheme := firstAuthScheme(cfg.Extractor)
+	if scheme == "" {
+		// The token does not travel in an Authorization header, but a 401 still
+		// has to name a scheme the client can retry with, and for a JWT that is
+		// the bearer scheme of RFC 6750.
+		scheme = "Bearer"
+	}
+	prefix := fmt.Sprintf("%s realm=%q", scheme, cfg.Realm)
+
+	ch := &challenge{
+		badRequest:   make([]string, len(challengeDescriptions)),
+		unauthorized: make([]string, len(challengeDescriptions)),
+		keepExisting: keepExisting,
+	}
+	for reason, description := range challengeDescriptions {
+		// The error parameters are defined for the bearer scheme only.
+		if !strings.EqualFold(scheme, "Bearer") {
+			ch.badRequest[reason] = prefix
+			ch.unauthorized[reason] = prefix
+			continue
+		}
+		ch.badRequest[reason] = withError(prefix, errorInvalidRequest, description)
+		ch.unauthorized[reason] = withError(prefix, errorInvalidToken, description)
+	}
+	return ch
+}
+
+// customErrorHandler reports whether the caller supplied the error handler. The
+// default one never writes a challenge, so its response needs no inspecting.
+func customErrorHandler(config []Config) bool {
+	return len(config) > 0 && config[0].ErrorHandler != nil
+}
+
+// withError appends the RFC 6750 Section 3 error parameters to a challenge.
+func withError(prefix, code, description string) string {
+	if description == "" {
+		return prefix + `, error="` + code + `"`
+	}
+	return prefix + `, error="` + code + `", error_description="` + description + `"`
+}
+
+// apply adds the challenge to a response that rejected the request, unless the
+// error handler already wrote one of its own.
+//
+// handlerErr is what the error handler returned, so that a handler which only
+// returns a *fiber.Error - leaving the status to Fiber's own error handler - is
+// still recognised as a rejection. cause is the failure the handler was called
+// with, and picks the error_description.
+func (ch *challenge) apply(c fiber.Ctx, handlerErr, cause error) {
+	status := c.Response().StatusCode()
+	switch status {
+	case fiber.StatusBadRequest, fiber.StatusUnauthorized, fiber.StatusProxyAuthRequired:
+		// The handler wrote the status itself, so it needs no interpreting.
+	default:
+		var fiberErr *fiber.Error
+		if errors.As(handlerErr, &fiberErr) {
+			status = fiberErr.Code
+		}
+	}
+
+	// RFC 6750 Section 3.1: credentials the resource server could not parse are
+	// a bad request, anything that got as far as being verified is a bad token.
+	header, values := fiber.HeaderWWWAuthenticate, ch.unauthorized
+	switch status {
+	case fiber.StatusBadRequest:
+		values = ch.badRequest
+	case fiber.StatusUnauthorized:
+	case fiber.StatusProxyAuthRequired:
+		header = fiber.HeaderProxyAuthenticate
+	default:
+		// Anything else is not an authentication challenge.
+		return
+	}
+
+	if ch.keepExisting && len(c.Response().Header.Peek(header)) > 0 {
+		return
+	}
+
+	c.Set(header, values[describe(cause)])
+}
+
+// describe classifies a failure so that the challenge can say what was wrong
+// with the token without repeating the error itself.
+func describe(err error) challengeReason {
+	switch {
+	case err == nil:
+		return reasonUnknown
+	case errors.Is(err, extractors.ErrNotFound):
+		return reasonMissing
+	case errors.Is(err, ErrCriticalHeader):
+		return reasonCritical
+	case errors.Is(err, ErrJWTAlg):
+		return reasonAlgorithm
+	case errors.Is(err, jwt.ErrTokenExpired):
+		return reasonExpired
+	case errors.Is(err, jwt.ErrTokenNotValidYet):
+		return reasonNotYetValid
+	case errors.Is(err, jwt.ErrTokenUsedBeforeIssued):
+		return reasonUsedBeforeIssued
+	case errors.Is(err, jwt.ErrTokenInvalidAudience):
+		return reasonAudience
+	case errors.Is(err, jwt.ErrTokenInvalidIssuer):
+		return reasonIssuer
+	case errors.Is(err, jwt.ErrTokenRequiredClaimMissing):
+		return reasonMissingClaim
+	case errors.Is(err, jwt.ErrTokenInvalidClaims):
+		return reasonClaims
+	case errors.Is(err, jwt.ErrTokenSignatureInvalid):
+		return reasonSignature
+	case errors.Is(err, jwt.ErrTokenMalformed):
+		return reasonMalformed
+	case errors.Is(err, jwt.ErrTokenUnverifiable):
+		return reasonUnverifiable
+	default:
+		return reasonUnknown
+	}
+}
+
+// firstAuthScheme reports the Authorization header scheme the extractor accepts,
+// walking a chain in the order it is tried. It returns an empty string when the
+// token never comes from an Authorization header.
+func firstAuthScheme(e extractors.Extractor) string {
+	if e.Source == extractors.SourceAuthHeader && e.AuthScheme != "" {
+		return e.AuthScheme
+	}
+	for _, chained := range e.Chain {
+		if scheme := firstAuthScheme(chained); scheme != "" {
+			return scheme
+		}
+	}
+	return ""
+}

--- a/v3/jwt/challenge.go
+++ b/v3/jwt/challenge.go
@@ -60,6 +60,11 @@ var challengeDescriptions = [...]string{
 	reasonUnverifiable:     "The access token could not be verified",
 }
 
+// bearerScheme is the authentication scheme RFC 6750 defines for a JWT, and the
+// one this middleware answers with wherever the token did not come from an
+// Authorization header naming some other scheme.
+const bearerScheme = "Bearer"
+
 // challenge holds the authentication challenge that has to accompany a rejected
 // request.
 //
@@ -80,7 +85,7 @@ func newChallenge(cfg Config) *challenge {
 		// The token does not travel in an Authorization header, but a 401 still
 		// has to name a scheme the client can retry with, and for a JWT that is
 		// the bearer scheme of RFC 6750.
-		schemes = []string{"Bearer"}
+		schemes = []string{bearerScheme}
 	}
 
 	ch := &challenge{
@@ -106,7 +111,7 @@ func render(schemes []string, realm, code, description string, reason challengeR
 		// The error parameters are defined for the bearer scheme only, and
 		// RFC 6750 Section 3.1 asks that a request which presented no usable
 		// credential be answered without naming an error about one.
-		if !strings.EqualFold(scheme, "Bearer") || reason == reasonMissing {
+		if !strings.EqualFold(scheme, bearerScheme) || reason == reasonMissing {
 			challenges = append(challenges, prefix)
 			continue
 		}
@@ -250,15 +255,32 @@ func describe(err error) challengeReason {
 // never comes from an Authorization header.
 func authSchemes(e extractors.Extractor) []string {
 	var schemes []string
+	add := func(scheme string) {
+		if !slices.ContainsFunc(schemes, func(known string) bool {
+			return strings.EqualFold(known, scheme)
+		}) {
+			schemes = append(schemes, scheme)
+		}
+	}
+
 	walkExtractor(&e, func(candidate *extractors.Extractor) bool {
-		if candidate.Source != extractors.SourceAuthHeader || candidate.AuthScheme == "" {
+		// A chain node carries a copy of its first extractor's source without
+		// that extractor's scheme, and the extractor itself is visited next, so
+		// reading the copy would announce a scheme in the wrong place.
+		if len(candidate.Chain) > 0 {
 			return false
 		}
-		if !slices.ContainsFunc(schemes, func(known string) bool {
-			return strings.EqualFold(known, candidate.AuthScheme)
-		}) {
-			schemes = append(schemes, candidate.AuthScheme)
+		if candidate.Source == extractors.SourceAuthHeader && candidate.AuthScheme != "" {
+			add(candidate.AuthScheme)
+			return false
 		}
+		// Everywhere else a JWT can travel - a query parameter, a cookie, a
+		// form field, a route parameter, an Authorization header with no scheme
+		// of its own, an extractor of the caller's - carries what RFC 6750
+		// calls a bearer token. A chain that mixes the two kinds has to offer
+		// both, or a client refused on the credential it did send is told to
+		// retry with a scheme it never used.
+		add(bearerScheme)
 		return false
 	})
 	return schemes

--- a/v3/jwt/challenge.go
+++ b/v3/jwt/challenge.go
@@ -130,6 +130,12 @@ func withError(prefix, code, description string) string {
 // returns a *fiber.Error - leaving the status to Fiber's own error handler - is
 // still recognised as a rejection. cause is the failure the handler was called
 // with, and picks the error_description.
+//
+// Those two are the whole of what can be read here. A handler that returns an
+// error of its own for fiber.Config.ErrorHandler to map to a status later is
+// answered without a challenge, because the status does not exist yet and the
+// same handler maps other errors to 403 and 500, where a challenge would be
+// wrong. The README tells such a handler to name the status itself.
 func (ch *challenge) apply(c fiber.Ctx, handlerErr, cause error) {
 	// A handler that returns a *fiber.Error leaves the status to Fiber's own
 	// error handler, and that code is the one the client will see; whatever is

--- a/v3/jwt/challenge.go
+++ b/v3/jwt/challenge.go
@@ -3,6 +3,7 @@ package jwtware
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
@@ -72,35 +73,46 @@ type challenge struct {
 	unauthorized []string
 }
 
-// newChallenge renders the challenges for the configured credential source.
+// newChallenge renders the challenges for the configured credential sources.
 func newChallenge(cfg Config) *challenge {
-	scheme := firstAuthScheme(cfg.Extractor)
-	if scheme == "" {
+	schemes := authSchemes(cfg.Extractor)
+	if len(schemes) == 0 {
 		// The token does not travel in an Authorization header, but a 401 still
 		// has to name a scheme the client can retry with, and for a JWT that is
 		// the bearer scheme of RFC 6750.
-		scheme = "Bearer"
+		schemes = []string{"Bearer"}
 	}
-	prefix := fmt.Sprintf("%s realm=%q", scheme, cfg.Realm)
 
 	ch := &challenge{
 		badRequest:   make([]string, len(challengeDescriptions)),
 		unauthorized: make([]string, len(challengeDescriptions)),
 	}
-	bearer := strings.EqualFold(scheme, "Bearer")
 	for reason, description := range challengeDescriptions {
+		ch.badRequest[reason] = render(schemes, cfg.Realm, errorInvalidRequest, description, challengeReason(reason))
+		ch.unauthorized[reason] = render(schemes, cfg.Realm, errorInvalidToken, description, challengeReason(reason))
+	}
+	return ch
+}
+
+// render builds the header value for one failure: one challenge per scheme the
+// extractor accepts, in the order a chain tries them. RFC 9110 Section 11.6.1
+// carries them as a comma separated list, so a client that cannot use the first
+// still sees the others.
+func render(schemes []string, realm, code, description string, reason challengeReason) string {
+	challenges := make([]string, 0, len(schemes))
+	for _, scheme := range schemes {
+		prefix := fmt.Sprintf("%s realm=%q", scheme, realm)
+
 		// The error parameters are defined for the bearer scheme only, and
 		// RFC 6750 Section 3.1 asks that a request which presented no usable
 		// credential be answered without naming an error about one.
-		if !bearer || challengeReason(reason) == reasonMissing {
-			ch.badRequest[reason] = prefix
-			ch.unauthorized[reason] = prefix
+		if !strings.EqualFold(scheme, "Bearer") || reason == reasonMissing {
+			challenges = append(challenges, prefix)
 			continue
 		}
-		ch.badRequest[reason] = withError(prefix, errorInvalidRequest, description)
-		ch.unauthorized[reason] = withError(prefix, errorInvalidToken, description)
+		challenges = append(challenges, withError(prefix, code, description))
 	}
-	return ch
+	return strings.Join(challenges, ", ")
 }
 
 // withError appends the RFC 6750 Section 3 error parameters to a challenge.
@@ -126,8 +138,10 @@ func (ch *challenge) apply(c fiber.Ctx, handlerErr, cause error) {
 	// reaches errors.As.
 	status := c.Response().StatusCode()
 	if handlerErr != nil {
+		// A typed-nil *fiber.Error satisfies errors.As without being something
+		// to dereference, and Fiber's own error handler tolerates one.
 		var fiberErr *fiber.Error
-		if errors.As(handlerErr, &fiberErr) {
+		if errors.As(handlerErr, &fiberErr) && fiberErr != nil {
 			status = fiberErr.Code
 		}
 	}
@@ -193,17 +207,21 @@ func describe(err error) challengeReason {
 	}
 }
 
-// firstAuthScheme reports the Authorization header scheme the extractor accepts,
-// walking a chain in the order it is tried. It returns an empty string when the
-// token never comes from an Authorization header.
-func firstAuthScheme(e extractors.Extractor) string {
-	var scheme string
+// authSchemes lists the Authorization header schemes the extractor accepts, in
+// the order a chain tries them and without repeats. It is empty when the token
+// never comes from an Authorization header.
+func authSchemes(e extractors.Extractor) []string {
+	var schemes []string
 	walkExtractor(&e, func(candidate *extractors.Extractor) bool {
-		if candidate.Source == extractors.SourceAuthHeader && candidate.AuthScheme != "" {
-			scheme = candidate.AuthScheme
-			return true
+		if candidate.Source != extractors.SourceAuthHeader || candidate.AuthScheme == "" {
+			return false
+		}
+		if !slices.ContainsFunc(schemes, func(known string) bool {
+			return strings.EqualFold(known, candidate.AuthScheme)
+		}) {
+			schemes = append(schemes, candidate.AuthScheme)
 		}
 		return false
 	})
-	return scheme
+	return schemes
 }

--- a/v3/jwt/challenge.go
+++ b/v3/jwt/challenge.go
@@ -124,7 +124,8 @@ func withError(prefix, code, description string) string {
 }
 
 // apply adds the challenge to a response that rejected the request, unless the
-// error handler already wrote one of its own.
+// error handler already wrote one of its own. A challenge inherited from an
+// earlier middleware is kept and this one added beside it.
 //
 // handlerErr is what the error handler returned, so that a handler which only
 // returns a *fiber.Error - leaving the status to Fiber's own error handler - is
@@ -136,7 +137,7 @@ func withError(prefix, code, description string) string {
 // answered without a challenge, because the status does not exist yet and the
 // same handler maps other errors to 403 and 500, where a challenge would be
 // wrong. The README tells such a handler to name the status itself.
-func (ch *challenge) apply(c fiber.Ctx, handlerErr, cause error) {
+func (ch *challenge) apply(c fiber.Ctx, handlerErr, cause error, inherited challengeHeaders) {
 	// A handler that returns a *fiber.Error leaves the status to Fiber's own
 	// error handler, and that code is the one the client will see; whatever is
 	// on the response right now may belong to a middleware that ran earlier.
@@ -166,14 +167,45 @@ func (ch *challenge) apply(c fiber.Ctx, handlerErr, cause error) {
 		return
 	}
 
-	// A challenge already on the response belongs to whoever put it there: an
-	// error handler of the caller's, or another authentication middleware that
-	// ran before this one and whose scheme the client may still be able to use.
-	if len(c.Response().Header.Peek(header)) > 0 {
-		return
+	// Who put a challenge there decides what happens to it.
+	switch existing := string(c.Response().Header.Peek(header)); {
+	case existing == "":
+		c.Set(header, values[describe(cause)])
+	case existing == inherited.get(header):
+		// Another authentication middleware ran before this one and its scheme
+		// may still be one the client can use. RFC 9110 Section 11.6.1 lets the
+		// field carry more than one challenge, and a client refused for a bad
+		// token is owed the reason, so this one goes beside it rather than
+		// instead of it.
+		c.Set(header, existing+", "+values[describe(cause)])
+	default:
+		// The error handler wrote this for this rejection. It is the answer.
 	}
+}
 
-	c.Set(header, values[describe(cause)])
+// challengeHeaders is the pair of challenge headers as they stood before an
+// error handler ran.
+type challengeHeaders struct {
+	wwwAuthenticate   string
+	proxyAuthenticate string
+}
+
+// inheritedChallenges reads them off the response. Peeking an absent header
+// yields an empty slice, which converts to "" without allocating, so the usual
+// rejection - nothing there to inherit - stays allocation free.
+func inheritedChallenges(c fiber.Ctx) challengeHeaders {
+	return challengeHeaders{
+		wwwAuthenticate:   string(c.Response().Header.Peek(fiber.HeaderWWWAuthenticate)),
+		proxyAuthenticate: string(c.Response().Header.Peek(fiber.HeaderProxyAuthenticate)),
+	}
+}
+
+// get returns the one belonging to the named header.
+func (h challengeHeaders) get(header string) string {
+	if header == fiber.HeaderProxyAuthenticate {
+		return h.proxyAuthenticate
+	}
+	return h.wwwAuthenticate
 }
 
 // describe classifies a failure so that the challenge can say what was wrong

--- a/v3/jwt/challenge.go
+++ b/v3/jwt/challenge.go
@@ -119,11 +119,13 @@ func withError(prefix, code, description string) string {
 // still recognised as a rejection. cause is the failure the handler was called
 // with, and picks the error_description.
 func (ch *challenge) apply(c fiber.Ctx, handlerErr, cause error) {
+	// A handler that returns a *fiber.Error leaves the status to Fiber's own
+	// error handler, and that code is the one the client will see; whatever is
+	// on the response right now may belong to a middleware that ran earlier.
+	// A handler that wrote its response returns nil, so the common path never
+	// reaches errors.As.
 	status := c.Response().StatusCode()
-	switch status {
-	case fiber.StatusBadRequest, fiber.StatusUnauthorized, fiber.StatusProxyAuthRequired:
-		// The handler wrote the status itself, so it needs no interpreting.
-	default:
+	if handlerErr != nil {
 		var fiberErr *fiber.Error
 		if errors.As(handlerErr, &fiberErr) {
 			status = fiberErr.Code
@@ -191,15 +193,28 @@ func describe(err error) challengeReason {
 	}
 }
 
+// maxExtractorDepth bounds the walks over an extractor's Chain. The metadata is
+// the caller's to build, and a chain that refers back to itself - which the
+// extractors package guards against in its own traversal - would otherwise
+// recurse until the stack ran out.
+const maxExtractorDepth = 32
+
 // firstAuthScheme reports the Authorization header scheme the extractor accepts,
 // walking a chain in the order it is tried. It returns an empty string when the
 // token never comes from an Authorization header.
 func firstAuthScheme(e extractors.Extractor) string {
+	return authSchemeAt(e, 0)
+}
+
+func authSchemeAt(e extractors.Extractor, depth int) string {
+	if depth > maxExtractorDepth {
+		return ""
+	}
 	if e.Source == extractors.SourceAuthHeader && e.AuthScheme != "" {
 		return e.AuthScheme
 	}
 	for _, chained := range e.Chain {
-		if scheme := firstAuthScheme(chained); scheme != "" {
+		if scheme := authSchemeAt(chained, depth+1); scheme != "" {
 			return scheme
 		}
 	}

--- a/v3/jwt/challenge.go
+++ b/v3/jwt/challenge.go
@@ -193,30 +193,17 @@ func describe(err error) challengeReason {
 	}
 }
 
-// maxExtractorDepth bounds the walks over an extractor's Chain. The metadata is
-// the caller's to build, and a chain that refers back to itself - which the
-// extractors package guards against in its own traversal - would otherwise
-// recurse until the stack ran out.
-const maxExtractorDepth = 32
-
 // firstAuthScheme reports the Authorization header scheme the extractor accepts,
 // walking a chain in the order it is tried. It returns an empty string when the
 // token never comes from an Authorization header.
 func firstAuthScheme(e extractors.Extractor) string {
-	return authSchemeAt(e, 0)
-}
-
-func authSchemeAt(e extractors.Extractor, depth int) string {
-	if depth > maxExtractorDepth {
-		return ""
-	}
-	if e.Source == extractors.SourceAuthHeader && e.AuthScheme != "" {
-		return e.AuthScheme
-	}
-	for _, chained := range e.Chain {
-		if scheme := authSchemeAt(chained, depth+1); scheme != "" {
-			return scheme
+	var scheme string
+	walkExtractor(&e, func(candidate *extractors.Extractor) bool {
+		if candidate.Source == extractors.SourceAuthHeader && candidate.AuthScheme != "" {
+			scheme = candidate.AuthScheme
+			return true
 		}
-	}
-	return ""
+		return false
+	})
+	return scheme
 }

--- a/v3/jwt/challenge.go
+++ b/v3/jwt/challenge.go
@@ -70,13 +70,10 @@ var challengeDescriptions = [...]string{
 type challenge struct {
 	badRequest   []string
 	unauthorized []string
-	// keepExisting records that the error handler is the caller's, and so may
-	// have written a challenge of its own that must not be overwritten.
-	keepExisting bool
 }
 
 // newChallenge renders the challenges for the configured credential source.
-func newChallenge(cfg Config, keepExisting bool) *challenge {
+func newChallenge(cfg Config) *challenge {
 	scheme := firstAuthScheme(cfg.Extractor)
 	if scheme == "" {
 		// The token does not travel in an Authorization header, but a 401 still
@@ -89,11 +86,13 @@ func newChallenge(cfg Config, keepExisting bool) *challenge {
 	ch := &challenge{
 		badRequest:   make([]string, len(challengeDescriptions)),
 		unauthorized: make([]string, len(challengeDescriptions)),
-		keepExisting: keepExisting,
 	}
+	bearer := strings.EqualFold(scheme, "Bearer")
 	for reason, description := range challengeDescriptions {
-		// The error parameters are defined for the bearer scheme only.
-		if !strings.EqualFold(scheme, "Bearer") {
+		// The error parameters are defined for the bearer scheme only, and
+		// RFC 6750 Section 3.1 asks that a request which presented no usable
+		// credential be answered without naming an error about one.
+		if !bearer || challengeReason(reason) == reasonMissing {
 			ch.badRequest[reason] = prefix
 			ch.unauthorized[reason] = prefix
 			continue
@@ -102,12 +101,6 @@ func newChallenge(cfg Config, keepExisting bool) *challenge {
 		ch.unauthorized[reason] = withError(prefix, errorInvalidToken, description)
 	}
 	return ch
-}
-
-// customErrorHandler reports whether the caller supplied the error handler. The
-// default one never writes a challenge, so its response needs no inspecting.
-func customErrorHandler(config []Config) bool {
-	return len(config) > 0 && config[0].ErrorHandler != nil
 }
 
 // withError appends the RFC 6750 Section 3 error parameters to a challenge.
@@ -151,7 +144,10 @@ func (ch *challenge) apply(c fiber.Ctx, handlerErr, cause error) {
 		return
 	}
 
-	if ch.keepExisting && len(c.Response().Header.Peek(header)) > 0 {
+	// A challenge already on the response belongs to whoever put it there: an
+	// error handler of the caller's, or another authentication middleware that
+	// ran before this one and whose scheme the client may still be able to use.
+	if len(c.Response().Header.Peek(header)) > 0 {
 		return
 	}
 

--- a/v3/jwt/config.go
+++ b/v3/jwt/config.go
@@ -246,6 +246,8 @@ func validAlgorithms(config []Config) []string {
 	}
 }
 
+// multiKeyfunc resolves keys against several JWK Set URLs at once, giving each
+// of them the same refresh policy and taking the first key that matches.
 func multiKeyfunc(givenKeys map[string]keyfunc.GivenKey, jwkSetURLs []string) (jwt.Keyfunc, error) {
 	opts := keyfuncOptions(givenKeys)
 	multiple := make(map[string]keyfunc.Options, len(jwkSetURLs))
@@ -262,6 +264,9 @@ func multiKeyfunc(givenKeys map[string]keyfunc.GivenKey, jwkSetURLs []string) (j
 	return multi.Keyfunc, nil
 }
 
+// keyfuncOptions is the refresh policy every JWK Set in a configuration is
+// fetched under: hourly in the background, rate limited, and re-fetched on a
+// key ID the cache has not seen.
 func keyfuncOptions(givenKeys map[string]keyfunc.GivenKey) keyfunc.Options {
 	return keyfunc.Options{
 		GivenKeys: givenKeys,
@@ -275,6 +280,10 @@ func keyfuncOptions(givenKeys map[string]keyfunc.GivenKey) keyfunc.Options {
 	}
 }
 
+// signingKeyFunc returns the key function for a single configured key. A key
+// that names an algorithm refuses a token signed with any other, wrapping
+// ErrJWTAlg so callers can match on it; this is the check RFC 8725 Section 3.1
+// asks for, and validAlgorithms hoists it into the parser where it can.
 func signingKeyFunc(key SigningKey) jwt.Keyfunc {
 	return func(token *jwt.Token) (interface{}, error) {
 		if key.JWTAlg != "" {

--- a/v3/jwt/config.go
+++ b/v3/jwt/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/MicahParks/keyfunc/v2"
@@ -36,6 +37,14 @@ type Config struct {
 	// It allows customization of JWT error responses.
 	// Optional. Default: 401 Invalid or expired JWT
 	ErrorHandler fiber.ErrorHandler
+
+	// Realm names the protected area in the "WWW-Authenticate" challenge that
+	// RFC 9110 Section 15.5.2 and RFC 6750 Section 3 require on a rejected
+	// request. The challenge is only added when the response does not already
+	// carry one, so an ErrorHandler may write its own instead.
+	//
+	// Optional. Default: "Restricted"
+	Realm string
 
 	// SigningKey is the primary key used to validate tokens.
 	// Used as a fallback if SigningKeys is empty.
@@ -75,8 +84,25 @@ type Config struct {
 	JWKSetURLs []string
 
 	// ParserOptions provides additional options for JWT parsing.
+	//
+	// This is where per-application claim validation belongs, such as
+	// jwt.WithAudience or jwt.WithIssuer: RFC 7519 Section 4.1.3 requires a JWT
+	// whose "aud" claim does not identify this application to be rejected, and
+	// only the application knows which value that is.
+	//
 	// Optional. Default: nil
 	ParserOptions []jwt.ParserOption
+
+	// KnownCriticalHeaders lists the JWS "crit" header parameters this
+	// application understands and processes itself, for example by reading them
+	// off the token returned by FromContext.
+	//
+	// RFC 7515 Section 4.1.11 requires a token that marks a header parameter
+	// critical to be rejected unless the recipient understands that parameter,
+	// so by default every such token is rejected.
+	//
+	// Optional. Default: nil
+	KnownCriticalHeaders []string
 }
 
 // SigningKey holds information about the recognized cryptographic keys used to sign JWTs by this program.
@@ -107,11 +133,15 @@ func makeCfg(config []Config) (cfg Config) {
 			if errors.Is(err, extractors.ErrNotFound) {
 				return c.Status(fiber.StatusBadRequest).SendString(ErrMissingToken.Error())
 			}
-			if e, ok := err.(*fiber.Error); ok {
-				return c.Status(e.Code).SendString(e.Message)
+			var fiberErr *fiber.Error
+			if errors.As(err, &fiberErr) {
+				return c.Status(fiberErr.Code).SendString(fiberErr.Message)
 			}
 			return c.Status(fiber.StatusUnauthorized).SendString("Invalid or expired JWT")
 		}
+	}
+	if cfg.Realm == "" {
+		cfg.Realm = "Restricted"
 	}
 	if cfg.SigningKey.Key == nil && len(cfg.SigningKeys) == 0 && len(cfg.JWKSetURLs) == 0 && cfg.KeyFunc == nil {
 		panic("Fiber: JWT middleware configuration: At least one of the following is required: KeyFunc, JWKSetURLs, SigningKeys, or SigningKey.")
@@ -166,7 +196,54 @@ func makeCfg(config []Config) (cfg Config) {
 		}
 	}
 
+	// RFC 7515 Section 4.1.11 requires critical header parameters to be
+	// understood before the JWS is accepted, and github.com/golang-jwt/jwt does
+	// not check them. The guard wraps a caller supplied key function too, so the
+	// rule holds however the keys are resolved.
+	cfg.KeyFunc = criticalHeaderGuard(cfg.KeyFunc, knownCriticalHeaders(cfg.KnownCriticalHeaders))
+
 	return cfg
+}
+
+// validAlgorithms reports the "alg" header values the configuration accepts, so
+// that the parser can reject every other algorithm before a key is looked up.
+//
+// RFC 8725 Section 3.1 asks a recipient to decide which algorithms are
+// acceptable from its own configuration rather than from the token. The key
+// functions below already refuse a key whose algorithm does not match, and
+// hoisting the check into the parser makes it happen earlier and uniformly.
+// Only algorithms the caller pinned are returned: a configuration that does not
+// name one keeps whatever the key material allows.
+func validAlgorithms(config []Config) []string {
+	if len(config) == 0 {
+		return nil
+	}
+	cfg := config[0]
+
+	switch {
+	case cfg.KeyFunc != nil, len(cfg.JWKSetURLs) > 0:
+		// The caller's key function, or the remote key set, decides which
+		// algorithms are acceptable. The configuration does not know them.
+		return nil
+	case len(cfg.SigningKeys) > 0:
+		algorithms := make([]string, 0, len(cfg.SigningKeys))
+		for _, key := range cfg.SigningKeys {
+			if key.JWTAlg == "" {
+				// A single unrestricted key leaves the whole set unrestricted.
+				return nil
+			}
+			if !slices.Contains(algorithms, key.JWTAlg) {
+				algorithms = append(algorithms, key.JWTAlg)
+			}
+		}
+		// Map iteration order is random; keep the parser's view stable.
+		slices.Sort(algorithms)
+		return algorithms
+	case cfg.SigningKey.JWTAlg != "":
+		return []string{cfg.SigningKey.JWTAlg}
+	default:
+		return nil
+	}
 }
 
 func multiKeyfunc(givenKeys map[string]keyfunc.GivenKey, jwkSetURLs []string) (jwt.Keyfunc, error) {
@@ -203,10 +280,10 @@ func signingKeyFunc(key SigningKey) jwt.Keyfunc {
 		if key.JWTAlg != "" {
 			alg, ok := token.Header["alg"].(string)
 			if !ok {
-				return nil, fmt.Errorf("unexpected jwt signing method: expected: %q: got: missing or unexpected JSON type", key.JWTAlg)
+				return nil, fmt.Errorf("%w: unexpected jwt signing method: expected: %q: got: missing or unexpected JSON type", ErrJWTAlg, key.JWTAlg)
 			}
 			if alg != key.JWTAlg {
-				return nil, fmt.Errorf("unexpected jwt signing method: expected: %q: got: %q", key.JWTAlg, alg)
+				return nil, fmt.Errorf("%w: unexpected jwt signing method: expected: %q: got: %q", ErrJWTAlg, key.JWTAlg, alg)
 			}
 		}
 		return key.Key, nil

--- a/v3/jwt/config.go
+++ b/v3/jwt/config.go
@@ -101,6 +101,11 @@ type Config struct {
 	// critical to be rejected unless the recipient understands that parameter,
 	// so by default every such token is rejected.
 	//
+	// An extension that changes how the JWS is parsed or verified cannot be
+	// listed here, because the parser has already decoded and verified the
+	// token by the time the application sees it. "b64" (RFC 7797) is the one
+	// such extension defined for JWS, and naming it panics at New.
+	//
 	// Optional. Default: nil
 	KnownCriticalHeaders []string
 }
@@ -133,8 +138,11 @@ func makeCfg(config []Config) (cfg Config) {
 			if errors.Is(err, extractors.ErrNotFound) {
 				return c.Status(fiber.StatusBadRequest).SendString(ErrMissingToken.Error())
 			}
+			// A typed-nil *fiber.Error satisfies errors.As without being
+			// something to dereference; leave it to Fiber, as its own error
+			// handler does.
 			var fiberErr *fiber.Error
-			if errors.As(err, &fiberErr) {
+			if errors.As(err, &fiberErr) && fiberErr != nil {
 				return c.Status(fiberErr.Code).SendString(fiberErr.Message)
 			}
 			return c.Status(fiber.StatusUnauthorized).SendString("Invalid or expired JWT")
@@ -193,6 +201,15 @@ func makeCfg(config []Config) (cfg Config) {
 			}
 		} else {
 			cfg.KeyFunc = signingKeyFunc(cfg.SigningKey)
+		}
+	}
+
+	// An extension that changes how the JWS is parsed cannot be handled by the
+	// application, whatever it declares: the parser has already decoded the
+	// token by the time anything of yours sees it.
+	for _, name := range cfg.KnownCriticalHeaders {
+		if _, unprocessable := unprocessableCriticalHeaders[name]; unprocessable {
+			panic(fmt.Sprintf("Fiber: JWT middleware configuration: KnownCriticalHeaders cannot contain %q, which changes how the JWS is parsed; tokens carrying it are always rejected", name))
 		}
 	}
 

--- a/v3/jwt/config_test.go
+++ b/v3/jwt/config_test.go
@@ -265,13 +265,20 @@ func TestCheckCriticalHeaders(t *testing.T) {
 	}
 }
 
-func TestFirstAuthScheme(t *testing.T) {
+func TestAuthSchemes(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, "Bearer", firstAuthScheme(extractors.FromAuthHeader("Bearer")))
-	require.Empty(t, firstAuthScheme(extractors.FromCookie("token")))
-	require.Equal(t, "Bearer", firstAuthScheme(extractors.Chain(
+	require.Equal(t, []string{"Bearer"}, authSchemes(extractors.FromAuthHeader("Bearer")))
+	require.Empty(t, authSchemes(extractors.FromCookie("token")))
+	require.Equal(t, []string{"Bearer"}, authSchemes(extractors.Chain(
 		extractors.FromCookie("token"),
 		extractors.FromAuthHeader("Bearer"),
+	)))
+
+	// Every scheme the chain accepts, in the order it tries them, without repeats.
+	require.Equal(t, []string{"Basic", "Bearer"}, authSchemes(extractors.Chain(
+		extractors.FromAuthHeader("Basic"),
+		extractors.FromAuthHeader("Bearer"),
+		extractors.FromAuthHeader("bearer"),
 	)))
 }

--- a/v3/jwt/config_test.go
+++ b/v3/jwt/config_test.go
@@ -270,6 +270,14 @@ func TestCheckCriticalHeaders(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			// A name JOSE already defines is not an extension, whichever
+			// specification defines it and whichever message type it is for.
+			name:    "JWA header parameter declared understood",
+			header:  map[string]any{"alg": HS256, "crit": []any{"epk"}, "epk": "v"},
+			known:   []string{"epk"},
+			wantErr: true,
+		},
+		{
 			// RFC 7797 changes how the payload is encoded, which the parser has
 			// already settled; declaring it understood must not help.
 			name:    "b64 declared understood",

--- a/v3/jwt/config_test.go
+++ b/v3/jwt/config_test.go
@@ -142,3 +142,136 @@ func TestPanicOnUnsupportedJWKSetURLScheme(t *testing.T) {
 	})
 	require.Panics(t, func() { makeCfg(config) })
 }
+
+func TestValidAlgorithms(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config []Config
+		want   []string
+	}{
+		{
+			name:   "no configuration",
+			config: nil,
+			want:   nil,
+		},
+		{
+			name:   "single key with an algorithm",
+			config: []Config{{SigningKey: SigningKey{JWTAlg: HS256, Key: []byte("secret")}}},
+			want:   []string{HS256},
+		},
+		{
+			name:   "single key without an algorithm",
+			config: []Config{{SigningKey: SigningKey{Key: []byte("secret")}}},
+			want:   nil,
+		},
+		{
+			name: "key set with algorithms",
+			config: []Config{{SigningKeys: map[string]SigningKey{
+				"one": {JWTAlg: HS512, Key: []byte("a")},
+				"two": {JWTAlg: HS256, Key: []byte("b")},
+			}}},
+			want: []string{HS256, HS512},
+		},
+		{
+			name: "key set with a duplicate algorithm",
+			config: []Config{{SigningKeys: map[string]SigningKey{
+				"one": {JWTAlg: HS256, Key: []byte("a")},
+				"two": {JWTAlg: HS256, Key: []byte("b")},
+			}}},
+			want: []string{HS256},
+		},
+		{
+			name: "one unrestricted key leaves the set unrestricted",
+			config: []Config{{SigningKeys: map[string]SigningKey{
+				"one": {JWTAlg: HS256, Key: []byte("a")},
+				"two": {Key: []byte("b")},
+			}}},
+			want: nil,
+		},
+		{
+			name: "a remote key set decides for itself",
+			config: []Config{{
+				JWKSetURLs: []string{"https://example.com/jwks.json"},
+				SigningKey: SigningKey{JWTAlg: HS256, Key: []byte("secret")},
+			}},
+			want: nil,
+		},
+		{
+			name: "a caller's key function decides for itself",
+			config: []Config{{
+				KeyFunc:    func(*jwt.Token) (any, error) { return nil, nil },
+				SigningKey: SigningKey{JWTAlg: HS256, Key: []byte("secret")},
+			}},
+			want: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, test.want, validAlgorithms(test.config))
+		})
+	}
+}
+
+func TestCheckCriticalHeaders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		header  map[string]any
+		name    string
+		known   []string
+		wantErr bool
+	}{
+		{
+			name:   "no crit header",
+			header: map[string]any{"alg": HS256},
+		},
+		{
+			name:   "understood extension",
+			header: map[string]any{"alg": HS256, "crit": []any{"ext"}, "ext": true},
+			known:  []string{"ext"},
+		},
+		{
+			name:    "unknown extension",
+			header:  map[string]any{"alg": HS256, "crit": []any{"ext"}, "ext": true},
+			wantErr: true,
+		},
+		{
+			name:    "empty list",
+			header:  map[string]any{"alg": HS256, "crit": []any{}},
+			wantErr: true,
+		},
+		{
+			name:    "wrong type",
+			header:  map[string]any{"alg": HS256, "crit": "ext", "ext": true},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := checkCriticalHeaders(test.header, knownCriticalHeaders(test.known))
+			if test.wantErr {
+				require.ErrorIs(t, err, ErrCriticalHeader)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestFirstAuthScheme(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "Bearer", firstAuthScheme(extractors.FromAuthHeader("Bearer")))
+	require.Empty(t, firstAuthScheme(extractors.FromCookie("token")))
+	require.Equal(t, "Bearer", firstAuthScheme(extractors.Chain(
+		extractors.FromCookie("token"),
+		extractors.FromAuthHeader("Bearer"),
+	)))
+}

--- a/v3/jwt/config_test.go
+++ b/v3/jwt/config_test.go
@@ -314,17 +314,34 @@ func TestCheckCriticalHeaders(t *testing.T) {
 func TestAuthSchemes(t *testing.T) {
 	t.Parallel()
 
+	// An Authorization header names its own scheme; everywhere else a JWT can
+	// travel carries a bearer token.
 	require.Equal(t, []string{"Bearer"}, authSchemes(extractors.FromAuthHeader("Bearer")))
-	require.Empty(t, authSchemes(extractors.FromCookie("token")))
-	require.Equal(t, []string{"Bearer"}, authSchemes(extractors.Chain(
-		extractors.FromCookie("token"),
-		extractors.FromAuthHeader("Bearer"),
-	)))
+	require.Equal(t, []string{"Basic"}, authSchemes(extractors.FromAuthHeader("Basic")))
+	require.Equal(t, []string{"Bearer"}, authSchemes(extractors.FromCookie("token")))
+	require.Equal(t, []string{"Bearer"}, authSchemes(extractors.FromQuery("token")))
 
 	// Every scheme the chain accepts, in the order it tries them, without repeats.
 	require.Equal(t, []string{"Basic", "Bearer"}, authSchemes(extractors.Chain(
 		extractors.FromAuthHeader("Basic"),
 		extractors.FromAuthHeader("Bearer"),
 		extractors.FromAuthHeader("bearer"),
+	)))
+
+	// A chain that mixes the two kinds offers both, in the order it tries them.
+	require.Equal(t, []string{"Basic", "Bearer"}, authSchemes(extractors.Chain(
+		extractors.FromAuthHeader("Basic"),
+		extractors.FromQuery("token"),
+	)))
+	require.Equal(t, []string{"Bearer", "Basic"}, authSchemes(extractors.Chain(
+		extractors.FromQuery("token"),
+		extractors.FromAuthHeader("Basic"),
+	)))
+
+	// The chain node copies its first extractor's source but not its scheme, so
+	// reading it would put a bearer challenge in front of the real one.
+	require.Equal(t, []string{"Basic", "Negotiate"}, authSchemes(extractors.Chain(
+		extractors.FromAuthHeader("Basic"),
+		extractors.FromAuthHeader("Negotiate"),
 	)))
 }

--- a/v3/jwt/config_test.go
+++ b/v3/jwt/config_test.go
@@ -143,6 +143,22 @@ func TestPanicOnUnsupportedJWKSetURLScheme(t *testing.T) {
 	require.Panics(t, func() { makeCfg(config) })
 }
 
+// TestPanicOnUnprocessableCriticalHeader refuses a configuration that claims to
+// handle an extension only the parser could have handled.
+func TestPanicOnUnprocessableCriticalHeader(t *testing.T) {
+	t.Parallel()
+
+	config := []Config{{
+		SigningKey:           SigningKey{JWTAlg: HS256, Key: []byte("secret")},
+		KnownCriticalHeaders: []string{"b64"},
+	}}
+	require.PanicsWithValue(
+		t,
+		`Fiber: JWT middleware configuration: KnownCriticalHeaders cannot contain "b64", which changes how the JWS is parsed; tokens carrying it are always rejected`,
+		func() { makeCfg(config) },
+	)
+}
+
 // TestValidAlgorithms pins which configurations produce a pinned algorithm list
 // for the parser, and which leave the key material to decide.
 func TestValidAlgorithms(t *testing.T) {
@@ -251,6 +267,22 @@ func TestCheckCriticalHeaders(t *testing.T) {
 		{
 			name:    "wrong type",
 			header:  map[string]any{"alg": HS256, "crit": "ext", "ext": true},
+			wantErr: true,
+		},
+		{
+			// RFC 7797 changes how the payload is encoded, which the parser has
+			// already settled; declaring it understood must not help.
+			name:    "b64 declared understood",
+			header:  map[string]any{"alg": HS256, "crit": []any{"b64"}, "b64": false},
+			known:   []string{"b64"},
+			wantErr: true,
+		},
+		{
+			// RFC 7797 Section 6 requires the crit entry, so this token is not
+			// conformant - but the payload is still encoded the way the parser
+			// does not expect.
+			name:    "b64 without the crit entry",
+			header:  map[string]any{"alg": HS256, "b64": false},
 			wantErr: true,
 		},
 	}

--- a/v3/jwt/config_test.go
+++ b/v3/jwt/config_test.go
@@ -143,6 +143,8 @@ func TestPanicOnUnsupportedJWKSetURLScheme(t *testing.T) {
 	require.Panics(t, func() { makeCfg(config) })
 }
 
+// TestValidAlgorithms pins which configurations produce a pinned algorithm list
+// for the parser, and which leave the key material to decide.
 func TestValidAlgorithms(t *testing.T) {
 	t.Parallel()
 
@@ -216,6 +218,8 @@ func TestValidAlgorithms(t *testing.T) {
 	}
 }
 
+// TestCheckCriticalHeaders walks the crit values RFC 7515 Section 4.1.11 admits
+// and the malformed ones it does not.
 func TestCheckCriticalHeaders(t *testing.T) {
 	t.Parallel()
 
@@ -265,6 +269,8 @@ func TestCheckCriticalHeaders(t *testing.T) {
 	}
 }
 
+// TestAuthSchemes collects the schemes an extractor answers for, in the order
+// the challenge lists them.
 func TestAuthSchemes(t *testing.T) {
 	t.Parallel()
 

--- a/v3/jwt/crit.go
+++ b/v3/jwt/crit.go
@@ -32,6 +32,20 @@ var joseHeaderParameters = map[string]struct{}{
 	"crit":     {},
 }
 
+// unprocessableCriticalHeaders names the critical extensions that no
+// configuration can declare understood, because they change how the JWS itself
+// is parsed or verified and this middleware only sees a token after the parser
+// has done both.
+//
+// "b64" (RFC 7797) is the one such extension defined for JWS. With "b64": false
+// the payload travels unencoded and the signature covers it verbatim;
+// github.com/golang-jwt/jwt does not implement that and always base64url-decodes
+// the second segment. Honouring a declaration would therefore let it read the
+// decoding of a signed message as the claims of a token nobody issued.
+var unprocessableCriticalHeaders = map[string]struct{}{
+	"b64": {},
+}
+
 // criticalHeaderGuard wraps a key function with the "crit" check of RFC 7515
 // Section 4.1.11, which github.com/golang-jwt/jwt does not perform.
 //
@@ -51,6 +65,17 @@ func criticalHeaderGuard(next jwt.Keyfunc, known map[string]struct{}) jwt.Keyfun
 // checkCriticalHeaders reports whether the JOSE header may be processed, given
 // the set of critical extensions the application declared it understands.
 func checkCriticalHeaders(header map[string]any, known map[string]struct{}) error {
+	// These are refused on sight, whatever their value and whether or not
+	// "crit" names them: RFC 7797 Section 6 requires the "crit" entry, but a
+	// producer that leaves it out still hands the parser a payload it may read
+	// the wrong way round. Running before "crit" is looked at is also what keeps
+	// a declaration from getting past the check.
+	for name := range unprocessableCriticalHeaders {
+		if _, present := header[name]; present {
+			return fmt.Errorf(`%w: the %q header parameter changes how the JWS is parsed and cannot be honoured here`, ErrCriticalHeader, name)
+		}
+	}
+
 	value, ok := header["crit"]
 	if !ok {
 		return nil

--- a/v3/jwt/crit.go
+++ b/v3/jwt/crit.go
@@ -15,10 +15,20 @@ import (
 // that violates the rules producers have to follow.
 var ErrCriticalHeader = errors.New("the JWT header contains an unsupported critical extension")
 
-// joseHeaderParameters holds the Header Parameter names RFC 7515 and RFC 7518
-// define for use with JWS. RFC 7515 Section 4.1.11 forbids listing any of them
-// in "crit", so finding one there invalidates the token.
+// joseHeaderParameters holds the Header Parameter names the core JOSE
+// specifications already define: RFC 7515 for JWS, RFC 7516 and RFC 7518 for
+// JWE. RFC 7515 Section 4.1.11 forbids a producer from listing any of them in
+// "crit", which only ever names extensions, so finding one there invalidates
+// the token.
+//
+// The JWE names are here because a name JOSE has already defined is not an
+// extension whatever the message is, and one of them in the "crit" list of a
+// JWS is a producer with a bug rather than an extension a recipient could
+// understand. "b64" (RFC 7797) is a real extension and belongs in "crit", so it
+// is not listed here; unprocessableCriticalHeaders refuses it for its own
+// reason.
 var joseHeaderParameters = map[string]struct{}{
+	// RFC 7515 Section 4.1, for JWS.
 	"alg":      {},
 	"jku":      {},
 	"jwk":      {},
@@ -30,6 +40,17 @@ var joseHeaderParameters = map[string]struct{}{
 	"typ":      {},
 	"cty":      {},
 	"crit":     {},
+	// RFC 7516 Section 4.1, for JWE.
+	"enc": {},
+	"zip": {},
+	// RFC 7518 Sections 4.6.1, 4.7.1 and 4.8.1, for JWE key management.
+	"epk": {},
+	"apu": {},
+	"apv": {},
+	"iv":  {},
+	"tag": {},
+	"p2s": {},
+	"p2c": {},
 }
 
 // unprocessableCriticalHeaders names the critical extensions that no

--- a/v3/jwt/crit.go
+++ b/v3/jwt/crit.go
@@ -1,0 +1,103 @@
+package jwtware
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// ErrCriticalHeader is returned when a token carries a "crit" (critical) header
+// parameter that this middleware is not allowed to ignore.
+//
+// RFC 7515 Section 4.1.11 requires a recipient to reject a JWS whose "crit" list
+// names an extension it does not understand, and lets it reject a "crit" value
+// that violates the rules producers have to follow.
+var ErrCriticalHeader = errors.New("the JWT header contains an unsupported critical extension")
+
+// joseHeaderParameters holds the Header Parameter names RFC 7515 and RFC 7518
+// define for use with JWS. RFC 7515 Section 4.1.11 forbids listing any of them
+// in "crit", so finding one there invalidates the token.
+var joseHeaderParameters = map[string]struct{}{
+	"alg":      {},
+	"jku":      {},
+	"jwk":      {},
+	"kid":      {},
+	"x5u":      {},
+	"x5c":      {},
+	"x5t":      {},
+	"x5t#S256": {},
+	"typ":      {},
+	"cty":      {},
+	"crit":     {},
+}
+
+// criticalHeaderGuard wraps a key function with the "crit" check of RFC 7515
+// Section 4.1.11, which github.com/golang-jwt/jwt does not perform.
+//
+// Key lookup is the last hook the parser offers before it verifies the
+// signature, which is where step 5 of the validation procedure in RFC 7515
+// Section 5.2 belongs. Tokens without a "crit" header - which is every token in
+// practice - pay one map lookup for the check.
+func criticalHeaderGuard(next jwt.Keyfunc, known map[string]struct{}) jwt.Keyfunc {
+	return func(token *jwt.Token) (any, error) {
+		if err := checkCriticalHeaders(token.Header, known); err != nil {
+			return nil, err
+		}
+		return next(token)
+	}
+}
+
+// checkCriticalHeaders reports whether the JOSE header may be processed, given
+// the set of critical extensions the application declared it understands.
+func checkCriticalHeaders(header map[string]any, known map[string]struct{}) error {
+	value, ok := header["crit"]
+	if !ok {
+		return nil
+	}
+
+	// RFC 7515 Section 4.1.11: the value is an array of strings, and the empty
+	// array is not a legal value.
+	names, ok := value.([]any)
+	if !ok || len(names) == 0 {
+		return fmt.Errorf(`%w: "crit" must be a non-empty array of header parameter names`, ErrCriticalHeader)
+	}
+
+	seen := make(map[string]struct{}, len(names))
+	for _, entry := range names {
+		name, ok := entry.(string)
+		if !ok {
+			return fmt.Errorf(`%w: "crit" must only contain header parameter names`, ErrCriticalHeader)
+		}
+		if _, duplicate := seen[name]; duplicate {
+			return fmt.Errorf(`%w: "crit" lists %q more than once`, ErrCriticalHeader, name)
+		}
+		seen[name] = struct{}{}
+
+		if _, reserved := joseHeaderParameters[name]; reserved {
+			return fmt.Errorf(`%w: "crit" must not list the registered header parameter %q`, ErrCriticalHeader, name)
+		}
+		if _, present := header[name]; !present {
+			return fmt.Errorf(`%w: "crit" lists %q, which the header does not contain`, ErrCriticalHeader, name)
+		}
+		if _, understood := known[name]; !understood {
+			return fmt.Errorf(`%w: the %q header parameter is not understood`, ErrCriticalHeader, name)
+		}
+	}
+
+	return nil
+}
+
+// knownCriticalHeaders turns the configured extension names into the set the
+// guard looks them up in. It returns nil for an empty configuration, which
+// rejects every token that marks a header parameter critical.
+func knownCriticalHeaders(names []string) map[string]struct{} {
+	if len(names) == 0 {
+		return nil
+	}
+	known := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		known[name] = struct{}{}
+	}
+	return known
+}

--- a/v3/jwt/go.mod
+++ b/v3/jwt/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gofiber/fiber/v3 v3.5.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/stretchr/testify v1.12.1
+	github.com/valyala/fasthttp v1.74.0
 )
 
 require (
@@ -20,7 +21,6 @@ require (
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/tinylib/msgp v1.6.4 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasthttp v1.74.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/crypto v0.57.0 // indirect
 	golang.org/x/net v0.59.0 // indirect

--- a/v3/jwt/jwt.go
+++ b/v3/jwt/jwt.go
@@ -6,7 +6,6 @@
 package jwtware
 
 import (
-	"net/url"
 	"reflect"
 	"strings"
 
@@ -80,9 +79,6 @@ func New(config ...Config) fiber.Handler {
 			return reject(c, err)
 		}
 
-		// The extractor's own answer is what the URL held; a processor may turn
-		// it into something else entirely.
-		extracted := auth
 		if processToken != nil {
 			if auth, err = processToken(auth); err != nil {
 				return reject(c, err)
@@ -102,7 +98,7 @@ func New(config ...Config) fiber.Handler {
 		// Store user information from token into context.
 		fiber.StoreInContext(c, tokenKey, token)
 
-		if fromURL(c, urlKeys, extracted) {
+		if urlCarriesCredential(c, urlKeys) {
 			return keepPrivate(c, successHandler)
 		}
 		return successHandler(c)
@@ -126,7 +122,8 @@ type urlParam struct {
 // and a cookie never reach the URL. A SourceCustom extractor reads wherever its
 // author wrote it to, so only they can say.
 //
-// Which source a given request actually used is settled per request, by fromURL.
+// Whether a given request's URL actually carries one is settled per request, by
+// urlCarriesCredential.
 //
 // The chain is walked with a visited set, as the extractors package walks its
 // own: the metadata is the caller's to build, and a chain that refers back to
@@ -146,20 +143,29 @@ func urlParams(e extractors.Extractor) []urlParam {
 	return params
 }
 
-// fromURL reports whether the token the extractor returned is the value one of
-// those parameters holds, which is what makes the URL sensitive. A chain that
-// answered from a header, a cookie or a request body leaves the URL clean, and
-// its response is none of this function's business.
-func fromURL(c fiber.Ctx, params []urlParam, token string) bool {
+// urlCarriesCredential reports whether the request URL holds a value in one of
+// those parameters, which is what makes it sensitive.
+//
+// It asks whether the parameter is populated, not whether its value is the
+// credential that authenticated: what a shared cache keys on is the URL, so a
+// chain that preferred a cookie over the query still answered a request whose
+// URL carries a token, and storing that response under it would hand the next
+// caller of that URL someone else's. A chain that reads only headers, cookies
+// or the request body leaves the URL clean and its response alone.
+func urlCarriesCredential(c fiber.Ctx, params []urlParam) bool {
 	for _, param := range params {
-		if !param.inPath {
-			if c.Query(param.key) == token {
+		if param.inPath {
+			// A route parameter that matched is part of the path by
+			// construction, so having a value is what there is to ask.
+			if c.Params(param.key) != "" {
 				return true
 			}
 			continue
 		}
-		// FromParam unescapes what it read, so the comparison has to as well.
-		if unescaped, err := url.PathUnescape(c.Params(param.key)); err == nil && unescaped == token {
+		// Only the query string: a form parameter reaches this list because
+		// FormValue reads the query before the body, and a value in the body is
+		// not in the URL.
+		if c.Request().URI().QueryArgs().Has(param.key) {
 			return true
 		}
 	}
@@ -191,21 +197,42 @@ func walkExtractor(e *extractors.Extractor, visit func(*extractors.Extractor) bo
 	return walk(e)
 }
 
-// keepPrivate runs the handler and then keeps its response out of shared
-// caches, as RFC 6750 Section 2.3 asks of a resource server answering a request
-// whose token travelled in the URL.
+// keepPrivate keeps the response to a request whose URL carries a token out of
+// shared caches, as RFC 6750 Section 2.3 asks of a resource server.
+//
+// The directive goes on twice. Once before the handler runs, because a cache
+// registered after this middleware reads the response and decides whether to
+// store it as its own stack unwinds - which happens before control comes back
+// here, so a directive added only afterwards would reach the client but not the
+// cache that already stored the body. Once after, because only then is the
+// handler's own policy known and mergeable, and because the status the RFC
+// scopes this to is only known then.
+//
+// A handler that replaces the header outright while a cache sits between it and
+// this middleware is the case neither pass can cover, since that cache reads the
+// replacement before this function runs again. Registering the cache outside
+// this middleware rather than inside it avoids that ordering entirely, which is
+// what the README recommends.
 func keepPrivate(c fiber.Ctx, next fiber.Handler) error {
+	setPrivate(c)
+
 	err := next(c)
 
-	// Only a response a cache would store needs the directive.
+	// Only a response a cache would store needs the directive, and the early
+	// pass already covered anything downstream that has stored one by now.
 	status := c.Response().StatusCode()
 	if status < fiber.StatusOK || status >= fiber.StatusMultipleChoices {
 		return err
 	}
 
+	setPrivate(c)
+	return err
+}
+
+// setPrivate merges the directive into whatever policy the response carries.
+func setPrivate(c fiber.Ctx) {
 	existing := string(c.Response().Header.Peek(fiber.HeaderCacheControl))
 	c.Set(fiber.HeaderCacheControl, privateCacheControl(existing))
-	return err
 }
 
 // privateCacheControl returns value with any directive that would let a shared
@@ -217,7 +244,14 @@ func privateCacheControl(value string) string {
 		return "private"
 	}
 
-	directives := splitCacheControl(value)
+	directives, wellFormed := splitCacheControl(value)
+	if !wellFormed {
+		// An unterminated quoted string swallows everything after it, so
+		// appending "private" to one would produce a policy that does not
+		// contain the directive at all. There is nothing to merge into: a
+		// policy no cache can parse is replaced rather than extended.
+		return "private"
+	}
 	kept := directives[:0]
 	private := false
 	for _, directive := range directives {
@@ -246,8 +280,10 @@ func privateCacheControl(value string) string {
 }
 
 // splitCacheControl splits a Cache-Control value on the commas that separate
-// directives, leaving the ones inside a quoted field list alone.
-func splitCacheControl(value string) []string {
+// directives, leaving the ones inside a quoted field list alone. It also reports
+// whether the value was well formed, which it is not when a quoted string is
+// left open.
+func splitCacheControl(value string) ([]string, bool) {
 	var (
 		directives []string
 		start      int
@@ -276,7 +312,7 @@ func splitCacheControl(value string) []string {
 	if directive := strings.TrimSpace(value[start:]); directive != "" {
 		directives = append(directives, directive)
 	}
-	return directives
+	return directives, !quoted
 }
 
 // claimsFactory returns a function that allocates an empty claims value of the

--- a/v3/jwt/jwt.go
+++ b/v3/jwt/jwt.go
@@ -62,8 +62,13 @@ func New(config ...Config) fiber.Handler {
 	urlKeys := urlParams(cfg.Extractor)
 
 	reject := func(c fiber.Ctx, err error) error {
+		// Read before the handler runs: whatever is on the response now came
+		// from a middleware that ran earlier, and anything the handler adds is
+		// its own answer to this rejection. The two are treated differently.
+		inherited := inheritedChallenges(c)
+
 		handlerErr := errorHandler(c, err)
-		authChallenge.apply(c, handlerErr, err)
+		authChallenge.apply(c, handlerErr, err, inherited)
 		return handlerErr
 	}
 
@@ -164,8 +169,11 @@ func urlCarriesCredential(c fiber.Ctx, params []urlParam) bool {
 		}
 		// Only the query string: a form parameter reaches this list because
 		// FormValue reads the query before the body, and a value in the body is
-		// not in the URL.
-		if c.Request().URI().QueryArgs().Has(param.key) {
+		// not in the URL. The value has to be there, not just the key: the
+		// extractors read "?token=" as no credential, so nothing sensitive is
+		// in a URL that only names the parameter. Note that this is the value,
+		// so FromQuery("") reading "/?=<token>" still counts.
+		if len(c.Request().URI().QueryArgs().Peek(param.key)) > 0 {
 			return true
 		}
 	}

--- a/v3/jwt/jwt.go
+++ b/v3/jwt/jwt.go
@@ -210,9 +210,10 @@ func walkExtractor(e *extractors.Extractor, visit func(*extractors.Extractor) bo
 //
 // A handler that replaces the header outright while a cache sits between it and
 // this middleware is the case neither pass can cover, since that cache reads the
-// replacement before this function runs again. Registering the cache outside
-// this middleware rather than inside it avoids that ordering entirely, which is
-// what the README recommends.
+// replacement before this function runs again. Moving the cache outside this
+// middleware would not help: it would then answer before any of this runs, so a
+// hit would skip authentication altogether. The README says to keep the cache
+// inside and key it on whatever identifies the user.
 func keepPrivate(c fiber.Ctx, next fiber.Handler) error {
 	setPrivate(c)
 

--- a/v3/jwt/jwt.go
+++ b/v3/jwt/jwt.go
@@ -56,9 +56,10 @@ func New(config ...Config) fiber.Handler {
 
 	// A token read from the query string ends up in the URL a shared cache keys
 	// on, so those responses need the RFC 6750 Section 2.3 directive. Which
-	// extractor of a chain supplied the token is only known per request, so the
-	// parameters it could have come from are collected here and compared then.
-	queryKeys := queryParams(cfg.Extractor)
+	// extractor of a chain supplied the token, and whether it came from the URL
+	// at all, is only known per request, so the parameters it could have come
+	// from are collected here and compared then.
+	queryKeys := urlParams(cfg.Extractor)
 
 	reject := func(c fiber.Ctx, err error) error {
 		handlerErr := errorHandler(c, err)
@@ -107,17 +108,22 @@ func New(config ...Config) fiber.Handler {
 	}
 }
 
-// queryParams lists the query string parameters the extractor may read the
-// token from, in the order a chain tries them. It is empty for the extractors
-// that never look at the query, which is the default.
+// urlParams lists the parameters whose value the extractor may find in the
+// query string, in the order a chain tries them. It is empty for the extractors
+// that never read it, which is the default.
+//
+// Form parameters count: Fiber's FormValue searches the query string before the
+// request body, so a form extractor answers "GET /?token=<jwt>" from the URL.
+// Which of the two a given request used is settled per request, by fromQuery.
 //
 // The chain is walked with a visited set, as the extractors package walks its
 // own: the metadata is the caller's to build, and a chain that refers back to
 // itself would otherwise be followed along every path through it.
-func queryParams(e extractors.Extractor) []string {
+func urlParams(e extractors.Extractor) []string {
 	var params []string
 	walkExtractor(&e, func(candidate *extractors.Extractor) bool {
-		if candidate.Source == extractors.SourceQuery {
+		switch candidate.Source {
+		case extractors.SourceQuery, extractors.SourceForm:
 			// The empty key is a real parameter: Fiber reads "/?=<token>" from it.
 			params = append(params, candidate.Key)
 		}

--- a/v3/jwt/jwt.go
+++ b/v3/jwt/jwt.go
@@ -78,6 +78,9 @@ func New(config ...Config) fiber.Handler {
 			return reject(c, err)
 		}
 
+		// The extractor's own answer is what the URL held; a processor may turn
+		// it into something else entirely.
+		extracted := auth
 		if processToken != nil {
 			if auth, err = processToken(auth); err != nil {
 				return reject(c, err)
@@ -97,7 +100,7 @@ func New(config ...Config) fiber.Handler {
 		// Store user information from token into context.
 		fiber.StoreInContext(c, tokenKey, token)
 
-		if fromQuery(c, queryKeys, auth) {
+		if fromQuery(c, queryKeys, extracted) {
 			return keepPrivate(c, successHandler)
 		}
 		return successHandler(c)
@@ -108,12 +111,18 @@ func New(config ...Config) fiber.Handler {
 // token from, in the order a chain tries them. It is empty for the extractors
 // that never look at the query, which is the default.
 func queryParams(e extractors.Extractor) []string {
-	var params []string
+	return appendQueryParams(nil, e, 0)
+}
+
+func appendQueryParams(params []string, e extractors.Extractor, depth int) []string {
+	if depth > maxExtractorDepth {
+		return params
+	}
 	if e.Source == extractors.SourceQuery && e.Key != "" {
 		params = append(params, e.Key)
 	}
 	for _, chained := range e.Chain {
-		params = append(params, queryParams(chained)...)
+		params = appendQueryParams(params, chained, depth+1)
 	}
 	return params
 }
@@ -196,6 +205,12 @@ func splitCacheControl(value string) []string {
 	)
 	for i := 0; i < len(value); i++ {
 		switch value[i] {
+		case '\\':
+			// RFC 9110 Section 5.6.4: inside a quoted string a backslash quotes
+			// the next character, so neither of them ends anything.
+			if quoted {
+				i++
+			}
 		case '"':
 			quoted = !quoted
 		case ',':

--- a/v3/jwt/jwt.go
+++ b/v3/jwt/jwt.go
@@ -7,6 +7,7 @@ package jwtware
 
 import (
 	"reflect"
+	"strings"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/extractors"
@@ -42,7 +43,7 @@ func New(config ...Config) fiber.Handler {
 	parser := jwt.NewParser(options...)
 
 	newClaims := claimsFactory(cfg.Claims)
-	authChallenge := newChallenge(cfg, customErrorHandler(config))
+	authChallenge := newChallenge(cfg)
 
 	// Hoisting the fields out of the config keeps the request path from chasing
 	// the same pointers on every call.
@@ -53,9 +54,11 @@ func New(config ...Config) fiber.Handler {
 	successHandler := cfg.SuccessHandler
 	errorHandler := cfg.ErrorHandler
 
-	if readsQuery(cfg.Extractor) {
-		successHandler = markPrivate(successHandler)
-	}
+	// A token read from the query string ends up in the URL a shared cache keys
+	// on, so those responses need the RFC 6750 Section 2.3 directive. Which
+	// extractor of a chain supplied the token is only known per request, so the
+	// parameters it could have come from are collected here and compared then.
+	queryKeys := queryParams(cfg.Extractor)
 
 	reject := func(c fiber.Ctx, err error) error {
 		handlerErr := errorHandler(c, err)
@@ -93,35 +96,122 @@ func New(config ...Config) fiber.Handler {
 
 		// Store user information from token into context.
 		fiber.StoreInContext(c, tokenKey, token)
+
+		if fromQuery(c, queryKeys, auth) {
+			return keepPrivate(c, successHandler)
+		}
 		return successHandler(c)
 	}
 }
 
-// readsQuery reports whether the extractor can take the token from the query
-// string, where it ends up in URLs that caches and logs keep.
-func readsQuery(e extractors.Extractor) bool {
-	return e.Contains(func(candidate extractors.Extractor) bool {
-		return candidate.Source == extractors.SourceQuery
-	})
+// queryParams lists the query string parameters the extractor may read the
+// token from, in the order a chain tries them. It is empty for the extractors
+// that never look at the query, which is the default.
+func queryParams(e extractors.Extractor) []string {
+	var params []string
+	if e.Source == extractors.SourceQuery && e.Key != "" {
+		params = append(params, e.Key)
+	}
+	for _, chained := range e.Chain {
+		params = append(params, queryParams(chained)...)
+	}
+	return params
 }
 
-// markPrivate wraps a handler so that a successful response to a request whose
-// token travelled in the query string is kept out of shared caches, which
-// RFC 6750 Section 2.3 asks of a resource server. A handler that states its own
-// caching policy keeps it.
-func markPrivate(next fiber.Handler) fiber.Handler {
-	return func(c fiber.Ctx) error {
-		err := next(c)
+// fromQuery reports whether the token the extractor returned is the value of
+// one of those parameters, which is what makes the URL sensitive. A chain that
+// answered from a header or a cookie leaves the URL clean, and its response is
+// none of this function's business.
+func fromQuery(c fiber.Ctx, params []string, token string) bool {
+	for _, param := range params {
+		if c.Query(param) == token {
+			return true
+		}
+	}
+	return false
+}
 
-		status := c.Response().StatusCode()
-		if status < fiber.StatusOK || status >= fiber.StatusMultipleChoices {
-			return err
-		}
-		if len(c.Response().Header.Peek(fiber.HeaderCacheControl)) == 0 {
-			c.Set(fiber.HeaderCacheControl, "private")
-		}
+// keepPrivate runs the handler and then keeps its response out of shared
+// caches, as RFC 6750 Section 2.3 asks of a resource server answering a request
+// whose token travelled in the URL.
+func keepPrivate(c fiber.Ctx, next fiber.Handler) error {
+	err := next(c)
+
+	// Only a response a cache would store needs the directive.
+	status := c.Response().StatusCode()
+	if status < fiber.StatusOK || status >= fiber.StatusMultipleChoices {
 		return err
 	}
+
+	existing := string(c.Response().Header.Peek(fiber.HeaderCacheControl))
+	c.Set(fiber.HeaderCacheControl, privateCacheControl(existing))
+	return err
+}
+
+// privateCacheControl returns value with any directive that would let a shared
+// cache store the response replaced by one that would not. A policy the handler
+// set is otherwise kept: only "public" is dropped, and "private" is added only
+// when nothing already keeps the response out of shared caches.
+func privateCacheControl(value string) string {
+	if value == "" {
+		return "private"
+	}
+
+	directives := splitCacheControl(value)
+	kept := directives[:0]
+	private := false
+	for _, directive := range directives {
+		name := directive
+		if i := strings.IndexByte(name, '='); i >= 0 {
+			name = name[:i]
+		}
+		switch strings.ToLower(strings.TrimSpace(name)) {
+		case "public":
+			// Contradicts what this response needs; drop it.
+			continue
+		case "no-store":
+			private = true
+		case "private":
+			// RFC 9111 Section 5.2.2.7: with field names, only those fields are
+			// private and a shared cache may still store the body, so only the
+			// bare form settles it.
+			private = private || !strings.Contains(directive, "=")
+		}
+		kept = append(kept, directive)
+	}
+	if !private {
+		kept = append(kept, "private")
+	}
+
+	return strings.Join(kept, ", ")
+}
+
+// splitCacheControl splits a Cache-Control value on the commas that separate
+// directives, leaving the ones inside a quoted field list alone.
+func splitCacheControl(value string) []string {
+	var (
+		directives []string
+		start      int
+		quoted     bool
+	)
+	for i := 0; i < len(value); i++ {
+		switch value[i] {
+		case '"':
+			quoted = !quoted
+		case ',':
+			if quoted {
+				continue
+			}
+			if directive := strings.TrimSpace(value[start:i]); directive != "" {
+				directives = append(directives, directive)
+			}
+			start = i + 1
+		}
+	}
+	if directive := strings.TrimSpace(value[start:]); directive != "" {
+		directives = append(directives, directive)
+	}
+	return directives
 }
 
 // claimsFactory returns a function that allocates an empty claims value of the

--- a/v3/jwt/jwt.go
+++ b/v3/jwt/jwt.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/extractors"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -23,51 +24,132 @@ const (
 
 // New ...
 func New(config ...Config) fiber.Handler {
+	// The accepted algorithms have to be read from the configuration as the
+	// caller wrote it: makeCfg installs a key function of its own, which
+	// afterwards is indistinguishable from one the caller supplied.
+	validMethods := validAlgorithms(config)
 	cfg := makeCfg(config)
+
+	// Everything that depends on the configuration alone is resolved here, once,
+	// so that a request pays for nothing but its own token. A parser is
+	// read-only once built, so a single one serves every request.
+	options := make([]jwt.ParserOption, 0, len(cfg.ParserOptions)+1)
+	if len(validMethods) > 0 {
+		options = append(options, jwt.WithValidMethods(validMethods))
+	}
+	// The caller's options come last, so an explicit jwt.WithValidMethods wins.
+	options = append(options, cfg.ParserOptions...)
+	parser := jwt.NewParser(options...)
+
+	newClaims := claimsFactory(cfg.Claims)
+	authChallenge := newChallenge(cfg, customErrorHandler(config))
+
+	// Hoisting the fields out of the config keeps the request path from chasing
+	// the same pointers on every call.
+	extract := cfg.Extractor.Extract
+	keyFunc := cfg.KeyFunc
+	next := cfg.Next
+	processToken := cfg.TokenProcessorFunc
+	successHandler := cfg.SuccessHandler
+	errorHandler := cfg.ErrorHandler
+
+	if readsQuery(cfg.Extractor) {
+		successHandler = markPrivate(successHandler)
+	}
+
+	reject := func(c fiber.Ctx, err error) error {
+		handlerErr := errorHandler(c, err)
+		authChallenge.apply(c, handlerErr, err)
+		return handlerErr
+	}
 
 	// Return middleware handler
 	return func(c fiber.Ctx) error {
 		// Filter request to skip middleware
-		if cfg.Next != nil && cfg.Next(c) {
+		if next != nil && next(c) {
 			return c.Next()
 		}
-		auth, err := cfg.Extractor.Extract(c)
+
+		auth, err := extract(c)
 		if err != nil {
-			return cfg.ErrorHandler(c, err)
+			return reject(c, err)
 		}
 
-		if cfg.TokenProcessorFunc != nil {
-			auth, err = cfg.TokenProcessorFunc(auth)
-			if err != nil {
-				return cfg.ErrorHandler(c, err)
+		if processToken != nil {
+			if auth, err = processToken(auth); err != nil {
+				return reject(c, err)
 			}
 		}
 
-		var token *jwt.Token
-		if _, ok := cfg.Claims.(jwt.MapClaims); ok {
-			token, err = jwt.Parse(auth, cfg.KeyFunc, cfg.ParserOptions...)
-		} else {
-			claimsType := reflect.TypeOf(cfg.Claims)
-			if claimsType == nil {
-				return cfg.ErrorHandler(c, fiber.NewError(fiber.StatusInternalServerError, "claims type cannot be nil"))
-			}
-
-			if claimsType.Kind() == reflect.Pointer {
-				claimsType = claimsType.Elem()
-			}
-
-			claims, ok := reflect.New(claimsType).Interface().(jwt.Claims)
-			if !ok {
-				return cfg.ErrorHandler(c, fiber.NewError(fiber.StatusInternalServerError, "claims type does not implement jwt.Claims"))
-			}
-			token, err = jwt.ParseWithClaims(auth, claims, cfg.KeyFunc, cfg.ParserOptions...)
+		token, err := parser.ParseWithClaims(auth, newClaims(), keyFunc)
+		if err != nil {
+			return reject(c, err)
 		}
-		if err == nil && token.Valid {
-			// Store user information from token into context.
-			fiber.StoreInContext(c, tokenKey, token)
-			return cfg.SuccessHandler(c)
+		if !token.Valid {
+			// The parser only reports success for a valid token, but a token is
+			// not trusted on the strength of a nil error alone.
+			return reject(c, jwt.ErrTokenUnverifiable)
 		}
-		return cfg.ErrorHandler(c, err)
+
+		// Store user information from token into context.
+		fiber.StoreInContext(c, tokenKey, token)
+		return successHandler(c)
+	}
+}
+
+// readsQuery reports whether the extractor can take the token from the query
+// string, where it ends up in URLs that caches and logs keep.
+func readsQuery(e extractors.Extractor) bool {
+	return e.Contains(func(candidate extractors.Extractor) bool {
+		return candidate.Source == extractors.SourceQuery
+	})
+}
+
+// markPrivate wraps a handler so that a successful response to a request whose
+// token travelled in the query string is kept out of shared caches, which
+// RFC 6750 Section 2.3 asks of a resource server. A handler that states its own
+// caching policy keeps it.
+func markPrivate(next fiber.Handler) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		err := next(c)
+
+		status := c.Response().StatusCode()
+		if status < fiber.StatusOK || status >= fiber.StatusMultipleChoices {
+			return err
+		}
+		if len(c.Response().Header.Peek(fiber.HeaderCacheControl)) == 0 {
+			c.Set(fiber.HeaderCacheControl, "private")
+		}
+		return err
+	}
+}
+
+// claimsFactory returns a function that allocates an empty claims value of the
+// configured type. Resolving the type once keeps reflection off the request
+// path, where only the allocation itself is unavoidable.
+//
+// The configured value supplies the type, never the contents: claims parsed from
+// one request must not be visible to the next.
+func claimsFactory(configured jwt.Claims) func() jwt.Claims {
+	if _, ok := configured.(jwt.MapClaims); ok {
+		return func() jwt.Claims { return jwt.MapClaims{} }
+	}
+
+	claimsType := reflect.TypeOf(configured)
+	if claimsType == nil {
+		panic("Fiber: JWT middleware configuration: Claims type cannot be nil")
+	}
+	if claimsType.Kind() == reflect.Pointer {
+		claimsType = claimsType.Elem()
+	}
+	if _, ok := reflect.New(claimsType).Interface().(jwt.Claims); !ok {
+		panic("Fiber: JWT middleware configuration: Claims type does not implement jwt.Claims")
+	}
+
+	return func() jwt.Claims {
+		// The assertion held for this type when the middleware was built.
+		claims, _ := reflect.New(claimsType).Interface().(jwt.Claims)
+		return claims
 	}
 }
 

--- a/v3/jwt/jwt.go
+++ b/v3/jwt/jwt.go
@@ -110,21 +110,45 @@ func New(config ...Config) fiber.Handler {
 // queryParams lists the query string parameters the extractor may read the
 // token from, in the order a chain tries them. It is empty for the extractors
 // that never look at the query, which is the default.
+//
+// The chain is walked with a visited set, as the extractors package walks its
+// own: the metadata is the caller's to build, and a chain that refers back to
+// itself would otherwise be followed along every path through it.
 func queryParams(e extractors.Extractor) []string {
-	return appendQueryParams(nil, e, 0)
+	var params []string
+	walkExtractor(&e, func(candidate *extractors.Extractor) bool {
+		if candidate.Source == extractors.SourceQuery {
+			// The empty key is a real parameter: Fiber reads "/?=<token>" from it.
+			params = append(params, candidate.Key)
+		}
+		return false
+	})
+	return params
 }
 
-func appendQueryParams(params []string, e extractors.Extractor, depth int) []string {
-	if depth > maxExtractorDepth {
-		return params
+// walkExtractor visits an extractor and its chain in the order a chain is
+// tried, stopping early when visit returns true. Each node is visited once.
+func walkExtractor(e *extractors.Extractor, visit func(*extractors.Extractor) bool) bool {
+	visited := make(map[*extractors.Extractor]struct{})
+
+	var walk func(*extractors.Extractor) bool
+	walk = func(candidate *extractors.Extractor) bool {
+		if _, seen := visited[candidate]; seen {
+			return false
+		}
+		visited[candidate] = struct{}{}
+
+		if visit(candidate) {
+			return true
+		}
+		for i := range candidate.Chain {
+			if walk(&candidate.Chain[i]) {
+				return true
+			}
+		}
+		return false
 	}
-	if e.Source == extractors.SourceQuery && e.Key != "" {
-		params = append(params, e.Key)
-	}
-	for _, chained := range e.Chain {
-		params = appendQueryParams(params, chained, depth+1)
-	}
-	return params
+	return walk(e)
 }
 
 // fromQuery reports whether the token the extractor returned is the value of
@@ -178,12 +202,11 @@ func privateCacheControl(value string) string {
 		case "public":
 			// Contradicts what this response needs; drop it.
 			continue
-		case "no-store":
-			private = true
-		case "private":
-			// RFC 9111 Section 5.2.2.7: with field names, only those fields are
-			// private and a shared cache may still store the body, so only the
-			// bare form settles it.
+		case "no-store", "private":
+			// RFC 9111 Section 5.2.3: a recipient ignores a directive carrying
+			// an argument the directive is not defined to take, and Section
+			// 5.2.2.7's field-scoped "private" leaves the body storable by a
+			// shared cache either way. Only the bare forms settle it.
 			private = private || !strings.Contains(directive, "=")
 		}
 		kept = append(kept, directive)

--- a/v3/jwt/jwt.go
+++ b/v3/jwt/jwt.go
@@ -6,6 +6,7 @@
 package jwtware
 
 import (
+	"net/url"
 	"reflect"
 	"strings"
 
@@ -59,7 +60,7 @@ func New(config ...Config) fiber.Handler {
 	// extractor of a chain supplied the token, and whether it came from the URL
 	// at all, is only known per request, so the parameters it could have come
 	// from are collected here and compared then.
-	queryKeys := urlParams(cfg.Extractor)
+	urlKeys := urlParams(cfg.Extractor)
 
 	reject := func(c fiber.Ctx, err error) error {
 		handlerErr := errorHandler(c, err)
@@ -101,35 +102,68 @@ func New(config ...Config) fiber.Handler {
 		// Store user information from token into context.
 		fiber.StoreInContext(c, tokenKey, token)
 
-		if fromQuery(c, queryKeys, extracted) {
+		if fromURL(c, urlKeys, extracted) {
 			return keepPrivate(c, successHandler)
 		}
 		return successHandler(c)
 	}
 }
 
-// urlParams lists the parameters whose value the extractor may find in the
-// query string, in the order a chain tries them. It is empty for the extractors
-// that never read it, which is the default.
+// urlParam names a parameter whose value the extractor may find in the request
+// URL, and how to read it back.
+type urlParam struct {
+	key    string
+	inPath bool
+}
+
+// urlParams lists those parameters, in the order a chain tries them. It is
+// empty for the extractors that never read the URL, which is the default.
 //
-// Form parameters count: Fiber's FormValue searches the query string before the
-// request body, so a form extractor answers "GET /?token=<jwt>" from the URL.
-// Which of the two a given request used is settled per request, by fromQuery.
+// The list covers every built-in source that can put the token in the URL and
+// no others: a query parameter obviously, a form parameter because Fiber's
+// FormValue searches the query string before the request body, and a route
+// parameter because it is part of the path. A header, an Authorization header
+// and a cookie never reach the URL. A SourceCustom extractor reads wherever its
+// author wrote it to, so only they can say.
+//
+// Which source a given request actually used is settled per request, by fromURL.
 //
 // The chain is walked with a visited set, as the extractors package walks its
 // own: the metadata is the caller's to build, and a chain that refers back to
 // itself would otherwise be followed along every path through it.
-func urlParams(e extractors.Extractor) []string {
-	var params []string
+func urlParams(e extractors.Extractor) []urlParam {
+	var params []urlParam
 	walkExtractor(&e, func(candidate *extractors.Extractor) bool {
 		switch candidate.Source {
 		case extractors.SourceQuery, extractors.SourceForm:
 			// The empty key is a real parameter: Fiber reads "/?=<token>" from it.
-			params = append(params, candidate.Key)
+			params = append(params, urlParam{key: candidate.Key})
+		case extractors.SourceParam:
+			params = append(params, urlParam{key: candidate.Key, inPath: true})
 		}
 		return false
 	})
 	return params
+}
+
+// fromURL reports whether the token the extractor returned is the value one of
+// those parameters holds, which is what makes the URL sensitive. A chain that
+// answered from a header, a cookie or a request body leaves the URL clean, and
+// its response is none of this function's business.
+func fromURL(c fiber.Ctx, params []urlParam, token string) bool {
+	for _, param := range params {
+		if !param.inPath {
+			if c.Query(param.key) == token {
+				return true
+			}
+			continue
+		}
+		// FromParam unescapes what it read, so the comparison has to as well.
+		if unescaped, err := url.PathUnescape(c.Params(param.key)); err == nil && unescaped == token {
+			return true
+		}
+	}
+	return false
 }
 
 // walkExtractor visits an extractor and its chain in the order a chain is
@@ -155,19 +189,6 @@ func walkExtractor(e *extractors.Extractor, visit func(*extractors.Extractor) bo
 		return false
 	}
 	return walk(e)
-}
-
-// fromQuery reports whether the token the extractor returned is the value of
-// one of those parameters, which is what makes the URL sensitive. A chain that
-// answered from a header or a cookie leaves the URL clean, and its response is
-// none of this function's business.
-func fromQuery(c fiber.Ctx, params []string, token string) bool {
-	for _, param := range params {
-		if c.Query(param) == token {
-			return true
-		}
-	}
-	return false
 }
 
 // keepPrivate runs the handler and then keeps its response out of shared

--- a/v3/jwt/jwt_bench_test.go
+++ b/v3/jwt/jwt_bench_test.go
@@ -1,9 +1,13 @@
 package jwtware_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/MicahParks/keyfunc/v2"
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/extractors"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
@@ -11,29 +15,109 @@ import (
 	jwtware "github.com/gofiber/contrib/v3/jwt"
 )
 
-// benchApp builds a Fiber app guarded by the JWT middleware and returns its
-// fasthttp handler together with a request context carrying the given header.
+// The benchmarks below all drive a one-route Fiber app through its fasthttp
+// handler, so a result is the cost of a whole request: routing, the middleware,
+// and a handler that does nothing but set a status. Benchmark_Middleware_JWT_Baseline
+// is that app without the middleware, and subtracting it leaves the
+// middleware's own cost.
 //
-// Reset the response between iterations, the way a served request starts from a
-// clean one: a handler that sets a response header would otherwise only set it
-// on the first iteration.
-func benchApp(b *testing.B, cfg jwtware.Config, header, value string) (fasthttp.RequestHandler, *fasthttp.RequestCtx) {
+// go test -run=^$ -bench=Benchmark_Middleware_JWT -benchmem -count=6
+
+// benchHandler builds the guarded app and returns its fasthttp handler.
+func benchHandler(b *testing.B, cfg jwtware.Config) fasthttp.RequestHandler {
+	b.Helper()
+
+	return benchHandlerFunc(b, cfg, func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusTeapot)
+	})
+}
+
+// benchHandlerFunc is benchHandler with a route handler of the caller's choice.
+func benchHandlerFunc(b *testing.B, cfg jwtware.Config, handler fiber.Handler) fasthttp.RequestHandler {
 	b.Helper()
 
 	app := fiber.New()
 	app.Use(jwtware.New(cfg))
-	app.Get("/", func(c fiber.Ctx) error {
-		return c.SendStatus(fiber.StatusTeapot)
-	})
+	app.Get("/", handler)
+	return app.Handler()
+}
 
+// benchCtx builds the request the benchmark replays.
+func benchCtx(setup ...func(*fasthttp.RequestCtx)) *fasthttp.RequestCtx {
 	fctx := &fasthttp.RequestCtx{}
 	fctx.Request.Header.SetMethod(fiber.MethodGet)
 	fctx.Request.SetRequestURI("/")
-	if header != "" {
-		fctx.Request.Header.Set(header, value)
+	for _, apply := range setup {
+		apply(fctx)
+	}
+	return fctx
+}
+
+func withBearer(token string) func(*fasthttp.RequestCtx) {
+	return func(fctx *fasthttp.RequestCtx) {
+		fctx.Request.Header.Set(fiber.HeaderAuthorization, "Bearer "+token)
+	}
+}
+
+func withCookie(name, token string) func(*fasthttp.RequestCtx) {
+	return func(fctx *fasthttp.RequestCtx) {
+		fctx.Request.Header.SetCookie(name, token)
+	}
+}
+
+func withQuery(param, token string) func(*fasthttp.RequestCtx) {
+	return func(fctx *fasthttp.RequestCtx) {
+		fctx.Request.SetRequestURI("/?" + param + "=" + token)
+	}
+}
+
+// runBench replays the request and checks the middleware answered as the
+// benchmark expects, so a benchmark cannot quietly measure the wrong path.
+//
+// The response is reset between iterations, the way a served request starts
+// from a clean one: a rejection that sets a challenge header would otherwise
+// only set it on the first iteration.
+func runBench(b *testing.B, h fasthttp.RequestHandler, fctx *fasthttp.RequestCtx, want int) {
+	b.Helper()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		fctx.Response.Reset()
+		h(fctx)
 	}
 
-	return app.Handler(), fctx
+	require.Equal(b, want, fctx.Response.Header.StatusCode())
+}
+
+// benchClaims mirrors the claim set of the shared test tokens, so a benchmark
+// that has to sign its own is still decoding the same amount of JSON as the
+// ones that do not.
+var benchClaims = jwt.MapClaims{"sub": "1234567890", "name": "John Doe", "iat": 1516239022}
+
+// hmacKey is the configuration the symmetric benchmarks share.
+func hmacKey(alg string) jwtware.Config {
+	return jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: alg, Key: []byte(defaultSigningKey)},
+	}
+}
+
+// publicKeys parses the test JWK Set once so the asymmetric algorithms can be
+// measured without a key set server in the loop.
+func publicKeys(b *testing.B) map[string]any {
+	b.Helper()
+
+	set, err := keyfunc.NewJSON([]byte(defaultKeySet))
+	require.NoError(b, err)
+	return set.ReadOnlyKeys()
+}
+
+// tamper invalidates a token's signature without disturbing its encoding.
+func tamper(token string) string {
+	replacement := byte('A')
+	if token[len(token)-1] == replacement {
+		replacement = 'B'
+	}
+	return token[:len(token)-1] + string(replacement)
 }
 
 // Benchmark_Middleware_JWT_Baseline drives the same Fiber app without the JWT
@@ -45,84 +129,209 @@ func Benchmark_Middleware_JWT_Baseline(b *testing.B) {
 		return c.SendStatus(fiber.StatusTeapot)
 	})
 
-	h := app.Handler()
-	fctx := &fasthttp.RequestCtx{}
-	fctx.Request.Header.SetMethod(fiber.MethodGet)
-	fctx.Request.SetRequestURI("/")
-
-	b.ReportAllocs()
-
-	for b.Loop() {
-		fctx.Response.Reset()
-		h(fctx)
-	}
-
-	require.Equal(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
+	runBench(b, app.Handler(), benchCtx(), fiber.StatusTeapot)
 }
 
-// go test -run=^$ -bench=Benchmark_Middleware_JWT -benchmem -count=6
 func Benchmark_Middleware_JWT_MapClaims(b *testing.B) {
-	h, fctx := benchApp(b, jwtware.Config{
-		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
-	}, fiber.HeaderAuthorization, "Bearer "+hamac[0].Token)
-
-	b.ReportAllocs()
-
-	for b.Loop() {
-		fctx.Response.Reset()
-		h(fctx)
-	}
-
-	require.Equal(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
+	h := benchHandler(b, hmacKey(jwtware.HS256))
+	runBench(b, h, benchCtx(withBearer(hamac[0].Token)), fiber.StatusTeapot)
 }
 
 func Benchmark_Middleware_JWT_CustomClaims(b *testing.B) {
-	h, fctx := benchApp(b, jwtware.Config{
-		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
-		Claims:     &customClaims{},
-	}, fiber.HeaderAuthorization, "Bearer "+hamac[0].Token)
+	cfg := hmacKey(jwtware.HS256)
+	cfg.Claims = &customClaims{}
 
-	b.ReportAllocs()
-
-	for b.Loop() {
-		fctx.Response.Reset()
-		h(fctx)
-	}
-
-	require.Equal(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
+	h := benchHandler(b, cfg)
+	runBench(b, h, benchCtx(withBearer(hamac[0].Token)), fiber.StatusTeapot)
 }
 
 func Benchmark_Middleware_JWT_ParserOptions(b *testing.B) {
-	h, fctx := benchApp(b, jwtware.Config{
-		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
-		ParserOptions: []jwt.ParserOption{
-			jwt.WithIssuedAt(),
-			jwt.WithLeeway(0),
-			jwt.WithValidMethods([]string{jwtware.HS256}),
-		},
-	}, fiber.HeaderAuthorization, "Bearer "+hamac[0].Token)
-
-	b.ReportAllocs()
-
-	for b.Loop() {
-		fctx.Response.Reset()
-		h(fctx)
+	cfg := hmacKey(jwtware.HS256)
+	cfg.ParserOptions = []jwt.ParserOption{
+		jwt.WithIssuedAt(),
+		jwt.WithLeeway(0),
+		jwt.WithValidMethods([]string{jwtware.HS256}),
 	}
 
-	require.Equal(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
+	h := benchHandler(b, cfg)
+	runBench(b, h, benchCtx(withBearer(hamac[0].Token)), fiber.StatusTeapot)
 }
 
 func Benchmark_Middleware_JWT_MissingToken(b *testing.B) {
-	h, fctx := benchApp(b, jwtware.Config{
-		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
-	}, "", "")
+	h := benchHandler(b, hmacKey(jwtware.HS256))
+	runBench(b, h, benchCtx(), fiber.StatusBadRequest)
+}
 
-	b.ReportAllocs()
+// Benchmark_Middleware_JWT_Algorithms measures each signing algorithm on the
+// same path. The spread between them is the verification cost, which dominates
+// a request.
+func Benchmark_Middleware_JWT_Algorithms(b *testing.B) {
+	keys := publicKeys(b)
 
-	for b.Loop() {
-		fctx.Response.Reset()
-		h(fctx)
+	tests := []struct {
+		key   any
+		name  string
+		alg   string
+		token string
+	}{
+		{name: "HS256", alg: jwtware.HS256, key: []byte(defaultSigningKey), token: hamac[0].Token},
+		{name: "HS384", alg: jwtware.HS384, key: []byte(defaultSigningKey), token: hamac[1].Token},
+		{name: "HS512", alg: jwtware.HS512, key: []byte(defaultSigningKey), token: hamac[2].Token},
+		{name: "RS256", alg: jwtware.RS256, key: keys["gofiber-rsa"], token: rsa[0].Token},
+		{name: "ES256", alg: jwtware.ES256, key: keys["gofiber-p-256"], token: ecdsa[0].Token},
 	}
 
-	require.Equal(b, fiber.StatusBadRequest, fctx.Response.Header.StatusCode())
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			h := benchHandler(b, jwtware.Config{
+				SigningKey: jwtware.SigningKey{JWTAlg: test.alg, Key: test.key},
+			})
+			runBench(b, h, benchCtx(withBearer(test.token)), fiber.StatusTeapot)
+		})
+	}
+}
+
+// Benchmark_Middleware_JWT_Extractors measures where the token is read from.
+// The query case also carries the RFC 6750 Section 2.3 cache directive the
+// middleware adds to those responses.
+func Benchmark_Middleware_JWT_Extractors(b *testing.B) {
+	token := hamac[0].Token
+
+	tests := []struct {
+		setup     func(*fasthttp.RequestCtx)
+		extractor extractors.Extractor
+		name      string
+	}{
+		{name: "AuthHeader", extractor: extractors.FromAuthHeader("Bearer"), setup: withBearer(token)},
+		{name: "Cookie", extractor: extractors.FromCookie("token"), setup: withCookie("token", token)},
+		{name: "Query", extractor: extractors.FromQuery("token"), setup: withQuery("token", token)},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			cfg := hmacKey(jwtware.HS256)
+			cfg.Extractor = test.extractor
+
+			h := benchHandler(b, cfg)
+			runBench(b, h, benchCtx(test.setup), fiber.StatusTeapot)
+		})
+	}
+}
+
+// Benchmark_Middleware_JWT_KeySource measures how the verification key is
+// found: straight from the configuration, by "kid" out of a key set, from a
+// caller's key function, or from a cached JWK Set.
+func Benchmark_Middleware_JWT_KeySource(b *testing.B) {
+	b.Run("SigningKey", func(b *testing.B) {
+		h := benchHandler(b, hmacKey(jwtware.HS256))
+		runBench(b, h, benchCtx(withBearer(hamac[0].Token)), fiber.StatusTeapot)
+	})
+
+	b.Run("SigningKeys", func(b *testing.B) {
+		h := benchHandler(b, jwtware.Config{
+			SigningKeys: map[string]jwtware.SigningKey{
+				"one": {JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+				"two": {JWTAlg: jwtware.HS256, Key: []byte("another-secret")},
+			},
+		})
+
+		token := signWith(b, benchClaims, map[string]any{"kid": "one"})
+		runBench(b, h, benchCtx(withBearer(token)), fiber.StatusTeapot)
+	})
+
+	b.Run("KeyFunc", func(b *testing.B) {
+		h := benchHandler(b, jwtware.Config{KeyFunc: customKeyfunc()})
+		runBench(b, h, benchCtx(withBearer(hamac[0].Token)), fiber.StatusTeapot)
+	})
+
+	b.Run("JWKSet", func(b *testing.B) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(defaultKeySet))
+		}))
+		b.Cleanup(server.Close)
+
+		// The set is fetched when the middleware is built, so the loop measures
+		// the cached lookup rather than the request to the server.
+		h := benchHandler(b, jwtware.Config{JWKSetURLs: []string{server.URL}})
+		runBench(b, h, benchCtx(withBearer(rsa[0].Token)), fiber.StatusTeapot)
+	})
+}
+
+// Benchmark_Middleware_JWT_Rejected measures the paths a request that fails
+// authentication takes, each of which also writes the challenge header.
+func Benchmark_Middleware_JWT_Rejected(b *testing.B) {
+	tests := []struct {
+		name   string
+		token  string
+		status int
+	}{
+		{name: "Malformed", token: "not-a-jwt", status: fiber.StatusUnauthorized},
+		{name: "Expired", token: expiredToken.Token, status: fiber.StatusUnauthorized},
+		{name: "BadSignature", token: tamper(hamac[0].Token), status: fiber.StatusUnauthorized},
+		// Refused by the parser before a key is looked up: hamac[1] is HS384.
+		{name: "UnexpectedAlgorithm", token: hamac[1].Token, status: fiber.StatusUnauthorized},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			h := benchHandler(b, hmacKey(jwtware.HS256))
+			runBench(b, h, benchCtx(withBearer(test.token)), test.status)
+		})
+	}
+}
+
+// Benchmark_Middleware_JWT_CriticalHeader measures the RFC 7515 Section 4.1.11
+// check on the tokens that reach it. Every other benchmark here carries no
+// "crit" header, which is the case that only costs a map lookup.
+func Benchmark_Middleware_JWT_CriticalHeader(b *testing.B) {
+	header := map[string]any{"crit": []string{"exp_ext"}, "exp_ext": "value"}
+	token := signWith(b, benchClaims, header)
+
+	b.Run("Understood", func(b *testing.B) {
+		cfg := hmacKey(jwtware.HS256)
+		cfg.KnownCriticalHeaders = []string{"exp_ext"}
+
+		h := benchHandler(b, cfg)
+		runBench(b, h, benchCtx(withBearer(token)), fiber.StatusTeapot)
+	})
+
+	b.Run("Rejected", func(b *testing.B) {
+		h := benchHandler(b, hmacKey(jwtware.HS256))
+		runBench(b, h, benchCtx(withBearer(token)), fiber.StatusUnauthorized)
+	})
+}
+
+// Benchmark_Middleware_JWT_Skipped measures a request the Next filter waves
+// through, which is the whole cost of having the middleware on a route it does
+// not guard.
+func Benchmark_Middleware_JWT_Skipped(b *testing.B) {
+	cfg := hmacKey(jwtware.HS256)
+	cfg.Next = func(fiber.Ctx) bool { return true }
+
+	h := benchHandler(b, cfg)
+	runBench(b, h, benchCtx(), fiber.StatusTeapot)
+}
+
+// Benchmark_Middleware_JWT_TokenProcessor measures the hook that rewrites the
+// extracted token, here with the cheapest possible processor so the result is
+// the cost of the hook itself.
+func Benchmark_Middleware_JWT_TokenProcessor(b *testing.B) {
+	cfg := hmacKey(jwtware.HS256)
+	cfg.TokenProcessorFunc = func(token string) (string, error) { return token, nil }
+
+	h := benchHandler(b, cfg)
+	runBench(b, h, benchCtx(withBearer(hamac[0].Token)), fiber.StatusTeapot)
+}
+
+// Benchmark_Middleware_JWT_FromContext measures a handler that reads the token
+// back out of the context, which is what a real one does.
+func Benchmark_Middleware_JWT_FromContext(b *testing.B) {
+	h := benchHandlerFunc(b, hmacKey(jwtware.HS256), func(c fiber.Ctx) error {
+		if jwtware.FromContext(c) == nil {
+			return c.SendStatus(fiber.StatusInternalServerError)
+		}
+		return c.SendStatus(fiber.StatusTeapot)
+	})
+
+	runBench(b, h, benchCtx(withBearer(hamac[0].Token)), fiber.StatusTeapot)
 }

--- a/v3/jwt/jwt_bench_test.go
+++ b/v3/jwt/jwt_bench_test.go
@@ -192,8 +192,9 @@ func Benchmark_Middleware_JWT_Algorithms(b *testing.B) {
 }
 
 // Benchmark_Middleware_JWT_Extractors measures where the token is read from.
-// The query case also carries the RFC 6750 Section 2.3 cache directive the
-// middleware adds to those responses.
+// These answer 2xx, unlike the rest, so the query case measures the RFC 6750
+// Section 2.3 cache directive the middleware adds to a response a cache could
+// otherwise store.
 func Benchmark_Middleware_JWT_Extractors(b *testing.B) {
 	token := hamac[0].Token
 
@@ -212,8 +213,12 @@ func Benchmark_Middleware_JWT_Extractors(b *testing.B) {
 			cfg := hmacKey(jwtware.HS256)
 			cfg.Extractor = test.extractor
 
-			h := benchHandler(b, cfg)
-			runBench(b, h, benchCtx(test.setup), fiber.StatusTeapot)
+			// A 2xx answer, so the query case pays for the cache directive it
+			// earns rather than being waved through as a non-cacheable status.
+			h := benchHandlerFunc(b, cfg, func(c fiber.Ctx) error {
+				return c.SendStatus(fiber.StatusOK)
+			})
+			runBench(b, h, benchCtx(test.setup), fiber.StatusOK)
 		})
 	}
 }

--- a/v3/jwt/jwt_bench_test.go
+++ b/v3/jwt/jwt_bench_test.go
@@ -1,0 +1,128 @@
+package jwtware_test
+
+import (
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+
+	jwtware "github.com/gofiber/contrib/v3/jwt"
+)
+
+// benchApp builds a Fiber app guarded by the JWT middleware and returns its
+// fasthttp handler together with a request context carrying the given header.
+//
+// Reset the response between iterations, the way a served request starts from a
+// clean one: a handler that sets a response header would otherwise only set it
+// on the first iteration.
+func benchApp(b *testing.B, cfg jwtware.Config, header, value string) (fasthttp.RequestHandler, *fasthttp.RequestCtx) {
+	b.Helper()
+
+	app := fiber.New()
+	app.Use(jwtware.New(cfg))
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusTeapot)
+	})
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.SetMethod(fiber.MethodGet)
+	fctx.Request.SetRequestURI("/")
+	if header != "" {
+		fctx.Request.Header.Set(header, value)
+	}
+
+	return app.Handler(), fctx
+}
+
+// Benchmark_Middleware_JWT_Baseline drives the same Fiber app without the JWT
+// middleware attached. Subtract it from the numbers below to read the
+// middleware's own cost.
+func Benchmark_Middleware_JWT_Baseline(b *testing.B) {
+	app := fiber.New()
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusTeapot)
+	})
+
+	h := app.Handler()
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.SetMethod(fiber.MethodGet)
+	fctx.Request.SetRequestURI("/")
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		fctx.Response.Reset()
+		h(fctx)
+	}
+
+	require.Equal(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
+}
+
+// go test -run=^$ -bench=Benchmark_Middleware_JWT -benchmem -count=6
+func Benchmark_Middleware_JWT_MapClaims(b *testing.B) {
+	h, fctx := benchApp(b, jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+	}, fiber.HeaderAuthorization, "Bearer "+hamac[0].Token)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		fctx.Response.Reset()
+		h(fctx)
+	}
+
+	require.Equal(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
+}
+
+func Benchmark_Middleware_JWT_CustomClaims(b *testing.B) {
+	h, fctx := benchApp(b, jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		Claims:     &customClaims{},
+	}, fiber.HeaderAuthorization, "Bearer "+hamac[0].Token)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		fctx.Response.Reset()
+		h(fctx)
+	}
+
+	require.Equal(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
+}
+
+func Benchmark_Middleware_JWT_ParserOptions(b *testing.B) {
+	h, fctx := benchApp(b, jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		ParserOptions: []jwt.ParserOption{
+			jwt.WithIssuedAt(),
+			jwt.WithLeeway(0),
+			jwt.WithValidMethods([]string{jwtware.HS256}),
+		},
+	}, fiber.HeaderAuthorization, "Bearer "+hamac[0].Token)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		fctx.Response.Reset()
+		h(fctx)
+	}
+
+	require.Equal(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
+}
+
+func Benchmark_Middleware_JWT_MissingToken(b *testing.B) {
+	h, fctx := benchApp(b, jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+	}, "", "")
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		fctx.Response.Reset()
+		h(fctx)
+	}
+
+	require.Equal(b, fiber.StatusBadRequest, fctx.Response.Header.StatusCode())
+}

--- a/v3/jwt/jwt_bench_test.go
+++ b/v3/jwt/jwt_bench_test.go
@@ -53,18 +53,22 @@ func benchCtx(setup ...func(*fasthttp.RequestCtx)) *fasthttp.RequestCtx {
 	return fctx
 }
 
+// withBearer presents the token the way RFC 6750 Section 2.1 prefers.
 func withBearer(token string) func(*fasthttp.RequestCtx) {
 	return func(fctx *fasthttp.RequestCtx) {
 		fctx.Request.Header.Set(fiber.HeaderAuthorization, "Bearer "+token)
 	}
 }
 
+// withCookie presents the token in a cookie.
 func withCookie(name, token string) func(*fasthttp.RequestCtx) {
 	return func(fctx *fasthttp.RequestCtx) {
 		fctx.Request.Header.SetCookie(name, token)
 	}
 }
 
+// withQuery presents the token in the query string, the source that also
+// exercises the Cache-Control marking on the way out.
 func withQuery(param, token string) func(*fasthttp.RequestCtx) {
 	return func(fctx *fasthttp.RequestCtx) {
 		fctx.Request.SetRequestURI("/?" + param + "=" + token)
@@ -132,11 +136,15 @@ func Benchmark_Middleware_JWT_Baseline(b *testing.B) {
 	runBench(b, app.Handler(), benchCtx(), fiber.StatusTeapot)
 }
 
+// Benchmark_Middleware_JWT_MapClaims measures the default claims type, where
+// the parser decodes straight into a map.
 func Benchmark_Middleware_JWT_MapClaims(b *testing.B) {
 	h := benchHandler(b, hmacKey(jwtware.HS256))
 	runBench(b, h, benchCtx(withBearer(hamac[0].Token)), fiber.StatusTeapot)
 }
 
+// Benchmark_Middleware_JWT_CustomClaims measures a struct claims type, the path
+// that used to walk reflect on every request.
 func Benchmark_Middleware_JWT_CustomClaims(b *testing.B) {
 	cfg := hmacKey(jwtware.HS256)
 	cfg.Claims = &customClaims{}
@@ -145,6 +153,8 @@ func Benchmark_Middleware_JWT_CustomClaims(b *testing.B) {
 	runBench(b, h, benchCtx(withBearer(hamac[0].Token)), fiber.StatusTeapot)
 }
 
+// Benchmark_Middleware_JWT_ParserOptions measures a configuration carrying
+// parser options, which the middleware now applies once instead of per request.
 func Benchmark_Middleware_JWT_ParserOptions(b *testing.B) {
 	cfg := hmacKey(jwtware.HS256)
 	cfg.ParserOptions = []jwt.ParserOption{
@@ -157,6 +167,8 @@ func Benchmark_Middleware_JWT_ParserOptions(b *testing.B) {
 	runBench(b, h, benchCtx(withBearer(hamac[0].Token)), fiber.StatusTeapot)
 }
 
+// Benchmark_Middleware_JWT_MissingToken measures the rejection path, including
+// the challenge the response is answered with.
 func Benchmark_Middleware_JWT_MissingToken(b *testing.B) {
 	h := benchHandler(b, hmacKey(jwtware.HS256))
 	runBench(b, h, benchCtx(), fiber.StatusBadRequest)

--- a/v3/jwt/jwt_test.go
+++ b/v3/jwt/jwt_test.go
@@ -8,9 +8,11 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/extractors"
@@ -849,4 +851,54 @@ func TestParserOptions(t *testing.T) {
 	// Assert
 	assert.NoError(t, err)
 	assert.Equal(t, 401, resp.StatusCode)
+}
+
+// TestConcurrentRequests exercises the parser and the claims factory that the
+// middleware builds once and then shares between requests.
+func TestConcurrentRequests(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(jwtware.New(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		Claims:     &customClaims{},
+	}))
+	app.Get("/ok", func(c fiber.Ctx) error {
+		claims, ok := jwtware.FromContext(c).Claims.(*customClaims)
+		if !ok || claims.Name != "John Doe" {
+			return c.SendStatus(fiber.StatusInternalServerError)
+		}
+		return c.SendString("OK")
+	})
+
+	handler := app.Handler()
+
+	const workers, requests = 8, 50
+	statuses := make([][]int, workers)
+
+	var wg sync.WaitGroup
+	for worker := range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			statuses[worker] = make([]int, requests)
+			for i := range requests {
+				fctx := &fasthttp.RequestCtx{}
+				fctx.Request.Header.SetMethod(fiber.MethodGet)
+				fctx.Request.SetRequestURI("/ok")
+				fctx.Request.Header.Set(fiber.HeaderAuthorization, "Bearer "+hamac[0].Token)
+
+				handler(fctx)
+				statuses[worker][i] = fctx.Response.StatusCode()
+			}
+		}()
+	}
+	wg.Wait()
+
+	for _, worker := range statuses {
+		for _, status := range worker {
+			assert.Equal(t, fiber.StatusOK, status)
+		}
+	}
 }

--- a/v3/jwt/rfc_test.go
+++ b/v3/jwt/rfc_test.go
@@ -628,6 +628,87 @@ func TestChainedQueryTokenMarksOnlyQueryRequests(t *testing.T) {
 	})
 }
 
+// TestUnselectedURLCredentialIsPrivate covers a request whose URL carries a
+// token the chain did not use. A shared cache keys on the URL, so storing this
+// response would file one caller's body under another's credential and hand it
+// to whoever presents that credential next; which extractor happened to win is
+// beside the point.
+func TestUnselectedURLCredentialIsPrivate(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(jwtware.New(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		Extractor: extractors.Chain(
+			extractors.FromCookie("token"),
+			extractors.FromQuery("token"),
+		),
+	}))
+	app.Get("/ok", func(c fiber.Ctx) error {
+		return c.SendString(jwtware.FromContext(c).Claims.(jwt.MapClaims)["name"].(string))
+	})
+
+	// The cookie wins the chain; the query string still holds someone else's.
+	req := httptest.NewRequest(http.MethodGet, "/ok?token="+signWith(t, jwt.MapClaims{"name": "bob"}, nil), nil)
+	req.AddCookie(&http.Cookie{Name: "token", Value: signWith(t, jwt.MapClaims{"name": "alice"}, nil)})
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "alice", string(body), "the cookie is what authenticated")
+	require.Equal(t, "private", resp.Header.Get(fiber.HeaderCacheControl))
+}
+
+// TestPrivateIsSetBeforeTheHandlerRuns pins the ordering the directive depends
+// on: a cache registered after this middleware reads the response as its own
+// stack unwinds, so anything downstream has to be able to see the directive
+// while it still matters.
+func TestPrivateIsSetBeforeTheHandlerRuns(t *testing.T) {
+	t.Parallel()
+
+	var seen string
+	app := fiber.New()
+	app.Use(jwtware.New(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		Extractor:  extractors.FromQuery("token"),
+	}))
+	app.Get("/ok", func(c fiber.Ctx) error {
+		seen = string(c.Response().Header.Peek(fiber.HeaderCacheControl))
+		return c.SendString("OK")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/ok?token="+hamac[0].Token, nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Equal(t, "private", seen, "downstream code has to see it too, not just the client")
+	require.Equal(t, "private", resp.Header.Get(fiber.HeaderCacheControl))
+}
+
+// TestMalformedCachePolicyIsReplaced covers a handler policy with an
+// unterminated quoted string. Appending to one hides the appended directive
+// inside the open quotes, so a policy no cache can parse is replaced instead.
+func TestMalformedCachePolicyIsReplaced(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(jwtware.New(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		Extractor:  extractors.FromQuery("token"),
+	}))
+	app.Get("/ok", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderCacheControl, `ext="unterminated`)
+		return c.SendString("OK")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/ok?token="+hamac[0].Token, nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Equal(t, "private", resp.Header.Get(fiber.HeaderCacheControl))
+}
+
 // TestQueryTokenWithProcessorIsPrivate covers a TokenProcessorFunc that turns
 // the extracted value into something else: what the URL held is the extractor's
 // answer, not the processor's, and that is what decides whether the response

--- a/v3/jwt/rfc_test.go
+++ b/v3/jwt/rfc_test.go
@@ -1,6 +1,7 @@
 package jwtware_test
 
 import (
+	"encoding/hex"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -584,4 +585,108 @@ func TestChainedQueryTokenMarksOnlyQueryRequests(t *testing.T) {
 		require.Equal(t, fiber.StatusOK, resp.StatusCode)
 		require.Equal(t, "private", resp.Header.Get(fiber.HeaderCacheControl))
 	})
+}
+
+// TestQueryTokenWithProcessorIsPrivate covers a TokenProcessorFunc that turns
+// the extracted value into something else: what the URL held is the extractor's
+// answer, not the processor's, and that is what decides whether the response
+// may be stored by a shared cache.
+func TestQueryTokenWithProcessorIsPrivate(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(jwtware.New(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		Extractor:  extractors.FromQuery("token"),
+		TokenProcessorFunc: func(token string) (string, error) {
+			decoded, err := hex.DecodeString(token)
+			return string(decoded), err
+		},
+	}))
+	app.Get("/ok", func(c fiber.Ctx) error { return c.SendString("OK") })
+
+	target := "/ok?token=" + hex.EncodeToString([]byte(hamac[0].Token))
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, target, nil))
+	require.NoError(t, err)
+
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Equal(t, "private", resp.Header.Get(fiber.HeaderCacheControl))
+}
+
+// TestQueryTokenPrivateOverQuotedPolicy covers a Cache-Control value whose
+// quoted field list contains an escaped quote, a comma and the word "private":
+// none of that may hide a real "public" directive from the scan.
+func TestQueryTokenPrivateOverQuotedPolicy(t *testing.T) {
+	t.Parallel()
+
+	policy := `ext="a\", private, b", public`
+
+	app := fiber.New()
+	app.Use(jwtware.New(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		Extractor:  extractors.FromQuery("token"),
+	}))
+	app.Get("/ok", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderCacheControl, policy)
+		return c.SendString("OK")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/ok?token="+hamac[0].Token, nil))
+	require.NoError(t, err)
+
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Equal(t, `ext="a\", private, b", private`, resp.Header.Get(fiber.HeaderCacheControl))
+}
+
+// TestChallengeUsesReturnedErrorStatus covers an error handler that leaves the
+// status to Fiber while an earlier middleware had already put a different one
+// on the response: the challenge has to match the status the client will see.
+func TestChallengeUsesReturnedErrorStatus(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.Status(fiber.StatusProxyAuthRequired)
+		return c.Next()
+	})
+	app.Use(jwtware.New(jwtware.Config{
+		SigningKey:   jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		ErrorHandler: func(_ fiber.Ctx, _ error) error { return fiber.ErrUnauthorized },
+	}))
+	app.Get("/ok", func(c fiber.Ctx) error { return c.SendString("OK") })
+
+	resp := doGet(t, app, "Bearer not-a-jwt")
+	require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	require.Equal(t,
+		`Bearer realm="Restricted", error="invalid_token", error_description="The access token is malformed"`,
+		resp.Header.Get(fiber.HeaderWWWAuthenticate))
+	require.Empty(t, resp.Header.Get(fiber.HeaderProxyAuthenticate))
+}
+
+// TestCyclicExtractorChain builds the extractor metadata a caller could hand
+// over by aliasing a slice, which the walks over Chain must survive.
+func TestCyclicExtractorChain(t *testing.T) {
+	t.Parallel()
+
+	chain := make([]extractors.Extractor, 1)
+	cyclic := extractors.Extractor{
+		Extract:    extractors.FromAuthHeader("Bearer").Extract,
+		Key:        fiber.HeaderAuthorization,
+		AuthScheme: "Bearer",
+		Source:     extractors.SourceAuthHeader,
+		Chain:      chain,
+	}
+	chain[0] = cyclic
+
+	app := fiber.New()
+	require.NotPanics(t, func() {
+		app.Use(jwtware.New(jwtware.Config{
+			SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+			Extractor:  cyclic,
+		}))
+	})
+	app.Get("/ok", func(c fiber.Ctx) error { return c.SendString("OK") })
+
+	resp := doGet(t, app, "Bearer "+hamac[0].Token)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
 }

--- a/v3/jwt/rfc_test.go
+++ b/v3/jwt/rfc_test.go
@@ -526,6 +526,32 @@ func TestQueryTokenResponseIsPrivate(t *testing.T) {
 	})
 }
 
+// TestChallengeOffersBearerForMixedChains covers a chain that reads both an
+// Authorization header with its own scheme and a URL parameter. A token refused
+// from the query is a bearer token, so the challenge has to offer Bearer beside
+// the header's scheme rather than answering with a scheme the client never used.
+func TestChallengeOffersBearerForMixedChains(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(jwtware.New(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		Extractor: extractors.Chain(
+			extractors.FromAuthHeader("Basic"),
+			extractors.FromQuery("token"),
+		),
+	}))
+	app.Get("/ok", func(c fiber.Ctx) error { return c.SendString("OK") })
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/ok?token=not-a-jwt", nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	require.Equal(
+		t,
+		`Basic realm="Restricted", Bearer realm="Restricted", error="invalid_token", error_description="The access token is malformed"`,
+		resp.Header.Get(fiber.HeaderWWWAuthenticate))
+}
+
 // TestChallengeJoinsAnEarlierMiddlewares checks that a challenge another
 // authentication middleware already put on the response survives and that this
 // middleware's own goes beside it: RFC 9110 Section 11.6.1 lets the field carry

--- a/v3/jwt/rfc_test.go
+++ b/v3/jwt/rfc_test.go
@@ -1,0 +1,483 @@
+package jwtware_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/extractors"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+
+	jwtware "github.com/gofiber/contrib/v3/jwt"
+)
+
+// signWith builds a token signed with the shared HMAC test key, applying the
+// given mutations to its header first.
+func signWith(t *testing.T, claims jwt.Claims, header map[string]any) string {
+	t.Helper()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	for name, value := range header {
+		token.Header[name] = value
+	}
+	signed, err := token.SignedString([]byte(defaultSigningKey))
+	require.NoError(t, err)
+	return signed
+}
+
+// protectedApp guards a single route with the middleware and echoes the token's
+// "name" claim, so a test can tell whose token was accepted.
+func protectedApp(cfg jwtware.Config) *fiber.App {
+	app := fiber.New()
+	app.Use(jwtware.New(cfg))
+	app.Get("/ok", func(c fiber.Ctx) error {
+		token := jwtware.FromContext(c)
+		if token == nil {
+			return c.SendStatus(fiber.StatusInternalServerError)
+		}
+		name, _ := token.Claims.(jwt.MapClaims)["name"].(string)
+		return c.SendString("OK " + name)
+	})
+	return app
+}
+
+func doGet(t *testing.T, app *fiber.App, authorization string) *http.Response {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/ok", nil)
+	if authorization != "" {
+		req.Header.Set(fiber.HeaderAuthorization, authorization)
+	}
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// TestCriticalHeaders covers RFC 7515 Section 4.1.11: a JWS that marks header
+// parameters critical may only be accepted when every one of them is understood.
+func TestCriticalHeaders(t *testing.T) {
+	t.Parallel()
+
+	claims := jwt.MapClaims{"name": "John Doe"}
+
+	tests := []struct {
+		header map[string]any
+		name   string
+		known  []string
+		status int
+	}{
+		{
+			name:   "unknown extension is rejected",
+			header: map[string]any{"crit": []string{"exp_ext"}, "exp_ext": "value"},
+			status: fiber.StatusUnauthorized,
+		},
+		{
+			name:   "declared extension is accepted",
+			header: map[string]any{"crit": []string{"exp_ext"}, "exp_ext": "value"},
+			known:  []string{"exp_ext"},
+			status: fiber.StatusOK,
+		},
+		{
+			name:   "declaring one extension does not cover another",
+			header: map[string]any{"crit": []string{"exp_ext", "other"}, "exp_ext": "v", "other": "v"},
+			known:  []string{"exp_ext"},
+			status: fiber.StatusUnauthorized,
+		},
+		{
+			name:   "registered header parameter may not be critical",
+			header: map[string]any{"crit": []string{"alg"}},
+			known:  []string{"alg"},
+			status: fiber.StatusUnauthorized,
+		},
+		{
+			name:   "name absent from the header is rejected",
+			header: map[string]any{"crit": []string{"exp_ext"}},
+			known:  []string{"exp_ext"},
+			status: fiber.StatusUnauthorized,
+		},
+		{
+			name:   "duplicate name is rejected",
+			header: map[string]any{"crit": []string{"exp_ext", "exp_ext"}, "exp_ext": "v"},
+			known:  []string{"exp_ext"},
+			status: fiber.StatusUnauthorized,
+		},
+		{
+			name:   "empty list is rejected",
+			header: map[string]any{"crit": []string{}},
+			known:  []string{"exp_ext"},
+			status: fiber.StatusUnauthorized,
+		},
+		{
+			name:   "non-array value is rejected",
+			header: map[string]any{"crit": "exp_ext", "exp_ext": "v"},
+			known:  []string{"exp_ext"},
+			status: fiber.StatusUnauthorized,
+		},
+		{
+			name:   "non-string entry is rejected",
+			header: map[string]any{"crit": []any{1}, "1": "v"},
+			known:  []string{"exp_ext"},
+			status: fiber.StatusUnauthorized,
+		},
+		{
+			name:   "token without crit is untouched",
+			header: nil,
+			status: fiber.StatusOK,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := protectedApp(jwtware.Config{
+				SigningKey:           jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+				KnownCriticalHeaders: test.known,
+			})
+
+			resp := doGet(t, app, "Bearer "+signWith(t, claims, test.header))
+			require.Equal(t, test.status, resp.StatusCode)
+		})
+	}
+}
+
+// TestCriticalHeaderWrapsCustomKeyfunc makes sure the "crit" check is not
+// something a caller loses by supplying a key function of their own.
+func TestCriticalHeaderWrapsCustomKeyfunc(t *testing.T) {
+	t.Parallel()
+
+	app := protectedApp(jwtware.Config{KeyFunc: customKeyfunc()})
+
+	header := map[string]any{"crit": []string{"exp_ext"}, "exp_ext": "value"}
+	resp := doGet(t, app, "Bearer "+signWith(t, jwt.MapClaims{"name": "John Doe"}, header))
+	require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+}
+
+// TestChallengeOnRejection covers RFC 9110 Section 15.5.2 and RFC 6750
+// Section 3: a rejected request has to be told how to authenticate, and why the
+// credentials it sent were refused.
+func TestChallengeOnRejection(t *testing.T) {
+	t.Parallel()
+
+	expired := signWith(t, jwt.RegisteredClaims{
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour)),
+	}, nil)
+
+	tests := []struct {
+		name      string
+		authValue string
+		challenge string
+		status    int
+	}{
+		{
+			name:      "missing credentials",
+			authValue: "",
+			status:    fiber.StatusBadRequest,
+			challenge: `Bearer realm="Restricted", error="invalid_request", error_description="The access token is missing or malformed"`,
+		},
+		{
+			name:      "malformed credentials",
+			authValue: "Bearer not-a-jwt",
+			status:    fiber.StatusUnauthorized,
+			challenge: `Bearer realm="Restricted", error="invalid_token", error_description="The access token is malformed"`,
+		},
+		{
+			name:      "expired token",
+			authValue: "Bearer " + expired,
+			status:    fiber.StatusUnauthorized,
+			challenge: `Bearer realm="Restricted", error="invalid_token", error_description="The access token expired"`,
+		},
+		{
+			name:      "signature from another key",
+			authValue: "Bearer " + hamac[1].Token,
+			status:    fiber.StatusUnauthorized,
+			challenge: `Bearer realm="Restricted", error="invalid_token", error_description="The access token signature is invalid"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := protectedApp(jwtware.Config{
+				SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+			})
+
+			resp := doGet(t, app, test.authValue)
+			require.Equal(t, test.status, resp.StatusCode)
+			require.Equal(t, test.challenge, resp.Header.Get(fiber.HeaderWWWAuthenticate))
+		})
+	}
+}
+
+func TestChallengeIsAbsentOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	app := protectedApp(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+	})
+
+	resp := doGet(t, app, "Bearer "+hamac[0].Token)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Empty(t, resp.Header.Get(fiber.HeaderWWWAuthenticate))
+}
+
+func TestChallengeUsesConfiguredRealmAndScheme(t *testing.T) {
+	t.Parallel()
+
+	app := protectedApp(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		Realm:      "api",
+		Extractor:  extractors.FromAuthHeader("JWT"),
+	})
+
+	resp := doGet(t, app, "JWT not-a-jwt")
+	require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	// The RFC 6750 error parameters are defined for the bearer scheme only.
+	require.Equal(t, `JWT realm="api"`, resp.Header.Get(fiber.HeaderWWWAuthenticate))
+}
+
+// TestChallengeForNonHeaderExtractor checks that a token read from somewhere
+// other than the Authorization header still produces the challenge RFC 9110
+// Section 15.5.2 requires.
+func TestChallengeForNonHeaderExtractor(t *testing.T) {
+	t.Parallel()
+
+	app := protectedApp(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		Extractor:  extractors.FromCookie("token"),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/ok", nil)
+	req.AddCookie(&http.Cookie{Name: "token", Value: "not-a-jwt"})
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+
+	require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	require.Equal(t,
+		`Bearer realm="Restricted", error="invalid_token", error_description="The access token is malformed"`,
+		resp.Header.Get(fiber.HeaderWWWAuthenticate))
+}
+
+func TestChallengeFromCustomErrorHandlerIsKept(t *testing.T) {
+	t.Parallel()
+
+	app := protectedApp(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		ErrorHandler: func(c fiber.Ctx, _ error) error {
+			c.Set(fiber.HeaderWWWAuthenticate, `Bearer realm="custom"`)
+			return c.SendStatus(fiber.StatusUnauthorized)
+		},
+	})
+
+	resp := doGet(t, app, "Bearer not-a-jwt")
+	require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	require.Equal(t, `Bearer realm="custom"`, resp.Header.Get(fiber.HeaderWWWAuthenticate))
+}
+
+// TestChallengeForDeferredStatus covers an error handler that leaves the status
+// to Fiber by returning a *fiber.Error instead of writing a response.
+func TestChallengeForDeferredStatus(t *testing.T) {
+	t.Parallel()
+
+	app := protectedApp(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		ErrorHandler: func(_ fiber.Ctx, _ error) error {
+			return fiber.ErrUnauthorized
+		},
+	})
+
+	resp := doGet(t, app, "Bearer not-a-jwt")
+	require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	require.Equal(t,
+		`Bearer realm="Restricted", error="invalid_token", error_description="The access token is malformed"`,
+		resp.Header.Get(fiber.HeaderWWWAuthenticate))
+}
+
+func TestNoChallengeOnUnrelatedStatus(t *testing.T) {
+	t.Parallel()
+
+	app := protectedApp(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		ErrorHandler: func(c fiber.Ctx, _ error) error {
+			return c.SendStatus(fiber.StatusTeapot)
+		},
+	})
+
+	resp := doGet(t, app, "Bearer not-a-jwt")
+	require.Equal(t, fiber.StatusTeapot, resp.StatusCode)
+	require.Empty(t, resp.Header.Get(fiber.HeaderWWWAuthenticate))
+}
+
+// TestAlgorithmIsPinnedToConfiguration covers RFC 8725 Section 3.1: the
+// algorithm comes from the configuration, never from the token.
+func TestAlgorithmIsPinnedToConfiguration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single key", func(t *testing.T) {
+		t.Parallel()
+
+		app := protectedApp(jwtware.Config{
+			SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS512, Key: []byte(defaultSigningKey)},
+		})
+
+		// hamac[0] is signed with the same key, but with HS256.
+		resp := doGet(t, app, "Bearer "+hamac[0].Token)
+		require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("key set", func(t *testing.T) {
+		t.Parallel()
+
+		app := protectedApp(jwtware.Config{
+			SigningKeys: map[string]jwtware.SigningKey{
+				"one": {JWTAlg: jwtware.HS512, Key: []byte(defaultSigningKey)},
+				"two": {JWTAlg: jwtware.HS384, Key: []byte(defaultSigningKey)},
+			},
+		})
+
+		accepted := signWith(t, jwt.MapClaims{"name": "John Doe"}, nil)
+		resp := doGet(t, app, "Bearer "+accepted)
+		require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode, "HS256 is not one of the configured algorithms")
+	})
+
+	t.Run("caller options win", func(t *testing.T) {
+		t.Parallel()
+
+		app := protectedApp(jwtware.Config{
+			SigningKey:    jwtware.SigningKey{Key: []byte(defaultSigningKey)},
+			ParserOptions: []jwt.ParserOption{jwt.WithValidMethods([]string{jwtware.HS512})},
+		})
+
+		resp := doGet(t, app, "Bearer "+hamac[0].Token)
+		require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	})
+}
+
+func TestUnexpectedAlgorithmIsReported(t *testing.T) {
+	t.Parallel()
+
+	var handled error
+	app := protectedApp(jwtware.Config{
+		// Without a pinned algorithm the parser accepts the token and the key
+		// function is the one that has to refuse it.
+		KeyFunc: func(_ *jwt.Token) (any, error) {
+			return nil, jwtware.ErrJWTAlg
+		},
+		ErrorHandler: func(c fiber.Ctx, err error) error {
+			handled = err
+			return c.SendStatus(fiber.StatusUnauthorized)
+		},
+	})
+
+	resp := doGet(t, app, "Bearer "+hamac[0].Token)
+	require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	require.ErrorIs(t, handled, jwtware.ErrJWTAlg)
+}
+
+// TestClaimsAreNotSharedBetweenRequests makes sure the configured Claims value
+// only ever supplies the type. Sharing the value itself would leak one request's
+// claims into the next.
+func TestClaimsAreNotSharedBetweenRequests(t *testing.T) {
+	t.Parallel()
+
+	configured := &customClaims{}
+
+	app := fiber.New()
+	app.Use(jwtware.New(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		Claims:     configured,
+	}))
+	app.Get("/ok", func(c fiber.Ctx) error {
+		claims, ok := jwtware.FromContext(c).Claims.(*customClaims)
+		require.True(t, ok)
+		return c.SendString(claims.Name)
+	})
+
+	for _, name := range []string{"first", "second"} {
+		token := signWith(t, jwt.MapClaims{"name": name}, nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/ok", nil)
+		req.Header.Set(fiber.HeaderAuthorization, "Bearer "+token)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, name, string(body))
+	}
+
+	require.Empty(t, configured.Name, "the configured claims value must not be written to")
+}
+
+// TestQueryTokenResponseIsPrivate covers RFC 6750 Section 2.3: a token in the
+// query string travels in the URL, so a shared cache must not keep the response.
+func TestQueryTokenResponseIsPrivate(t *testing.T) {
+	t.Parallel()
+
+	newApp := func(handler fiber.Handler) *fiber.App {
+		app := fiber.New()
+		app.Use(jwtware.New(jwtware.Config{
+			SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+			Extractor:  extractors.FromQuery("token"),
+		}))
+		app.Get("/ok", handler)
+		return app
+	}
+
+	get := func(t *testing.T, app *fiber.App, target string) *http.Response {
+		t.Helper()
+		resp, err := app.Test(httptest.NewRequest(http.MethodGet, target, nil))
+		require.NoError(t, err)
+		return resp
+	}
+
+	okHandler := func(c fiber.Ctx) error { return c.SendString("OK") }
+
+	t.Run("success is marked private", func(t *testing.T) {
+		t.Parallel()
+
+		resp := get(t, newApp(okHandler), "/ok?token="+hamac[0].Token)
+		require.Equal(t, fiber.StatusOK, resp.StatusCode)
+		require.Equal(t, "private", resp.Header.Get(fiber.HeaderCacheControl))
+	})
+
+	t.Run("handler keeps its own policy", func(t *testing.T) {
+		t.Parallel()
+
+		app := newApp(func(c fiber.Ctx) error {
+			c.Set(fiber.HeaderCacheControl, "no-store")
+			return c.SendString("OK")
+		})
+
+		resp := get(t, app, "/ok?token="+hamac[0].Token)
+		require.Equal(t, "no-store", resp.Header.Get(fiber.HeaderCacheControl))
+	})
+
+	t.Run("rejection is not marked", func(t *testing.T) {
+		t.Parallel()
+
+		resp := get(t, newApp(okHandler), "/ok?token=not-a-jwt")
+		require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+		require.Empty(t, resp.Header.Get(fiber.HeaderCacheControl))
+	})
+
+	t.Run("header tokens are left alone", func(t *testing.T) {
+		t.Parallel()
+
+		app := fiber.New()
+		app.Use(jwtware.New(jwtware.Config{
+			SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		}))
+		app.Get("/ok", okHandler)
+
+		resp := doGet(t, app, "Bearer "+hamac[0].Token)
+		require.Equal(t, fiber.StatusOK, resp.StatusCode)
+		require.Empty(t, resp.Header.Get(fiber.HeaderCacheControl))
+	})
+}

--- a/v3/jwt/rfc_test.go
+++ b/v3/jwt/rfc_test.go
@@ -690,3 +690,92 @@ func TestCyclicExtractorChain(t *testing.T) {
 	resp := doGet(t, app, "Bearer "+hamac[0].Token)
 	require.Equal(t, fiber.StatusOK, resp.StatusCode)
 }
+
+// TestBranchingCyclicExtractorChain covers extractor metadata whose cycle
+// branches: following every path through such a chain is exponential, so the
+// walk has to visit each node once rather than merely bounding its depth.
+func TestBranchingCyclicExtractorChain(t *testing.T) {
+	t.Parallel()
+
+	chain := make([]extractors.Extractor, 2)
+	cyclic := extractors.Extractor{
+		Extract:    extractors.FromAuthHeader("Bearer").Extract,
+		Key:        fiber.HeaderAuthorization,
+		AuthScheme: "Bearer",
+		Source:     extractors.SourceAuthHeader,
+		Chain:      chain,
+	}
+	chain[0] = cyclic
+	chain[1] = cyclic
+
+	built := make(chan fiber.Handler, 1)
+	go func() {
+		built <- jwtware.New(jwtware.Config{
+			SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+			Extractor:  cyclic,
+		})
+	}()
+
+	select {
+	case handler := <-built:
+		require.NotNil(t, handler)
+	case <-time.After(10 * time.Second):
+		t.Fatal("building the middleware did not finish: the chain walk is not visiting each node once")
+	}
+}
+
+// TestQueryTokenPrivateOverArgumentedDirectives covers directives carrying an
+// argument they are not defined to take: RFC 9111 Section 5.2.3 has a recipient
+// ignore those, so they cannot be what keeps the response out of a shared cache.
+func TestQueryTokenPrivateOverArgumentedDirectives(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		policy   string
+		expected string
+	}{
+		{name: "argumented no-store", policy: "no-store=foo", expected: "no-store=foo, private"},
+		{name: "bare no-store", policy: "no-store", expected: "no-store"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := fiber.New()
+			app.Use(jwtware.New(jwtware.Config{
+				SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+				Extractor:  extractors.FromQuery("token"),
+			}))
+			app.Get("/ok", func(c fiber.Ctx) error {
+				c.Set(fiber.HeaderCacheControl, test.policy)
+				return c.SendString("OK")
+			})
+
+			resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/ok?token="+hamac[0].Token, nil))
+			require.NoError(t, err)
+			require.Equal(t, fiber.StatusOK, resp.StatusCode)
+			require.Equal(t, test.expected, resp.Header.Get(fiber.HeaderCacheControl))
+		})
+	}
+}
+
+// TestEmptyQueryParamTokenIsPrivate covers extractors.FromQuery(""), which reads
+// the token from "/?=<jwt>": the URL carries it just the same.
+func TestEmptyQueryParamTokenIsPrivate(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(jwtware.New(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		Extractor:  extractors.FromQuery(""),
+	}))
+	app.Get("/ok", func(c fiber.Ctx) error { return c.SendString("OK") })
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/ok?="+hamac[0].Token, nil))
+	require.NoError(t, err)
+
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Equal(t, "private", resp.Header.Get(fiber.HeaderCacheControl))
+}

--- a/v3/jwt/rfc_test.go
+++ b/v3/jwt/rfc_test.go
@@ -47,6 +47,8 @@ func protectedApp(cfg jwtware.Config) *fiber.App {
 	return app
 }
 
+// doGet sends a GET to the protected route, optionally with an Authorization
+// header, and returns the response for the caller to assert on.
 func doGet(t *testing.T, app *fiber.App, authorization string) *http.Response {
 	t.Helper()
 
@@ -218,6 +220,8 @@ func TestChallengeOnRejection(t *testing.T) {
 	}
 }
 
+// TestChallengeIsAbsentOnSuccess keeps the challenge on the rejection path: a
+// request whose token verified is not being asked for credentials.
 func TestChallengeIsAbsentOnSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -230,6 +234,8 @@ func TestChallengeIsAbsentOnSuccess(t *testing.T) {
 	require.Empty(t, resp.Header.Get(fiber.HeaderWWWAuthenticate))
 }
 
+// TestChallengeUsesConfiguredRealmAndScheme reads the realm from Config.Realm
+// and the scheme from the extractor rather than assuming Bearer.
 func TestChallengeUsesConfiguredRealmAndScheme(t *testing.T) {
 	t.Parallel()
 
@@ -267,6 +273,8 @@ func TestChallengeForNonHeaderExtractor(t *testing.T) {
 		resp.Header.Get(fiber.HeaderWWWAuthenticate))
 }
 
+// TestChallengeFromCustomErrorHandlerIsKept covers the rule that a challenge
+// already on the response is never replaced, whoever put it there.
 func TestChallengeFromCustomErrorHandlerIsKept(t *testing.T) {
 	t.Parallel()
 
@@ -302,6 +310,8 @@ func TestChallengeForDeferredStatus(t *testing.T) {
 		resp.Header.Get(fiber.HeaderWWWAuthenticate))
 }
 
+// TestNoChallengeOnUnrelatedStatus limits the header to the statuses RFC 9110
+// defines it for: an ErrorHandler answering with anything else gets none.
 func TestNoChallengeOnUnrelatedStatus(t *testing.T) {
 	t.Parallel()
 
@@ -362,6 +372,8 @@ func TestAlgorithmIsPinnedToConfiguration(t *testing.T) {
 	})
 }
 
+// TestUnexpectedAlgorithmIsReported checks that ErrJWTAlg survives to the
+// ErrorHandler when the key function is the one refusing the algorithm.
 func TestUnexpectedAlgorithmIsReported(t *testing.T) {
 	t.Parallel()
 

--- a/v3/jwt/rfc_test.go
+++ b/v3/jwt/rfc_test.go
@@ -177,7 +177,9 @@ func TestChallengeOnRejection(t *testing.T) {
 			name:      "missing credentials",
 			authValue: "",
 			status:    fiber.StatusBadRequest,
-			challenge: `Bearer realm="Restricted", error="invalid_request", error_description="The access token is missing or malformed"`,
+			// RFC 6750 Section 3.1: nothing usable was presented, so the
+			// challenge names no error about it.
+			challenge: `Bearer realm="Restricted"`,
 		},
 		{
 			name:      "malformed credentials",
@@ -479,5 +481,107 @@ func TestQueryTokenResponseIsPrivate(t *testing.T) {
 		resp := doGet(t, app, "Bearer "+hamac[0].Token)
 		require.Equal(t, fiber.StatusOK, resp.StatusCode)
 		require.Empty(t, resp.Header.Get(fiber.HeaderCacheControl))
+	})
+}
+
+// TestChallengeFromEarlierMiddlewareIsKept checks that a challenge another
+// authentication middleware already put on the response survives, whether or
+// not this middleware's error handler is the default one.
+func TestChallengeFromEarlierMiddlewareIsKept(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderWWWAuthenticate, `Basic realm="other"`)
+		return c.Next()
+	})
+	app.Use(jwtware.New(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+	}))
+	app.Get("/ok", func(c fiber.Ctx) error { return c.SendString("OK") })
+
+	resp := doGet(t, app, "Bearer not-a-jwt")
+	require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	require.Equal(t, `Basic realm="other"`, resp.Header.Get(fiber.HeaderWWWAuthenticate))
+}
+
+// TestQueryTokenIsPrivateOverPublicPolicy covers a handler that would otherwise
+// let a shared cache store a response whose URL carries the token.
+func TestQueryTokenIsPrivateOverPublicPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		policy   string
+		expected string
+	}{
+		{name: "public is replaced", policy: "public, max-age=60", expected: "max-age=60, private"},
+		{name: "no-store is enough", policy: "no-store", expected: "no-store"},
+		{name: "private is enough", policy: "private, max-age=60", expected: "private, max-age=60"},
+		{name: "field-scoped private is not", policy: `private="x-user", max-age=60`, expected: `private="x-user", max-age=60, private`},
+		{name: "unrelated policy is kept", policy: "max-age=60", expected: "max-age=60, private"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := fiber.New()
+			app.Use(jwtware.New(jwtware.Config{
+				SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+				Extractor:  extractors.FromQuery("token"),
+			}))
+			app.Get("/ok", func(c fiber.Ctx) error {
+				c.Set(fiber.HeaderCacheControl, test.policy)
+				return c.SendString("OK")
+			})
+
+			resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/ok?token="+hamac[0].Token, nil))
+			require.NoError(t, err)
+			require.Equal(t, fiber.StatusOK, resp.StatusCode)
+			require.Equal(t, test.expected, resp.Header.Get(fiber.HeaderCacheControl))
+		})
+	}
+}
+
+// TestChainedQueryTokenMarksOnlyQueryRequests covers a chain that can read the
+// query but did not: a token that never appeared in the URL leaves the
+// response as cacheable as the application made it.
+func TestChainedQueryTokenMarksOnlyQueryRequests(t *testing.T) {
+	t.Parallel()
+
+	newApp := func() *fiber.App {
+		app := fiber.New()
+		app.Use(jwtware.New(jwtware.Config{
+			SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+			Extractor: extractors.Chain(
+				extractors.FromCookie("token"),
+				extractors.FromQuery("token"),
+			),
+		}))
+		app.Get("/ok", func(c fiber.Ctx) error { return c.SendString("OK") })
+		return app
+	}
+
+	t.Run("cookie is left alone", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/ok", nil)
+		req.AddCookie(&http.Cookie{Name: "token", Value: hamac[0].Token})
+		resp, err := newApp().Test(req)
+		require.NoError(t, err)
+
+		require.Equal(t, fiber.StatusOK, resp.StatusCode)
+		require.Empty(t, resp.Header.Get(fiber.HeaderCacheControl))
+	})
+
+	t.Run("query is marked private", func(t *testing.T) {
+		t.Parallel()
+
+		resp, err := newApp().Test(httptest.NewRequest(http.MethodGet, "/ok?token="+hamac[0].Token, nil))
+		require.NoError(t, err)
+
+		require.Equal(t, fiber.StatusOK, resp.StatusCode)
+		require.Equal(t, "private", resp.Header.Get(fiber.HeaderCacheControl))
 	})
 }

--- a/v3/jwt/rfc_test.go
+++ b/v3/jwt/rfc_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -778,4 +779,87 @@ func TestEmptyQueryParamTokenIsPrivate(t *testing.T) {
 
 	require.Equal(t, fiber.StatusOK, resp.StatusCode)
 	require.Equal(t, "private", resp.Header.Get(fiber.HeaderCacheControl))
+}
+
+// TestFormTokenFromQueryIsPrivate covers extractors.FromForm: Fiber's FormValue
+// searches the query string before the request body, so a form parameter can
+// carry the token in the URL just as a query parameter does - and when it comes
+// from the body instead, the URL is clean and the response is left alone.
+func TestFormTokenFromQueryIsPrivate(t *testing.T) {
+	t.Parallel()
+
+	newApp := func() *fiber.App {
+		app := fiber.New()
+		app.Use(jwtware.New(jwtware.Config{
+			SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+			Extractor:  extractors.FromForm("token"),
+		}))
+		handler := func(c fiber.Ctx) error { return c.SendString("OK") }
+		app.Get("/ok", handler)
+		app.Post("/ok", handler)
+		return app
+	}
+
+	t.Run("from the query string", func(t *testing.T) {
+		t.Parallel()
+
+		resp, err := newApp().Test(httptest.NewRequest(http.MethodGet, "/ok?token="+hamac[0].Token, nil))
+		require.NoError(t, err)
+
+		require.Equal(t, fiber.StatusOK, resp.StatusCode)
+		require.Equal(t, "private", resp.Header.Get(fiber.HeaderCacheControl))
+	})
+
+	t.Run("from the request body", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodPost, "/ok", strings.NewReader("token="+hamac[0].Token))
+		req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationForm)
+		resp, err := newApp().Test(req)
+		require.NoError(t, err)
+
+		require.Equal(t, fiber.StatusOK, resp.StatusCode)
+		require.Empty(t, resp.Header.Get(fiber.HeaderCacheControl), "the URL never held the token")
+	})
+}
+
+// TestChallengeNamesEveryScheme covers a chain accepting more than one scheme:
+// the challenge has to offer each of them, not only the first, or a client
+// whose credential the later extractor took is told to retry with the wrong one.
+func TestChallengeNamesEveryScheme(t *testing.T) {
+	t.Parallel()
+
+	app := protectedApp(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		Extractor: extractors.Chain(
+			extractors.FromAuthHeader("Basic"),
+			extractors.FromAuthHeader("Bearer"),
+		),
+	})
+
+	resp := doGet(t, app, "Bearer not-a-jwt")
+	require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	require.Equal(t,
+		`Basic realm="Restricted", Bearer realm="Restricted", error="invalid_token", error_description="The access token is malformed"`,
+		resp.Header.Get(fiber.HeaderWWWAuthenticate))
+}
+
+// TestTypedNilErrorFromHandler covers an error handler returning an interface
+// holding a nil *fiber.Error, which errors.As matches without giving anything
+// to dereference.
+func TestTypedNilErrorFromHandler(t *testing.T) {
+	t.Parallel()
+
+	app := protectedApp(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		ErrorHandler: func(_ fiber.Ctx, _ error) error {
+			var typedNil *fiber.Error
+			return typedNil
+		},
+	})
+
+	require.NotPanics(t, func() {
+		resp := doGet(t, app, "Bearer not-a-jwt")
+		require.NotNil(t, resp)
+	})
 }

--- a/v3/jwt/rfc_test.go
+++ b/v3/jwt/rfc_test.go
@@ -17,15 +17,15 @@ import (
 
 // signWith builds a token signed with the shared HMAC test key, applying the
 // given mutations to its header first.
-func signWith(t *testing.T, claims jwt.Claims, header map[string]any) string {
-	t.Helper()
+func signWith(tb testing.TB, claims jwt.Claims, header map[string]any) string {
+	tb.Helper()
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	for name, value := range header {
 		token.Header[name] = value
 	}
 	signed, err := token.SignedString([]byte(defaultSigningKey))
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	return signed
 }
 

--- a/v3/jwt/rfc_test.go
+++ b/v3/jwt/rfc_test.go
@@ -526,10 +526,12 @@ func TestQueryTokenResponseIsPrivate(t *testing.T) {
 	})
 }
 
-// TestChallengeFromEarlierMiddlewareIsKept checks that a challenge another
-// authentication middleware already put on the response survives, whether or
-// not this middleware's error handler is the default one.
-func TestChallengeFromEarlierMiddlewareIsKept(t *testing.T) {
+// TestChallengeJoinsAnEarlierMiddlewares checks that a challenge another
+// authentication middleware already put on the response survives and that this
+// middleware's own goes beside it: RFC 9110 Section 11.6.1 lets the field carry
+// several, the client may be able to use either scheme, and a request refused
+// for a bad token is still owed the reason it was refused.
+func TestChallengeJoinsAnEarlierMiddlewares(t *testing.T) {
 	t.Parallel()
 
 	app := fiber.New()
@@ -544,7 +546,10 @@ func TestChallengeFromEarlierMiddlewareIsKept(t *testing.T) {
 
 	resp := doGet(t, app, "Bearer not-a-jwt")
 	require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
-	require.Equal(t, `Basic realm="other"`, resp.Header.Get(fiber.HeaderWWWAuthenticate))
+	require.Equal(
+		t,
+		`Basic realm="other", Bearer realm="Restricted", error="invalid_token", error_description="The access token is malformed"`,
+		resp.Header.Get(fiber.HeaderWWWAuthenticate))
 }
 
 // TestQueryTokenIsPrivateOverPublicPolicy covers a handler that would otherwise
@@ -707,6 +712,32 @@ func TestMalformedCachePolicyIsReplaced(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusOK, resp.StatusCode)
 	require.Equal(t, "private", resp.Header.Get(fiber.HeaderCacheControl))
+}
+
+// TestEmptyQueryValueIsNotACredential covers "?token=" alongside a cookie that
+// authenticated. The parameter is named but holds nothing, which the extractors
+// read as no credential, so there is nothing in the URL for a shared cache to
+// leak and no reason to keep the response out of one.
+func TestEmptyQueryValueIsNotACredential(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(jwtware.New(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		Extractor: extractors.Chain(
+			extractors.FromCookie("token"),
+			extractors.FromQuery("token"),
+		),
+	}))
+	app.Get("/ok", func(c fiber.Ctx) error { return c.SendString("OK") })
+
+	req := httptest.NewRequest(http.MethodGet, "/ok?token=", nil)
+	req.AddCookie(&http.Cookie{Name: "token", Value: hamac[0].Token})
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Empty(t, resp.Header.Get(fiber.HeaderCacheControl))
 }
 
 // TestQueryTokenWithProcessorIsPrivate covers a TokenProcessorFunc that turns

--- a/v3/jwt/rfc_test.go
+++ b/v3/jwt/rfc_test.go
@@ -863,3 +863,62 @@ func TestTypedNilErrorFromHandler(t *testing.T) {
 		require.NotNil(t, resp)
 	})
 }
+
+// TestPathParamTokenIsPrivate covers extractors.FromParam: a route parameter is
+// part of the URL, so a token read from one is in every log and cache key the
+// path reaches.
+func TestPathParamTokenIsPrivate(t *testing.T) {
+	t.Parallel()
+
+	// A route parameter is only in scope for handlers on that route, so the
+	// middleware goes on the route rather than on app.Use.
+	app := fiber.New()
+	app.Get("/auth/:token", jwtware.New(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		Extractor:  extractors.FromParam("token"),
+	}), func(c fiber.Ctx) error { return c.SendString("OK") })
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/auth/"+hamac[0].Token, nil))
+	require.NoError(t, err)
+
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Equal(t, "private", resp.Header.Get(fiber.HeaderCacheControl))
+}
+
+// TestHeaderTokenIsNotMarkedPrivate is the other side of it: the sources that
+// never reach the URL leave the response's caching to the application.
+func TestHeaderTokenIsNotMarkedPrivate(t *testing.T) {
+	t.Parallel()
+
+	for name, extractor := range map[string]extractors.Extractor{
+		"auth header": extractors.FromAuthHeader("Bearer"),
+		"header":      extractors.FromHeader("X-Token"),
+		"cookie":      extractors.FromCookie("token"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			app := fiber.New()
+			app.Use(jwtware.New(jwtware.Config{
+				SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+				Extractor:  extractor,
+			}))
+			app.Get("/ok", func(c fiber.Ctx) error { return c.SendString("OK") })
+
+			req := httptest.NewRequest(http.MethodGet, "/ok", nil)
+			switch extractor.Source {
+			case extractors.SourceCookie:
+				req.AddCookie(&http.Cookie{Name: "token", Value: hamac[0].Token})
+			case extractors.SourceAuthHeader:
+				req.Header.Set(fiber.HeaderAuthorization, "Bearer "+hamac[0].Token)
+			default:
+				req.Header.Set("X-Token", hamac[0].Token)
+			}
+
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			require.Equal(t, fiber.StatusOK, resp.StatusCode)
+			require.Empty(t, resp.Header.Get(fiber.HeaderCacheControl))
+		})
+	}
+}

--- a/v3/jwt/rfc_test.go
+++ b/v3/jwt/rfc_test.go
@@ -149,6 +149,34 @@ func TestCriticalHeaders(t *testing.T) {
 	}
 }
 
+// TestUnencodedPayloadIsRejected covers RFC 7797's "b64". golang-jwt always
+// base64url-decodes the second segment, so a JWS that says the payload is
+// unencoded would be verified over the payload as it stands and then read as
+// the decoding of that payload - claims its signer never asserted. The header
+// is refused whether or not it is marked critical, since the parser has settled
+// the encoding either way.
+func TestUnencodedPayloadIsRejected(t *testing.T) {
+	t.Parallel()
+
+	claims := jwt.MapClaims{"name": "John Doe"}
+
+	for name, header := range map[string]map[string]any{
+		"marked critical":        {"crit": []string{"b64"}, "b64": false},
+		"without the crit entry": {"b64": false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			app := protectedApp(jwtware.Config{
+				SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+			})
+
+			resp := doGet(t, app, "Bearer "+signWith(t, claims, header))
+			require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+		})
+	}
+}
+
 // TestCriticalHeaderWrapsCustomKeyfunc makes sure the "crit" check is not
 // something a caller loses by supplying a key function of their own.
 func TestCriticalHeaderWrapsCustomKeyfunc(t *testing.T) {
@@ -872,6 +900,27 @@ func TestTypedNilErrorFromHandler(t *testing.T) {
 
 	require.NotPanics(t, func() {
 		resp := doGet(t, app, "Bearer not-a-jwt")
+		require.NotNil(t, resp)
+	})
+}
+
+// TestTypedNilErrorReachesDefaultHandler is the same typed nil arriving at the
+// default error handler, which reads a *fiber.Error's status the same way and
+// so has to guard the same case. A token processor is one of the places a
+// caller's own code hands the middleware an error.
+func TestTypedNilErrorReachesDefaultHandler(t *testing.T) {
+	t.Parallel()
+
+	app := protectedApp(jwtware.Config{
+		SigningKey: jwtware.SigningKey{JWTAlg: jwtware.HS256, Key: []byte(defaultSigningKey)},
+		TokenProcessorFunc: func(string) (string, error) {
+			var typedNil *fiber.Error
+			return "", typedNil
+		},
+	})
+
+	require.NotPanics(t, func() {
+		resp := doGet(t, app, "Bearer "+hamac[0].Token)
 		require.NotNil(t, resp)
 	})
 }


### PR DESCRIPTION
# Description

An audit of the jwt middleware for per-request overhead and for the JWT/JOSE and HTTP authentication standards it sits on. Two of the three standards gaps are MUST-level and were silently unenforced; the performance work removes the state the handler rebuilt on every request.

**Performance.** `jwt.Parse` allocates a fresh parser and validator per call and re-applies every `ParserOption`, and the non-`MapClaims` path walked `reflect.TypeOf`/`Kind`/`Elem` and re-asserted `jwt.Claims` before it could allocate the claims. Both are now settled in `New`: one parser serves every request (it is read-only once built, and a concurrency test covers that), and a claims factory closes over the resolved type. A profile puts the ceiling on this in context — about 78% of a verified request is inside `github.com/golang-jwt/jwt` (39% JSON decoding, 24% HMAC) and roughly 5% is the middleware's own code — so the honest result is 2 fewer allocations and 144 fewer bytes per request with the wall time within noise.

**RFC 7515 Section 4.1.11 (`crit`).** A JWS whose `crit` list names an extension the recipient does not understand MUST be rejected. `golang-jwt` does not look at `crit` at all, so those tokens were accepted. The check now rides along with key lookup, the last hook the parser offers before it verifies the signature, which is where step 5 of the procedure in Section 5.2 belongs; a token without `crit` pays one map lookup for it. A `crit` value that is not a non-empty array of names, repeats a name, names a registered JOSE parameter such as `alg`, or names a parameter absent from the header is rejected as well. Applications that do process an extension declare it in the new `KnownCriticalHeaders`.

One extension cannot be declared. RFC 7797's `b64: false` says the payload travels unencoded and the signature covers it verbatim; `golang-jwt` does not implement it and always base64url-decodes the second segment, so it verifies such a token (the signing input works out to the same string) and then reads the *decoding* of the signed payload as the claims. A signer that will sign an attacker's message becomes an issuer of tokens it never issued. No application hook can fix this, because the parsing is over by the time one runs, so `b64` is refused whatever its value and whether or not `crit` names it — RFC 7797 Section 6 requires the `crit` entry, but nothing makes a producer conform — and a `KnownCriticalHeaders` that names it panics at `New` instead of quietly not meaning what it says.

**RFC 9110 Section 15.5.2 and RFC 6750 Section 3 (`WWW-Authenticate`).** Every 401 MUST carry a `WWW-Authenticate` header, and a resource server refusing a bearer token has to say why in it. The middleware sent neither. Rejections now carry a challenge — `Bearer realm="Restricted", error="invalid_token", error_description="The access token expired"` — with the scheme taken from the extractor, the realm from the new `Realm`, and the description derived from the failure rather than forwarded from the error string (RFC 6750's grammar admits neither quotes nor backslashes, and the parser's messages can name configuration details). A request that presented no usable credential gets a bare `Bearer realm="..."`, which Section 3.1 asks for. The values are all assembled in `New`, so a rejection allocates nothing, and a challenge already on the response is never replaced — whether an `ErrorHandler` of yours or an earlier authentication middleware put it there. This follows the shape of `fiber/v3/middleware/keyauth`, which builds its challenge once and applies it by response status.

**RFC 6750 Section 2.3 (query-string tokens).** A success response to a request whose token travelled in the URL should not be kept by a shared cache, since the URL such a cache keys on holds the token. Those responses are marked `Cache-Control: private`: a policy the handler set is kept, except that `public` is dropped and `private` added unless the policy already keeps the response out of shared caches — which a bare `no-store` or a bare `private` does, and a field-scoped `private="..."` does not (RFC 9111 Section 5.2.2.7), nor does either name carrying an argument it is not defined to take (Section 5.2.3). Whether the token came from the URL is decided per request, against the value the extractor returned rather than whatever a `TokenProcessorFunc` turned it into, so a chain that answered from a header or a cookie leaves its response alone.

**One deliberate deviation, flagged for review.** A request carrying no credentials still returns **400**, as this middleware has always done. RFC 6750 Section 3.1 reserves 400 for a malformed request and answers one that "lacks any authentication information" with 401, but `extractors` reports a missing and a malformed credential as the same `ErrNotFound`, so the two cannot be told apart without guessing, and changing the status would break existing clients. The README documents the gap and gives the `ErrorHandler` that produces the strict OAuth 2.0 behaviour. Happy to switch the default instead if maintainers prefer.

Also in this PR: the accepted algorithms are pinned in the parser from the configured `JWTAlg` values, so an unexpected `alg` is refused before a key is looked up as RFC 8725 Section 3.1 asks (a caller's `jwt.WithValidMethods` still wins); `ErrJWTAlg` is wrapped into the errors `signingKeyFunc` returns, having been exported but never reachable; and the default `ErrorHandler` matches a wrapped `*fiber.Error` instead of only a bare one.

Fixes: no linked issue.

## Changes introduced

- [x] **Benchmarks**: new `v3/jwt/jwt_bench_test.go`, covering the middleware's surface — each signing algorithm (HS256/384/512, RS256, ES256), each place the token is read from (auth header, cookie, query), each way the verification key is found (`SigningKey`, `SigningKeys` by `kid`, a caller's `KeyFunc`, a cached JWK Set), the rejection paths (malformed, expired, bad signature, unexpected algorithm), the `crit` check on the tokens that reach it, a request the `Next` filter waves through, the `TokenProcessorFunc` hook, and a handler reading the token back out of the context. Every one asserts the status the middleware answered with, so none can quietly measure the wrong path, and `Benchmark_Middleware_JWT_Baseline` is the same Fiber app without the middleware, to subtract.

  The optimisation itself was measured by building a binary from `main` and one from this branch and running them alternately, eight rounds, medians below. The `Baseline` row is identical code in both binaries, so its −3.3% is the measurement noise on this 4 vCPU box and the timing column should be read as "no regression", not as a win. The allocation columns are deterministic.

  | Benchmark | main | this PR |
  |---|---|---|
  | Baseline (no middleware) | 131 ns, 0 allocs | 127 ns, 0 allocs |
  | MapClaims | 8240 ns, 2520 B, 49 allocs | 8011 ns, 2377 B, **47 allocs** |
  | Custom struct claims | 8783 ns, 2481 B, 45 allocs | 8428 ns, 2337 B, **43 allocs** |
  | With ParserOptions | 8465 ns, 2545 B, 50 allocs | 8221 ns, 2400 B, **48 allocs** |
  | Missing token (rejection) | 251 ns, 0 allocs | ~500 ns, **0 allocs** |

  The rejection path is the one regression: writing the challenge header the RFCs require, and probing for one already on the response so it is not clobbered. It stays allocation free.

  Some numbers from the wider set, for orientation (single machine, so they compare with each other rather than across hardware): a request the `Next` filter skips costs 150 ns against the 124 ns baseline; a malformed token is rejected in 1.6 µs and 8 allocations, an unexpected algorithm in 6.6 µs (refused before a key is looked up), a bad signature in 9.1 µs and an expired token in 11.5 µs; and verification dominates a valid request — HS256 8.1 µs, RS256 through a cached JWK Set 28 µs, ES256 substantially more.

  An allocation profile attributes the 47 on the HS256 path: about 19 to `encoding/json`, 6 to `hmac.New`/`sha256.New`/`Sum`, 3.5 to `base64.DecodeString`, 3.5 to `ParseUnverified`, and exactly one to this middleware (the claims value). Pooling that one was prototyped end to end: it reaches 45 allocs and 2041 B, with the time unchanged, and it is not worth it — the token is stored in the request context and `FromContext` is documented for use with `c.Context()` in service layers, so recycling the claims would let a retained reference observe the next request's claims, silently and without a race-detector hit.

- [x] **Documentation Update**: `v3/jwt/README.md` — a new *Standards compliance* section (what the middleware enforces, what the application must configure for `aud`/`typ`/`jti`, and the status-code deviation with its `ErrorHandler`), the two new `Config` rows, and a note on the challenge in the opening behaviour summary. All new snippets were compile-checked.

- [x] **Changelog/What's New**:
  - jwt: tokens whose `crit` header names an extension the middleware does not understand are rejected, as RFC 7515 requires; applications declare the ones they handle in the new `KnownCriticalHeaders`.
  - jwt: a token whose header carries RFC 7797's `b64` is rejected, since the parser cannot honour it; naming `b64` in `KnownCriticalHeaders` is a configuration error and panics.
  - jwt: rejections carry the `WWW-Authenticate` challenge required by RFC 9110 and RFC 6750, with an `error`/`error_description` derived from the failure; the new `Realm` names the protected area, and a challenge already on the response is left alone.
  - jwt: a success response to a request whose token came from the URL — query string, form field or route parameter — is kept out of shared caches (RFC 6750 Section 2.3).
  - jwt: the configured `JWTAlg` values are enforced by the parser before key lookup (RFC 8725 Section 3.1).
  - jwt: the parser and the claims type are resolved once instead of per request — 2 fewer allocations and 144 fewer bytes per request.
  - jwt: `ErrJWTAlg` is now actually returned by the built-in key function, so `errors.Is` against it works.

- [x] **Migration Guide**: no code changes needed. Behavioural differences: rejected requests gain a `WWW-Authenticate` (or `Proxy-Authenticate` on 407) header unless one is already there; a token carrying `crit`, or carrying `b64` in any form, is now rejected instead of accepted; a URL-carried token keeps its success responses out of shared caches; with `JWTAlg` configured, a token signed with another algorithm is refused by the parser rather than by the key function, so the error is `jwt.ErrTokenSignatureInvalid` where it was a bare `fmt.Errorf`; an `ErrorHandler` that receives a wrapped `*fiber.Error` now sees its status honoured; and a `Claims` value whose type does not resolve panics at `New` rather than returning 500 per request (unreachable for any type that compiles as `jwt.Claims`).

- [ ] **API Alignment with Express**: not applicable.

- [x] **API Longevity**: additive only. `Realm` and `KnownCriticalHeaders` are new optional `Config` fields with zero-value defaults, and `ErrCriticalHeader` is a new sentinel error; nothing exported was removed or re-signed. `Realm` mirrors `fiber/v3/middleware/keyauth`'s field of the same name and default (`"Restricted"`), so the two auth middlewares stay consistent. Per-application claim validation stays in `ParserOptions` rather than growing dedicated fields, so `jwt.WithAudience`/`WithIssuer` remain the one way to do it.

- [x] **Examples**: `go test -run '^$' -bench . -benchmem` in `v3/jwt` runs the whole set; `-bench 'MapClaims|CustomClaims'` isolates the parse path, `-bench Rejected` the rejection paths and `-bench Algorithms` the verification cost. The README's *Standards compliance* section carries the `aud`/`iss`, explicit-typing and strict-401 snippets.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to existing features and functionality)
- [x] Documentation update (changes to documentation)
- [x] Performance improvement (non-breaking change which improves efficiency)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage. (Not applicable: the new fields follow this repository's and `fiber/middleware/keyauth`'s conventions rather than an Express counterpart.)
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation in the module README (this repository has no `/docs/` directory).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features: `rfc_test.go` covers the ten `crit` cases (unknown, declared, partially declared, registered name, absent name, duplicate, empty list, wrong type, non-string entry, no `crit`), the `b64` refusal in both its forms, the `crit` guard wrapping a caller's `KeyFunc`, the challenge for each rejection reason and each status, custom realm and scheme, a non-header extractor, a challenge from an `ErrorHandler` or an earlier middleware being kept, a status deferred to Fiber overriding a stale one, a typed-nil `*fiber.Error` reaching either error handler, the three algorithm-pinning cases, claims not being shared between requests, the cache directive against `public`, argumented and quoted policies, a token processor, an empty query parameter name, a route-parameter token, a chain answering from a cookie, and cyclic and branching-cyclic extractor chains; `config_test.go` unit-tests `validAlgorithms`, `checkCriticalHeaders`, `authSchemes` and the `KnownCriticalHeaders` panic; `jwt_test.go` adds a concurrency test for the shared parser. Coverage 93.3%.
- [x] Ensured that new and existing unit tests pass locally with the changes (`go test -race -count=1 ./...` in `v3/jwt`, plus `go vet` and `gofmt`); linting is covered by the repository's `lint / lint (v3/jwt)` job, which is green on this branch.
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community. No new modules: `github.com/valyala/fasthttp` moves from indirect to direct in `v3/jwt/go.mod` because the benchmarks drive `app.Handler()` with a `fasthttp.RequestCtx`, the pattern `fiber/middleware/basicauth` and this repository's `v3/coraza` benchmarks use. It was already in the graph through Fiber.
- [x] Aimed for optimal performance with minimal allocations in the new code. The `crit` check costs two map lookups on tokens without the header; the challenge tables, parser and claims factory are built in `New`; the rejection path allocates nothing.
- [x] Provided benchmarks for the new code to analyze and improve upon.

## Review rounds folded in

Six rounds of bot review are already applied, so the later commits are worth reading as their own changes rather than as part of the first:

- `82b7e7f` — the cache directive is merged into a policy the handler set instead of yielding to it; the query source is decided per request; a request with no usable credential gets a bare challenge; an existing challenge is never replaced.
- `9af34ac` — the query source is compared against the credential as extracted rather than as processed; `Cache-Control` splitting honours backslash escapes; a returned `*fiber.Error` names the status the challenge answers for; the extractor walks are bounded.
- `7187c62` — those walks visit each node once rather than bounding depth, since a branching cycle is exponential either way; the empty query parameter name is kept; `no-store` carrying an argument no longer counts; the extractor benchmarks answer 2xx so the query case measures the work that distinguishes it.
- `4c06e2c` — the challenge lists every scheme the extractor chain accepts rather than only the first; a typed-nil `*fiber.Error` is not dereferenced; `FromForm` counts as URL-carried, since fasthttp's `FormValue` reads the query string before the body; the `exp`/`nbf` guarantee is described as the default it is.
- `42df32b` — route parameters are collected as a URL source too, so a token in the path is not left shared-cacheable.
- `6d1093b` — `b64` is refused and cannot be declared (above); the typed-nil guard extended to the default `ErrorHandler`, reachable through a caller's extractor or token processor; two README guarantees scoped to what actually holds — keys are never read from the token under the *built-in* lookup, not under a caller's `KeyFunc` or `jwt.UnsafeAllowNoneSignatureType`, and unpadded segments are the parser's default, which `jwt.WithPaddingAllowed` relaxes.

`privateCacheControl`, the extractor walk and the `b64` refusal are the parts that took the most iteration and are worth the closest read.

## Follow-up, not in this PR

While profiling this, `extractors.isValidToken68` in Fiber turned out to be the hottest function in a JWT request at realistic token sizes — 20% flat for a 704-byte token, ahead of SHA-256 — because its per-byte range chain mispredicts on every credential. Replacing it with a 256-entry membership table takes the scan from ~950 ns to ~85 ns at 150 bytes and ~6.1 µs to ~0.37 µs at 900 bytes, worth about 23% of a whole authenticated request. That belongs in `gofiber/fiber`, not here, and will be raised separately. Its existing NOTE records a `swar.MatchRangeMask` attempt benchmarking 16% slower, which is consistent — the table approach is a different one and was not covered by that note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYjEBeTe8im9N4JdPhMoFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYjEBeTe8im9N4JdPhMoFY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added RFC-compliant authentication challenges with configurable realms and support for multiple authentication schemes.
  - Added validation for critical headers, permitted algorithms, expiration, and not-before claims.
  - Added protection against shared caching for successful requests authenticated with URL-sourced tokens.
  - Added support for configuring recognized critical headers and clearer authentication error handling.

- **Documentation**
  - Documented JWT standards compliance, challenge behavior, configuration options, and credential-less request handling.

- **Performance**
  - Improved request processing by reusing resolved JWT configuration and parsing components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
